### PR TITLE
Fix Windows implementation errors

### DIFF
--- a/src/audio/windows.rs
+++ b/src/audio/windows.rs
@@ -1,5 +1,5 @@
 use std::collections::VecDeque;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use wasapi::{
     self,
     AudioClient,
@@ -9,6 +9,8 @@ use wasapi::{
     WaveFormat,
     SampleType,
 };
+use windows::Win32::System::Com;
+use sysinfo::{System, SystemExt, ProcessExt};
 use super::core::{
     AudioApplication, AudioCaptureBackend, AudioCaptureStream, AudioConfig,
     AudioError, AudioFormat,
@@ -20,8 +22,11 @@ pub struct WasapiBackend {
 
 impl WasapiBackend {
     pub fn new() -> Result<Self, AudioError> {
-        wasapi::initialize_mta()
-            .map_err(|e| AudioError::InitializationFailed(e.to_string()))?;
+        unsafe {
+            if let Err(e) = Com::CoInitializeEx(None, Com::COINIT_MULTITHREADED) {
+                return Err(AudioError::InitializationFailed(format!("Failed to initialize COM: {:?}", e)));
+            }
+        }
         
         Ok(Self { initialized: true })
     }
@@ -30,7 +35,9 @@ impl WasapiBackend {
 impl Drop for WasapiBackend {
     fn drop(&mut self) {
         if self.initialized {
-            wasapi::deinitialize();
+            unsafe {
+                Com::CoUninitialize();
+            }
         }
     }
 }
@@ -41,18 +48,16 @@ impl AudioCaptureBackend for WasapiBackend {
     }
 
     fn list_applications(&self) -> Result<Vec<AudioApplication>, AudioError> {
-        // Use sysinfo to get running processes
-        use sysinfo::{ProcessRefreshKind, RefreshKind, System};
-        let refreshes = RefreshKind::new().with_processes(ProcessRefreshKind::everything());
-        let system = System::new_with_specifics(refreshes);
+        let mut system = System::new();
+        system.refresh_processes();
         
         let mut apps = Vec::new();
         for (pid, process) in system.processes() {
             // Only include processes that might produce audio
             apps.push(AudioApplication {
-                name: process.name().to_string(),
+                name: process.name().to_owned(),
                 id: pid.to_string(),
-                executable_name: process.name().to_string(),
+                executable_name: process.name().to_owned(),
                 pid: pid.as_u32(),
             });
         }
@@ -71,38 +76,30 @@ impl AudioCaptureBackend for WasapiBackend {
 }
 
 pub struct WasapiCaptureStream {
-    client: AudioClient,
-    capture_client: AudioCaptureClient,
-    event_handle: wasapi::Handle,
-    buffer: VecDeque<u8>,
+    client: Arc<Mutex<AudioClient>>,
+    capture_client: Arc<Mutex<AudioCaptureClient>>,
+    event_handle: Arc<wasapi::Handle>,
+    buffer: Arc<Mutex<VecDeque<u8>>>,
     config: AudioConfig,
 }
+
+// SAFETY: The Arc<Mutex<...>> makes the stream Send-safe
+unsafe impl Send for WasapiCaptureStream {}
 
 impl WasapiCaptureStream {
     fn new(process_id: u32, config: AudioConfig) -> Result<Self, AudioError> {
         let desired_format = WaveFormat::new(
-            match config.format {
-                AudioFormat::F32LE => 32,
-                AudioFormat::S16LE => 16,
-                AudioFormat::S32LE => 32,
-            },
-            match config.format {
-                AudioFormat::F32LE => 32,
-                AudioFormat::S16LE => 16,
-                AudioFormat::S32LE => 32,
-            },
+            config.channels.into(),
+            config.sample_rate.try_into().unwrap(),
             &match config.format {
                 AudioFormat::F32LE => SampleType::Float,
                 AudioFormat::S16LE | AudioFormat::S32LE => SampleType::Int,
             },
-            config.sample_rate,
-            config.channels,
-            None,
         );
 
         let include_process_tree = true;
         let mut client = AudioClient::new_application_loopback_client(process_id, include_process_tree)
-            .map_err(|e| AudioError::InitializationFailed(e.to_string()))?;
+            .map_err(|e| AudioError::InitializationFailed(format!("Failed to create audio client: {:?}", e)))?;
 
         client.initialize_client(
             &desired_format,
@@ -110,19 +107,19 @@ impl WasapiCaptureStream {
             &Direction::Capture,
             &ShareMode::Shared,
             true,  // Allow format conversion
-        ).map_err(|e| AudioError::InitializationFailed(e.to_string()))?;
+        ).map_err(|e| AudioError::InitializationFailed(format!("Failed to initialize client: {:?}", e)))?;
 
         let event_handle = client.set_get_eventhandle()
-            .map_err(|e| AudioError::InitializationFailed(e.to_string()))?;
+            .map_err(|e| AudioError::InitializationFailed(format!("Failed to get event handle: {:?}", e)))?;
 
         let capture_client = client.get_audiocaptureclient()
-            .map_err(|e| AudioError::InitializationFailed(e.to_string()))?;
+            .map_err(|e| AudioError::InitializationFailed(format!("Failed to get capture client: {:?}", e)))?;
 
         Ok(Self {
-            client,
-            capture_client,
-            event_handle,
-            buffer: VecDeque::new(),
+            client: Arc::new(Mutex::new(client)),
+            capture_client: Arc::new(Mutex::new(capture_client)),
+            event_handle: Arc::new(event_handle),
+            buffer: Arc::new(Mutex::new(VecDeque::new())),
             config,
         })
     }
@@ -130,25 +127,31 @@ impl WasapiCaptureStream {
 
 impl AudioCaptureStream for WasapiCaptureStream {
     fn start(&mut self) -> Result<(), AudioError> {
-        self.client
-            .start_stream()
-            .map_err(|e| AudioError::CaptureError(e.to_string()))
+        let mut client = self.client.lock()
+            .map_err(|e| AudioError::CaptureError(format!("Failed to lock client: {:?}", e)))?;
+        client.start_stream()
+            .map_err(|e| AudioError::CaptureError(format!("Failed to start stream: {:?}", e)))
     }
 
     fn stop(&mut self) -> Result<(), AudioError> {
-        self.client
-            .stop_stream()
-            .map_err(|e| AudioError::CaptureError(e.to_string()))
+        let mut client = self.client.lock()
+            .map_err(|e| AudioError::CaptureError(format!("Failed to lock client: {:?}", e)))?;
+        client.stop_stream()
+            .map_err(|e| AudioError::CaptureError(format!("Failed to stop stream: {:?}", e)))
     }
 
     fn read(&mut self, buffer: &mut [u8]) -> Result<usize, AudioError> {
         // If we have enough data in the buffer, return it
-        if !self.buffer.is_empty() {
-            let bytes_to_copy = std::cmp::min(buffer.len(), self.buffer.len());
-            for i in 0..bytes_to_copy {
-                buffer[i] = self.buffer.pop_front().unwrap();
+        {
+            let mut internal_buffer = self.buffer.lock()
+                .map_err(|e| AudioError::CaptureError(format!("Failed to lock buffer: {:?}", e)))?;
+            if !internal_buffer.is_empty() {
+                let bytes_to_copy = std::cmp::min(buffer.len(), internal_buffer.len());
+                for i in 0..bytes_to_copy {
+                    buffer[i] = internal_buffer.pop_front().unwrap();
+                }
+                return Ok(bytes_to_copy);
             }
-            return Ok(bytes_to_copy);
         }
 
         // Wait for new data
@@ -157,14 +160,20 @@ impl AudioCaptureStream for WasapiCaptureStream {
         }
 
         // Get new frames
-        if let Ok(Some(frames)) = self.capture_client.get_next_nbr_frames() {
+        let mut capture_client = self.capture_client.lock()
+            .map_err(|e| AudioError::CaptureError(format!("Failed to lock capture client: {:?}", e)))?;
+
+        if let Ok(Some(frames)) = capture_client.get_next_nbr_frames() {
             if frames > 0 {
-                self.capture_client.read_from_device_to_deque(&mut self.buffer)
-                    .map_err(|e| AudioError::CaptureError(e.to_string()))?;
+                let mut internal_buffer = self.buffer.lock()
+                    .map_err(|e| AudioError::CaptureError(format!("Failed to lock buffer: {:?}", e)))?;
                 
-                let bytes_to_copy = std::cmp::min(buffer.len(), self.buffer.len());
+                capture_client.read_from_device_to_deque(&mut internal_buffer)
+                    .map_err(|e| AudioError::CaptureError(format!("Failed to read from device: {:?}", e)))?;
+                
+                let bytes_to_copy = std::cmp::min(buffer.len(), internal_buffer.len());
                 for i in 0..bytes_to_copy {
-                    buffer[i] = self.buffer.pop_front().unwrap();
+                    buffer[i] = internal_buffer.pop_front().unwrap();
                 }
                 return Ok(bytes_to_copy);
             }


### PR DESCRIPTION
Fix Windows implementation errors:

- Make WasapiCaptureStream Send-safe using Arc<Mutex<...>>
- Fix COM initialization using windows-sys
- Fix process listing with sysinfo
- Fix WaveFormat creation with proper types
- Improve error handling with better messages