### PR TITLE
0.4.1 stack L1: the library - data plane, compose, consumption API, backends

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,13 @@
+# CodeRabbit configuration for rsac.
+#
+# base_branches: PRs whose BASE branch matches these regexes get reviewed in
+# addition to PRs targeting the default branch. Without this, CodeRabbit
+# reports "reviews are disabled for this base branch" on the 0.4.1 release
+# stack, whose layer PRs target release/0.4.1 instead of master
+# (decision record: seed rsac-79bc; stack epic: rsac-4844).
+#
+# CodeRabbit reads this file from the HEAD branch of a PR, so every layer
+# branch cut from release/0.4.1 inherits it automatically.
+reviews:
+  base_branches:
+    - "release/.*"

--- a/.github/workflows/ci-audio-tests.yml
+++ b/.github/workflows/ci-audio-tests.yml
@@ -22,7 +22,7 @@ name: Audio Integration Tests
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
     paths:
       - 'src/**'
       - 'tests/**'
@@ -30,7 +30,7 @@ on:
       - 'Cargo.lock'
       - '.github/workflows/ci-audio-tests.yml'
   pull_request:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
     paths:
       - 'src/**'
       - 'tests/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
     # Also run on stable semver tags so the version-lockstep job's tag-time
     # hard-gate (which asserts all six manifests equal the tag) actually fires
     # at the point of no return — it was previously dead code (ci.yml had no
@@ -14,7 +14,7 @@ on:
       - 'v*.*.*'
       - '!v*-*'
   pull_request:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
   workflow_dispatch:
 
 env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,6 +889,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,6 +1722,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hound",
+ "jni-sys 0.3.1",
  "libc",
  "libspa",
  "libspa-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -68,15 +83,24 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -114,6 +138,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "audio-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
+
+[[package]]
+name = "audioadapter"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f87b70b051c5866680ad79f6743a42ccab264c009d1a71f4d33a3872ae60c8"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-buffers"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9097d67933fb083d382ce980430afdb758aada60846010aee6be068c06cef0ca"
+dependencies = [
+ "audioadapter",
+ "audioadapter-sample",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-sample"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ab94f2bc04a14e1f49ee5f222f66460e8a1b51627bdfedf34eed394d747938"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,7 +202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "annotate-snippets",
- "bitflags",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -152,6 +213,12 @@ dependencies = [
  "shlex",
  "syn",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -305,7 +372,7 @@ version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
- "anstream",
+ "anstream 0.6.20",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -408,7 +475,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d15c3c3cee7c087938f7ad1c3098840b3ef1f1bdc7f6e496336c3b1e7a6f3914"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "objc2-audio-toolbox",
  "objc2-core-audio",
@@ -522,12 +589,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -541,9 +639,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -551,11 +649,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "env_filter",
  "jiff",
@@ -767,22 +865,23 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -833,7 +932,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b8cfa2a7656627b4c92c6b9ef929433acd673d5ab3708cda1b18478ac00df4"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cc",
  "convert_case 0.8.0",
  "cookie-factory",
@@ -903,7 +1002,7 @@ version = "2.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55740c4ae1d8696773c78fdafd5d0e5fe9bc9f1b071c7ba493ba5c413a9184f3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "ctor",
  "napi-derive",
  "napi-sys",
@@ -963,7 +1062,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -975,7 +1074,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1007,6 +1106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1043,7 +1151,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -1060,11 +1168,12 @@ dependencies = [
 
 [[package]]
 name = "objc2-audio-toolbox"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cbe18d879e20a4aea544f8befe38bcf52255eb63d3f23eca2842f3319e4c07"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
+ "block2",
  "libc",
  "objc2",
  "objc2-core-audio",
@@ -1074,12 +1183,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2",
+ "objc2-audio-toolbox",
+ "objc2-core-audio-types",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -1102,7 +1225,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "objc2",
 ]
 
@@ -1112,7 +1235,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -1123,7 +1246,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "dispatch2",
  "objc2",
 ]
@@ -1134,7 +1257,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -1157,7 +1280,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -1169,7 +1292,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -1197,7 +1320,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "block2",
  "libc",
  "objc2",
@@ -1220,7 +1343,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1231,7 +1354,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -1292,7 +1415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9688b89abf11d756499f7c6190711d6dbe5a3acdb30c8fbf001d6596d06a8d44"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "libspa",
  "libspa-sys",
@@ -1370,6 +1493,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
 ]
 
 [[package]]
@@ -1506,10 +1638,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.1"
+name = "realfft"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1519,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1530,15 +1671,17 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rsac"
 version = "0.4.0"
 dependencies = [
  "atomic-waker",
+ "audioadapter-buffers",
+ "block2",
  "clap",
  "color-eyre",
  "core-foundation",
@@ -1557,12 +1700,14 @@ dependencies = [
  "log",
  "objc2",
  "objc2-app-kit",
+ "objc2-avf-audio",
  "objc2-foundation",
  "pipewire",
  "pkg-config",
  "rand",
  "rand_pcg",
  "rtrb",
+ "rubato",
  "serde",
  "serde_json",
  "sysinfo",
@@ -1613,6 +1758,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ade083ccbb4bf536df69d1f6432cc23deb7acccff86b183f3923a6fd56a1153"
 
 [[package]]
+name = "rubato"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4be9c88e3d722d3d36939e41941f6b6f52810c1235bf19998a7d4535b402892"
+dependencies = [
+ "audioadapter",
+ "audioadapter-buffers",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
+ "visibility",
+ "windowfunctions",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,12 +1786,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1745,6 +1920,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
@@ -2003,6 +2184,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,6 +2240,17 @@ name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "walkdir"
@@ -2177,7 +2379,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.4",
  "indexmap",
  "semver",
@@ -2229,6 +2431,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windowfunctions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "windows"
@@ -2569,7 +2780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,20 @@ build = "build.rs"
 autobins = false
 description = "Cross-platform audio capture library with per-application process taps (macOS), WASAPI (Windows), and PipeWire (Linux)"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/baladita/rust-crossplat-audio-capture"
+repository = "https://github.com/Codeseys-Labs/rust-crossplat-audio-capture"
 readme = "README.md"
 keywords = ["audio", "capture", "wasapi", "coreaudio", "pipewire"]
 categories = ["multimedia::audio", "os"]
 exclude = [
-    # Application + binding subdirs (published separately or not at all)
+    # Application + binding subdirs (published separately or not at all).
+    # /bindings matters for rsac-go in particular: the Rust binding crates are
+    # auto-excluded by their own Cargo.toml manifests, but rsac-go (Go sources,
+    # Makefile, C bridge — no Cargo.toml) would otherwise ship in the tarball.
     "/apps",
+    "/bindings",
+    # Mobile platform glue (Kotlin AAR + SwiftPM package; ADR-0012) — built by
+    # Gradle/Xcode, not cargo; never ships in the crates.io tarball.
+    "/mobile",
     # Project-internal docs, scripts, infra (not library artifacts)
     "/docs",
     "/docker",
@@ -52,9 +59,16 @@ exclude = [
 feat_windows = []
 feat_linux = []
 feat_macos = []
+# Mobile backends (ADR-0012/0013; docs/MOBILE_BACKEND_DESIGN.md). Double-gated
+# on target_os like the desktop backends, so enabling them on the wrong OS is
+# inert. Current slice: Device-target microphone capture only (AAudio /
+# AVAudioEngine); playback-capture tiers arrive with rsac-77f1 / rsac-b3aa.
+feat_android = []
+feat_ios = []
 
-# Default features - enables all platform backends
-default = ["feat_windows", "feat_linux", "feat_macos"]
+# Default features - enables all platform backends (the two-way target_os
+# gate makes non-matching entries no-ops, so this is safe cross-platform).
+default = ["feat_windows", "feat_linux", "feat_macos", "feat_android", "feat_ios"]
 
 test-utils = [] # Feature to enable test utilities
 
@@ -71,6 +85,27 @@ bridge-zerocopy = []
 # deps). With it on, they emit tracing events/spans and `install_default_tracing`
 # becomes available. Pulls in only the `tracing` facade (no tracing-subscriber).
 tracing = ["dep:tracing"]
+# ADR-0011: opt-in multi-source channel composition (CompositionBuilder /
+# Composition in src/compose/). Default OFF — pulls rubato (resampling to the
+# session rate; FFT path brings realfft + num-complex) and audioadapter-buffers
+# (interleaved-slice adapters rubato v3 consumes). With the feature off the
+# dependency graph and API are unchanged.
+compose = ["dep:rubato", "dep:audioadapter-buffers"]
+# rsac-1ecd: the CLI demo binary's dependencies, feature-gated so library
+# consumers stop paying for them (clap/color-eyre/ctrlc/env_logger were
+# unconditional before 0.5). NOT in default features — build the demo with
+# `cargo build --features cli` / `cargo install rsac --features cli`. Binaries
+# and examples that need these declare `required-features = ["cli"]`.
+cli = ["dep:clap", "dep:color-eyre", "dep:ctrlc", "dep:env_logger"]
+# ADR-0015: opt-in macOS system-audio-capture TCC preflight. Default OFF —
+# it dlopen/dlsym's the PRIVATE, undocumented TCC.framework SPI
+# `TCCAccessPreflight("kTCCServiceAudioCapture")` to make
+# `check_audio_capture_permission()` return a real Granted/Denied answer on
+# macOS instead of the honest `NotDetermined` stub. Kept behind a feature
+# because private SPI is App-Store-review-risky and may break on a future
+# macOS. Off by default → no private symbol in the shipped artifact, public
+# API unchanged. Adds no dependency (uses libc dlopen + core-foundation).
+macos-tcc-spi = []
 
 [dependencies]
 # Core dependencies
@@ -82,12 +117,21 @@ log = "0.4.29"                                                 # For logging
 tracing = { version = "0.1.41", optional = true }              # Optional structured instrumentation (behind the `tracing` feature; rsac_event!/rsac_span! fall back to `log::` when off)
 
 hound = "3.5.1"
-clap = { version = "4.5.60", features = ["derive"] }
-color-eyre = "0.6.5"
-ctrlc = "3.5.2"
+# CLI-only deps (behind the `cli` feature; see [features] above).
+clap = { version = "4.5.60", features = ["derive"], optional = true }
+color-eyre = { version = "0.6.5", optional = true }
+ctrlc = { version = "3.5.2", optional = true }
 libc = "0.2.183"
 
-env_logger = "0.11.9"
+env_logger = { version = "0.11.11", optional = true }
+
+# compose-only deps (behind the `compose` feature; ADR-0011). rubato v3 MSRV is
+# 1.85 — under our 1.87 floor; the CI `msrv` job is the tripwire if a future
+# bump raises it. audioadapter-buffers is pinned to the same major rubato 3.x
+# itself consumes (its `Adapter`/`AdapterMut` traits must come from the SAME
+# crate version rubato's `process_into_buffer` expects, or the impls mismatch).
+rubato = { version = "3.0.0", optional = true }
+audioadapter-buffers = { version = "3.0.0", optional = true }
 
 serde = { version = "1.0.228", features = ["derive"] }
 # serde_json: hard library dep on the native Linux PipeWire path — it parses the
@@ -126,7 +170,7 @@ sysinfo = "0.38.4"     # For process discovery by name
 [target.'cfg(target_os = "linux")'.dependencies]
 # PipeWire dependencies for application-specific capture
 # System requirements: libpipewire-0.3-dev, pkg-config, build-essential, clang, libclang-dev, and llvm-dev
-pipewire = { version = "0.9.2", features = ["v0_3_44"] }  # PipeWire bindings with v0.3.44+ features for monitor streams
+pipewire = { version = "0.9.2", features = ["v0_3_65"] }  # v0.3.65 API gate (transitively includes v0_3_44 monitor-stream APIs and enables spa/v0_3_65). Declared here as a real cargo feature — previously force-injected globally via a .cargo/config.toml rustflags cfg hack (rsac-9b3c).
 libspa = "0.9.2"      # SPA (Simple Plugin API) for format negotiation and parameter handling
 libspa-sys = "0.9.2"  # Low-level SPA bindings for direct parameter access
 
@@ -148,36 +192,80 @@ core-foundation-sys = "0.8.7"       # Low-level Core Foundation FFI bindings
 sysinfo = "0.38.4"                  # For process tree discovery (ProcessTree capture target)
 # Note: CATapDescription is a private CoreAudio class — raw msg_send! is required (no objc2 bindings)
 
+[target.'cfg(target_os = "ios")'.dependencies]
+# iOS backend (feat_ios, mic slice — rsac-9e02): AVAudioEngine via the objc2
+# family, versions matching the macOS block above. This dependency block is
+# owned by the iOS backend work; extend it there if typed framework crates
+# (e.g. objc2-avf-audio) prove viable for cross-checking without an Apple SDK.
+#
+# NOTE: deliberately WITHOUT the objc2 "exception" feature the macOS block
+# enables — that feature pulls in objc2-exception-helper, whose build script
+# compiles an Objective-C file (needs xcrun + an Apple SDK), which breaks the
+# host-independent `cargo check --target aarch64-apple-ios` CI/dev loop. The
+# iOS backend does not use objc2::exception::catch, so nothing is lost.
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = [
+    "NSString", "NSArray", "NSValue",
+    "NSAutoreleasePool", "NSObject", "NSError",
+] }
+block2 = "0.6"   # ObjC blocks for the AVAudioEngine input-node tap callback
+# Typed AVFAudio bindings (same objc2 0.6 generation as the macOS block's
+# objc2-app-kit). Features cover exactly the mic-tap surface used by
+# src/audio/ios/avaudio.rs: engine + input node, bus formats, the PCM tap
+# buffer/time types, and the block2 glue for AVAudioNodeTapBlock.
+objc2-avf-audio = { version = "0.3", features = [
+    "AVAudioEngine", "AVAudioNode", "AVAudioIONode", "AVAudioFormat",
+    "AVAudioBuffer", "AVAudioTime", "AVAudioTypes", "block2",
+] }
+
+# Android backend (feat_android, mic slice — rsac-20cd) needs no crate deps:
+# AAudio is bound via in-tree extern "C" declarations against the stable NDK
+# ABI (see src/audio/android/aaudio.rs); JNI deps arrive with rsac-77f1.
+
 [build-dependencies]
 pkg-config = "0.3.32"
 
 [dev-dependencies]
-criterion = "0.8.2" # Benchmarking
 tempfile = "3.27.0" # Temporary files for tests
 rand = "0.10.0" # For generating test data
 rand_pcg = "0.10.1" # For deterministic random numbers in tests
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 futures-util = "0.3"
 
+# criterion is target-gated OFF the mobile OSes: cargo compiles EVERY
+# dev-dependency for any `--tests` target, and criterion's `alloca` dependency
+# builds C via cc (needs xcrun / an NDK toolchain), which breaks the
+# host-independent mobile cross-target check loops
+# (`cargo check --target aarch64-apple-ios --tests`). Benches never run on
+# mobile anyway; the [[bench]] targets also set `test = false` so `--tests`
+# does not select them where criterion is absent.
+[target.'cfg(not(any(target_os = "ios", target_os = "android")))'.dev-dependencies]
+criterion = "0.8.2" # Benchmarking
+
 [[bin]]
 name = "rsac"
 path = "src/main.rs"
+required-features = ["cli"]
 
 [[bin]]
 name = "standardized_test"
 path = "src/bin/standardized_test.rs"
+required-features = ["cli"]
 
 [[example]]
 name = "verify_audio"
 path = "examples/verify_audio.rs"
+required-features = ["cli"]
 
 [[example]]
 name = "basic_capture"
 path = "examples/basic_capture.rs"
+required-features = ["cli"]
 
 [[example]]
 name = "record_to_file"
 path = "examples/record_to_file.rs"
+required-features = ["cli"]
 
 [[example]]
 name = "list_devices"
@@ -187,6 +275,11 @@ path = "examples/list_devices.rs"
 name = "async_capture"
 path = "examples/async_capture.rs"
 required-features = ["async-stream"]
+
+[[example]]
+name = "composed_capture"
+path = "examples/composed_capture.rs"
+required-features = ["compose"]
 
 [[bin]]
 name = "app_capture_test"
@@ -242,10 +335,16 @@ harness = true
 
 # rsac-603b: criterion benchmark harness for the bridge data plane. harness =
 # false hands main() to criterion_main!; does not affect cargo build/cargo test.
+# test = false keeps `cargo check --tests` from selecting the bench target
+# (bench targets default to test = true): criterion's `alloca` dep compiles C
+# via cc/xcrun, which breaks the host-independent mobile cross-target loops
+# (`cargo check --target aarch64-apple-ios --tests`). No CI job runs benches
+# in test mode, so nothing is lost (AGENTS.md §8: benches are not executed).
 [[bench]]
 name = "bridge"
 path = "benches/bridge.rs"
 harness = false
+test = false
 
 # rsac-03a5: criterion benchmark for the consumer-side observability read path
 # (stream_stats / backpressure_report assembly + AudioBuffer level meters). Proves
@@ -255,9 +354,16 @@ harness = false
 name = "observability"
 path = "benches/observability.rs"
 harness = false
+test = false
 
 [workspace]
-members = ["bindings/rsac-python", "bindings/rsac-ffi", "bindings/rsac-napi"]
+members = [
+    "bindings/rsac-python",
+    "bindings/rsac-ffi",
+    "bindings/rsac-napi",
+    # NOTE (stack L1, rsac-f86e): the mobile/android-native member rides in
+    # the mobile tail PR of the 0.4.1 stack (rsac-d303) together with mobile/.
+]
 exclude = ["apps/audio-graph/src-tauri"]
 
 # rsac#16: docs.rs rendering config. Without this, docs.rs builds with the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,6 +207,9 @@ objc2 = "0.6"
 objc2-foundation = { version = "0.3", features = [
     "NSString", "NSArray", "NSValue",
     "NSAutoreleasePool", "NSObject", "NSError",
+    # ReplayKit broadcast ring consumer (rsac-b3aa): App Group container
+    # resolution via -[NSFileManager containerURLForSecurityApplicationGroupIdentifier:].
+    "NSFileManager", "NSURL",
 ] }
 block2 = "0.6"   # ObjC blocks for the AVAudioEngine input-node tap callback
 # Typed AVFAudio bindings (same objc2 0.6 generation as the macOS block's
@@ -218,9 +221,18 @@ objc2-avf-audio = { version = "0.3", features = [
     "AVAudioBuffer", "AVAudioTime", "AVAudioTypes", "block2",
 ] }
 
-# Android backend (feat_android, mic slice — rsac-20cd) needs no crate deps:
+# Android backend (feat_android — rsac-20cd mic slice, rsac-77f1 playback):
 # AAudio is bound via in-tree extern "C" declarations against the stable NDK
-# ABI (see src/audio/android/aaudio.rs); JNI deps arrive with rsac-77f1.
+# ABI (see src/audio/android/aaudio.rs). The playback-capture path (JNI
+# orchestration of the mobile/android AAR, src/audio/android/jni.rs) uses
+# jni-sys — the canonical, declarations-only transcription of jni.h (no
+# transitive deps, no build.rs). Chosen over (a) the full `jni` crate, which
+# drags cesu8/combine/thiserror for ~15 functions we call, and (b) an
+# in-tree hand transcription of the 233-entry JNIEnv vtable, where a single
+# misplaced field silently calls the wrong JVM function (UB) — the exact
+# failure class the in-tree-FFI convention exists to avoid, inverted.
+[target.'cfg(target_os = "android")'.dependencies]
+jni-sys = "0.3"
 
 [build-dependencies]
 pkg-config = "0.3.32"
@@ -362,7 +374,9 @@ members = [
     "bindings/rsac-ffi",
     "bindings/rsac-napi",
     # NOTE (stack L1, rsac-f86e): the mobile/android-native member rides in
-    # the mobile tail PR of the 0.4.1 stack (rsac-d303) together with mobile/.
+    # the mobile tail PR of the 0.4.1 stack (rsac-d303) together with the
+    # rest of mobile/. The two Kotlin contract sources ARE in this layer —
+    # the cfg-independent jni_lockstep tests include_str! them.
 ]
 exclude = ["apps/audio-graph/src-tauri"]
 

--- a/build.rs
+++ b/build.rs
@@ -1,20 +1,28 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
-    // Platform-specific build configuration for application capture
-    // Only configure if the corresponding feature is enabled
+    // Platform-specific build configuration for application capture.
+    //
+    // Dispatch on the COMPILE TARGET (CARGO_CFG_TARGET_OS) + the enabled
+    // feature (CARGO_FEATURE_*), not on host `#[cfg]`: build scripts are
+    // compiled FOR THE HOST, so `#[cfg(target_os = "linux")]` here would be
+    // true when cross-compiling from a Linux host to aarch64-linux-android —
+    // which made the android cross-check demand host PipeWire libraries
+    // (rsac-1a6e first-run failure). Android/iOS targets need no build.rs
+    // work: their linking is declared via `#[link]` attributes in-tree.
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let feature_on =
+        |name: &str| std::env::var(format!("CARGO_FEATURE_{}", name.to_uppercase())).is_ok();
 
-    #[cfg(all(target_os = "windows", feature = "feat_windows"))]
-    configure_windows_build();
-
-    #[cfg(all(target_os = "linux", feature = "feat_linux"))]
-    configure_linux_build();
-
-    #[cfg(all(target_os = "macos", feature = "feat_macos"))]
-    configure_macos_build();
+    match target_os.as_str() {
+        "windows" if feature_on("feat_windows") => configure_windows_build(),
+        "linux" if feature_on("feat_linux") => configure_linux_build(),
+        "macos" if feature_on("feat_macos") => configure_macos_build(),
+        // android / ios / anything else: nothing to configure here.
+        _ => {}
+    }
 }
 
-#[cfg(all(target_os = "windows", feature = "feat_windows"))]
 fn configure_windows_build() {
     // Windows-specific build configuration for WASAPI Process Loopback
     println!("cargo:rustc-link-lib=ole32"); // For COM operations
@@ -28,7 +36,7 @@ fn configure_windows_build() {
     println!("cargo:rustc-link-lib=winmm"); // For multimedia operations
 }
 
-#[cfg(all(target_os = "linux", feature = "feat_linux"))]
+#[allow(dead_code)] // dispatched at runtime by target_os; unused on non-linux builds
 fn configure_linux_build() {
     use std::{
         env,
@@ -136,7 +144,7 @@ fn configure_linux_build() {
     process::exit(1);
 }
 
-#[cfg(all(target_os = "macos", feature = "feat_macos"))]
+#[allow(dead_code)] // dispatched at runtime by target_os; unused on non-macos builds
 fn configure_macos_build() {
     // macOS-specific build configuration for CoreAudio Process Tap
 
@@ -172,7 +180,7 @@ fn configure_macos_build() {
     }
 }
 
-#[cfg(all(target_os = "macos", feature = "feat_macos"))]
+#[allow(dead_code)] // helper for configure_macos_build
 fn parse_macos_version(version_str: &str) -> Option<(u32, u32)> {
     let parts: Vec<&str> = version_str.split('.').collect();
     if parts.len() >= 2 {

--- a/docs/designs/0015-macos-tcc-audiocapture-preflight.md
+++ b/docs/designs/0015-macos-tcc-audiocapture-preflight.md
@@ -1,0 +1,131 @@
+# ADR 0015 — macOS system-audio-capture permission preflight (private TCC SPI)
+
+**Status:** Accepted
+**Date:** 2026-07-06
+**Scope:** `src/audio/macos/permission.rs` (new), `src/core/introspection.rs`
+(`check_audio_capture_permission`), `Cargo.toml` (`macos-tcc-spi` feature)
+**Verdict:** rsac MAY report the macOS Process-Tap TCC authorization status
+(`kTCCServiceAudioCapture`) ahead of a capture attempt, but ONLY behind an
+opt-in `macos-tcc-spi` Cargo feature, because the sole mechanism is a **private,
+undocumented** TCC.framework SPI (`TCCAccessPreflight`). With the feature off,
+`check_audio_capture_permission()` keeps its honest `NotDetermined` stub on macOS
+and the public API is unchanged.
+
+## 1. Context
+
+macOS Process Taps (`AudioHardwareCreateProcessTap` / `CATapDescription`, macOS
+14.4+) are gated by the **Audio Capture** TCC service (`kTCCServiceAudioCapture`)
+— a distinct, stricter service from the microphone (`kTCCServiceMicrophone`,
+which `AVCaptureDevice.authorizationStatus(for: .audio)` covers) and from Screen
+Recording (`kTCCServiceScreenCapture`). It surfaces in System Settings under
+**Privacy & Security → Screen & System Audio Recording**.
+
+Three facts make this hard to handle honestly (all verified on macOS 26 Tahoe,
+arm64, during the 2026-07-06 real-hardware verification of PR #35):
+
+1. **There is no public API to query this permission before attempting a tap.**
+   `AVCaptureDevice.authorizationStatus(.audio)` reports the *microphone*
+   service, not `kTCCServiceAudioCapture`. The only working preflight is the
+   private `TCCAccessPreflight("kTCCServiceAudioCapture", NULL)` SPI in
+   `/System/Library/PrivateFrameworks/TCC.framework` — the approach the
+   reference implementation [`insidegui/AudioCap`](../../reference/AudioCap)
+   uses (`AudioCap/ProcessTap/AudioRecordingPermission.swift`, behind its own
+   `ENABLE_TCC_SPI` build flag).
+
+2. **Denial is silent.** With permission missing/denied, every setup call
+   (`AudioHardwareCreateProcessTap`, `AudioHardwareCreateAggregateDevice`,
+   `AudioDeviceCreateIOProcIDWithBlock`, `AudioDeviceStart`) returns `noErr`,
+   then the IOProc delivers **zeroed buffers** (or no callbacks). Apple does not
+   document this. So the *attempt-and-handle* path cannot distinguish "denied"
+   from "genuinely silent audio" by return code — see [ADR-0016](0016-macos-process-tap-silent-zeros-guard.md)
+   for the runtime side of the same problem.
+
+3. **The `Info.plist` key is a hard prerequisite, and attribution matters.**
+   Without `NSAudioCaptureUsageDescription` in the *responsible* (LaunchServices-
+   attributed) app bundle, `tccd` refuses the request categorically — no prompt
+   ever fires. A terminal-launched CLI makes the terminal the responsible
+   process, so it is silently denied unless the terminal itself carries the key.
+
+Meanwhile `check_audio_capture_permission()` already exists
+([`src/core/introspection.rs`](../../src/core/introspection.rs)) and returns
+`PermissionStatus::NotDetermined` unconditionally on macOS — a documented stub
+whose own comment names this ADR's work as the intended fix.
+
+## 2. Decision drivers
+
+- **Honesty over convenience.** rsac's stated philosophy
+  ([`src/core/capabilities.rs`](../../src/core/capabilities.rs) §doc,
+  `AGENTS.md` §"never pretend a platform can do something it cannot") forbids
+  reporting `Granted` when we cannot actually know. A stub that returns
+  `NotDetermined` is honest; a preflight that returns a real answer is *more*
+  useful — but only if it is real.
+- **Private SPI is a liability.** `TCCAccessPreflight` is undocumented, may
+  change or vanish in a future macOS, and its presence in a binary is a known
+  App Store review risk. It must never be on the default build path.
+- **The public API surface must not change** whether or not the feature is on.
+  `check_audio_capture_permission() -> PermissionStatus` is the single entry
+  point; the feature only changes the macOS *answer* from always-`NotDetermined`
+  to a real preflight result.
+- **No new dependency.** The shim uses `libc::dlopen`/`dlsym` (already a
+  dependency) and `core-foundation` `CFString` (already a macOS dependency).
+
+## 3. Decision
+
+Add an opt-in `macos-tcc-spi` Cargo feature (default OFF). When enabled on
+macOS, `check_audio_capture_permission()` dispatches to a new
+`src/audio/macos/permission.rs` that:
+
+- `dlopen`s `/System/Library/PrivateFrameworks/TCC.framework` (RTLD_LAZY),
+- `dlsym`s `TCCAccessPreflight` (signature `(CFStringRef, CFDictionaryRef) ->
+  c_long`),
+- calls it with the `kTCCServiceAudioCapture` CFString and a null dictionary,
+- maps the result: `0 → Granted`, `1 → Denied`, anything else (incl. `2`) →
+  `NotDetermined`,
+- and on ANY failure (framework missing, symbol absent, dlopen error) returns
+  `NotDetermined` — never panics, never claims a definite answer it doesn't have.
+
+With the feature OFF, the macOS arm keeps returning `NotDetermined` exactly as
+today. Non-macOS platforms keep returning `NotRequired`.
+
+We deliberately do **not** wire `TCCAccessRequest` (the prompt-trigger SPI) in
+this ADR: triggering the consent prompt is a host-app UX concern (it needs a
+foreground app with the `Info.plist` key), not a capture-library concern. The
+library's job is to *report* status; the host app decides when to prompt.
+
+## 4. Consequences
+
+- Consumers that opt into `macos-tcc-spi` (typically a bundled GUI app that
+  already ships `NSAudioCaptureUsageDescription`, e.g. the audio-graph Tauri
+  app) get a real, prompt-free authorization check for onboarding UX.
+- The default build, crates.io publish, and every CI leg stay free of the
+  private SPI — no App Store risk for the common consumer, no undocumented
+  symbol in the shipped `.rlib`.
+- The preflight is **advisory**: because the TCC DB row can be stale relative to
+  runtime enforcement (and because a terminal-launched or unbundled process is
+  denied regardless of the DB), a `Granted` preflight is not a guarantee of
+  non-silent capture. The runtime silent-zeros guard in
+  [ADR-0016](0016-macos-process-tap-silent-zeros-guard.md) is the authoritative
+  backstop; this preflight is the cheap, proactive UX signal.
+- If a future macOS removes `TCCAccessPreflight`, the shim degrades to
+  `NotDetermined` (its dlsym fails) rather than breaking the build — the feature
+  becomes a no-op, and the runtime guard still catches denial.
+
+## 5. Alternatives considered
+
+- **Public API only (no SPI).** Rejected as the *only* option: there is no
+  public preflight for `kTCCServiceAudioCapture`, so the stub would stay a stub
+  forever and consumers get no proactive signal. Kept as the default (feature
+  off) precisely because it's the honest floor.
+- **Unconditionally link the SPI (no feature gate).** Rejected: forces the
+  private-SPI liability onto every consumer and the crates.io artifact.
+- **Trigger the prompt from the library (`TCCAccessRequest`).** Deferred: it is
+  a host-app UX decision and requires a foreground bundle; out of scope for a
+  capture library.
+
+## 6. References
+
+- [`reference/AudioCap/AudioCap/ProcessTap/AudioRecordingPermission.swift`](../../reference/AudioCap)
+  — the canonical `TCCAccessPreflight`/`TCCAccessRequest` worked example.
+- [ADR-0016](0016-macos-process-tap-silent-zeros-guard.md) — the runtime
+  silent-zeros guard (the authoritative denial backstop).
+- Seed `rsac-84b8`.

--- a/docs/designs/0016-macos-process-tap-silent-zeros-guard.md
+++ b/docs/designs/0016-macos-process-tap-silent-zeros-guard.md
@@ -1,0 +1,133 @@
+# ADR 0016 — macOS Process-Tap silent-zeros diagnostic (denied-permission guard)
+
+**Status:** Accepted
+**Date:** 2026-07-06
+**Scope:** `src/audio/macos/thread.rs` (`create_macos_capture`, `MacosPlatformStream`)
+**Verdict:** When a macOS **Process-Tap** capture (SystemDefault / Application /
+ApplicationByName / ProcessTree) starts but delivers **only zeroed samples**
+throughout a bounded grace window while the stream is otherwise healthy, rsac
+emits a **single `log::warn!`** naming the most likely cause (missing/denied
+`kTCCServiceAudioCapture` permission). It is a **diagnostic only** — never an
+error, because pure silence is a legitimate stream state.
+
+## 1. Context
+
+macOS Process Taps are gated by the Audio Capture TCC service
+(`kTCCServiceAudioCapture`). When that permission is missing or denied, the
+CoreAudio setup path is **silently deceptive** (verified on macOS 26 Tahoe,
+arm64, 2026-07-06, and corroborated by community write-ups): every call —
+`AudioHardwareCreateProcessTap`, `AudioHardwareCreateAggregateDevice`,
+`AudioDeviceCreateIOProcIDWithBlock`, `AudioDeviceStart` — returns `noErr`, and
+then the IO proc delivers **all-zero buffers** (or never fires). Apple does not
+document this. There is **no error code** to key on.
+
+Consequently rsac's `create_macos_capture` returns a perfectly healthy-looking
+`MacosPlatformStream`, the reader gets well-formed 48 kHz buffers, and the only
+symptom is that every sample is `0.0`. A downstream consumer (e.g. the
+audio-graph transcription pipeline) sees "working capture, no audio" with no
+signal as to *why* — the single most confusing failure mode on the platform.
+
+This is exactly the trap the branch's real-hardware verification hit: the host
+terminal (cmux) lacked `NSAudioCaptureUsageDescription`, so `tccd` refused the
+service, and every capture streamed silence with no diagnostic.
+
+The proactive preflight ([ADR-0015](0015-macos-tcc-audiocapture-preflight.md)) is
+*advisory* and requires a private SPI + an opt-in feature; a `Granted` preflight
+still doesn't guarantee non-silent capture (a terminal-launched or unbundled
+process is denied at runtime regardless of the TCC DB). So a **runtime** signal
+is the authoritative, always-available backstop.
+
+## 2. Decision drivers
+
+- **Honest failure over silent success** (`src/core/capabilities.rs` §doc,
+  `AGENTS.md`). The M8 precedent — rejecting output-only AUHAL devices rather
+  than returning a "silently-dead capture" (`thread.rs` `resolve_capture_target`)
+  — is the same principle: do not hand back a stream that looks alive but can
+  never carry signal without saying so.
+- **But silence is legitimate.** A paused video, a muted call, or a genuinely
+  quiet source all produce all-zero buffers with permission fully granted.
+  Escalating silence to an `AudioError` would break every one of those valid
+  captures. So the guard must **warn, not fail**.
+- **RT-safety is non-negotiable** (ADR-0001). The detection touching the audio
+  IO-proc must be alloc-free and lock-free; anything that logs, sleeps, or
+  allocates happens off the RT thread.
+- **Scope to where the trap exists.** Only the Process-Tap tiers hit the
+  silent-denial behavior. A plain `Device` (AUHAL input / mic) capture that is
+  silent is far more likely to be genuinely quiet and is gated by a *different*
+  service (microphone), so the guard does not run for it.
+
+## 3. Decision
+
+In `create_macos_capture`, for **Process-Tap captures only** (`process_tap.is_some()`):
+
+1. **RT side** — a shared `Arc<AtomicBool> non_silence_seen`, cloned into the
+   input callback. On each callback, if the flag is not yet set, a cheap
+   alloc-free scan (`data.iter().any(|&s| s != 0.0)`) sets it the first time any
+   non-zero sample arrives. Once set, subsequent callbacks do a single relaxed
+   load and skip the scan — so the steady-state cost is one atomic load. ADR-0001
+   preserved (no alloc, no lock, no blocking).
+
+2. **Non-RT side** — a detached watchdog thread spawned right after
+   `AudioOutputUnitStop`'s sibling `start()`. It sleeps a bounded grace window
+   (`SILENCE_GRACE`, 2 s) in short increments, then, if and only if
+   `non_silence_seen` is still `false` **and** the stream has not reached a
+   terminal state (it's genuinely running, not stopped/errored) **and** teardown
+   has not begun, emits one `log::warn!` pointing at the likely
+   `kTCCServiceAudioCapture` / `NSAudioCaptureUsageDescription` cause and how to
+   check it. It then exits. It never touches the RT thread and never mutates
+   stream state.
+
+3. **Teardown** — a shared `Arc<AtomicBool> watchdog_stop` (set in
+   `stop_audio_unit` and `Drop`) makes the watchdog exit promptly and suppresses
+   a spurious warning when the user stops within the grace window. The thread is
+   detached (self-terminating within one sleep increment of the stop flag or the
+   grace deadline), so it imposes no join on the struct's documented drop-order
+   contract.
+
+The warning fires **at most once** per capture. There is **no `AudioError`**,
+no state change, no behavioral difference for a correctly-permissioned or
+legitimately-silent capture beyond one atomic load per callback.
+
+## 4. Consequences
+
+- A denied-permission Process-Tap capture now says so in the log within ~2 s,
+  instead of silently streaming zeros forever. This is the single highest-value
+  diagnostic for the platform's most confusing failure mode.
+- A legitimately-silent capture (paused/muted) also logs the warning once. This
+  is an accepted false-positive: it is a `warn`, it is one line, and its text is
+  explicit that silence *may* be legitimate — it does not fail or degrade the
+  capture. Consumers that expect silence can filter the target or lower the log
+  level.
+- Always-on (no feature gate), matching the always-on device-alive listener
+  (ADR-0010) — an honest diagnostic should not be something a consumer has to
+  opt into. Cost when audio is flowing is one relaxed atomic load per callback.
+- Pairs with ADR-0015: the opt-in preflight is the *proactive* UX signal; this
+  runtime guard is the *always-available* authoritative backstop. Neither is
+  required by the other.
+
+## 5. Alternatives considered
+
+- **Escalate to `AudioError::PermissionDenied` on sustained silence.** Rejected:
+  indistinguishable from a legitimately silent source at the sample level, so it
+  would break valid captures. The existing `PermissionDenied` variant is still
+  produced on the *explicit* CoreAudio `'hog!'` permission OSStatus
+  (`coreaudio.rs` `map_ca_error`) — that path is a real error and stays an error.
+- **Compute RMS/dBFS instead of a non-zero scan.** Rejected as overkill: the
+  denied case is *bit-exact* zeros, so `any(|&s| s != 0.0)` is both sufficient
+  and cheaper than the `AudioBuffer::rms` sum-of-squares. (The level meters
+  remain available for consumers who want graded silence detection.)
+- **Detect on the RT thread and signal inline.** Rejected: logging/sleeping is
+  not RT-safe; the split (RT sets a flag, non-RT decides + warns) is the only
+  ADR-0001-compatible shape.
+- **Feature-gate it.** Rejected: an honest diagnostic belongs on by default
+  (device-alive listener precedent). The cost is negligible.
+
+## 6. References
+
+- [ADR-0001](0001-rt-allocation-guarantee.md) — RT-allocation guarantee (the
+  constraint on the callback-side detection).
+- [ADR-0010](0010-producer-terminal-signal.md) — the always-on device-alive
+  listener (precedent for an always-on, non-RT macOS watchdog).
+- [ADR-0015](0015-macos-tcc-audiocapture-preflight.md) — the opt-in proactive
+  preflight this backstops.
+- Seed `rsac-4c3b`.

--- a/examples/composed_capture.rs
+++ b/examples/composed_capture.rs
@@ -1,0 +1,111 @@
+//! # Composed Multi-Source Capture (ADR-0011)
+//!
+//! Demonstrates the `compose` feature: capture an application and the system
+//! mix **simultaneously**, composed into one multi-channel stream —
+//!
+//! - group "app"    → the named application, mixed down to **1 mono channel**
+//! - group "system" → the system default output, native channels kept as-is
+//!
+//! The composed stream is interleaved f32 at the session rate; the
+//! [`ChannelMap`] reports which output channel belongs to which group. Sources
+//! delivering a different sample rate are resampled transparently.
+//!
+//! Run with:
+//! `cargo run --example composed_capture --features compose -- <app-name>`
+//! (falls back to a system-only composition when no app name is given).
+
+use rsac::compose::{CompositionBuilder, Group, GroupLayout};
+use rsac::CaptureTarget;
+use std::time::{Duration, Instant};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let app_name = std::env::args().nth(1);
+
+    // ── Declare the composition ─────────────────────────────────────
+    let mut builder = CompositionBuilder::new().sample_rate(48_000);
+    if let Some(name) = &app_name {
+        builder = builder.group(
+            Group::new("app")
+                .source(CaptureTarget::ApplicationByName(name.clone()))
+                .mixdown(GroupLayout::Mono), // → 1 composed channel
+        );
+        println!("Group 'app'   : application '{name}' → mono");
+    }
+    builder = builder.group(
+        Group::new("system")
+            .source(CaptureTarget::SystemDefault)
+            .keep_channels(), // → the endpoint's native channels
+    );
+    println!("Group 'system': system default → native channels");
+
+    let mut session = builder.build()?;
+    session.start()?;
+
+    // ── Inspect the resolved layout ─────────────────────────────────
+    let map = session.channel_map().expect("started").clone();
+    println!("\nComposed layout: {} channels @ 48 kHz", map.channels());
+    for (i, origin) in map.entries().iter().enumerate() {
+        println!(
+            "  channel {i}: group '{}' (channel {} within group)",
+            origin.group, origin.channel_in_group
+        );
+    }
+
+    // ── Read composed audio for a few seconds ───────────────────────
+    println!("\nCapturing 5 seconds of composed audio...");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut buffers = 0u64;
+    let mut frames = 0u64;
+    while Instant::now() < deadline {
+        match session.read_chunk_nonblocking() {
+            Ok(Some(buffer)) => {
+                buffers += 1;
+                frames += buffer.num_frames() as u64;
+                if buffers.is_multiple_of(100) {
+                    // Per-group RMS via the channel map.
+                    let mut levels = String::new();
+                    for entry in map.entries() {
+                        let ch = map
+                            .group_range(&entry.group)
+                            .map(|r| r.start)
+                            .unwrap_or_default();
+                        if entry.channel_in_group == 0 {
+                            let rms = buffer.channel_rms(ch as u16).unwrap_or(0.0);
+                            levels.push_str(&format!("{}={rms:.4} ", entry.group));
+                        }
+                    }
+                    println!("  {buffers} buffers, {frames} frames | rms: {levels}");
+                }
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(1)),
+            Err(e) if e.is_fatal() => {
+                println!("Composition ended: {e}");
+                break;
+            }
+            Err(e) => eprintln!("transient read error (retrying): {e}"),
+        }
+    }
+
+    // ── Stats + teardown ────────────────────────────────────────────
+    if let Some(stats) = session.stats() {
+        println!(
+            "\nStats: {} ticks ({} wall-clock fallback)",
+            stats.ticks, stats.fallback_ticks
+        );
+        for s in &stats.sources {
+            println!(
+                "  [{}] {} — buffers={} padded={} trimmed={} resampling={} ended={}",
+                s.group,
+                s.target,
+                s.buffers_received,
+                s.padded_frames,
+                s.trimmed_frames,
+                s.resampling,
+                s.ended
+            );
+        }
+    }
+    session.stop()?;
+    println!("Done: {buffers} composed buffers, {frames} frames total.");
+    Ok(())
+}

--- a/mobile/android/src/main/kotlin/ai/codeseys/rsac/CaptureBridge.kt
+++ b/mobile/android/src/main/kotlin/ai/codeseys/rsac/CaptureBridge.kt
@@ -1,0 +1,282 @@
+package ai.codeseys.rsac
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioPlaybackCaptureConfiguration
+import android.media.AudioRecord
+import android.media.projection.MediaProjection
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * The Java-side playback-capture loop (docs/MOBILE_BACKEND_DESIGN.md § two
+ * data paths): `AudioPlaybackCaptureConfiguration` can only be attached to a
+ * Java [AudioRecord], so this dedicated thread loops
+ * `audioRecord.read(FloatArray, READ_BLOCKING)` and forwards each period to
+ * Rust via [nativePush] — one JNI call per buffer, into
+ * `BridgeProducer::push_samples_or_drop()` on the Rust side.
+ *
+ * **No capture policy** (ADR-0012 §4.2): which UID to match (or none), the
+ * sample rate, and the channel count are *inputs*, resolved by Rust per
+ * ADR-0013 (`SystemDefault` = usage filters only; `Application*` /
+ * `ProcessTree` = `addMatchingUid`). The usage-filter set
+ * (MEDIA / GAME / UNKNOWN) is the fixed transport mapping from ADR-0013 —
+ * `USAGE_VOICE_COMMUNICATION` is never capturable by third parties.
+ *
+ * ### Allocation discipline (ADR-0001, adapted for JNI)
+ *
+ * The read buffer is allocated **once** in the constructor and reused for
+ * every read — no per-read garbage, so GC pauses on this thread manifest as
+ * ring drops (visible via `overrun_count`) rather than as jank elsewhere.
+ * This thread is *not* an OS real-time callback thread ([AudioRecord.read]
+ * is a buffered blocking read); the hard-RT rules bind the Rust side of
+ * [nativePush] (session-lifetime scratch, no per-call allocation).
+ *
+ * ### Lifecycle
+ *
+ * ```
+ * CaptureBridge(projection, session, rate, ch, uid) // builds the AudioRecord
+ *   .also { RsacCaptureService.registerBridge(it) } // anchor to the FGS
+ *   .start()                                        // spawn the read thread
+ * ...
+ * bridge.stop()                                     // idempotent: stop + join + release
+ * RsacCaptureService.unregisterBridge(bridge)
+ * ```
+ *
+ * Constructed and driven by the Rust orchestration (src/audio/android/
+ * playback.rs, seed rsac-77f1) through JNI; a mediaProjection foreground
+ * service must be running (API 34+ enforces this) and RECORD_AUDIO granted,
+ * or [AudioRecord] construction fails.
+ *
+ * @param projection consent-granted projection (Rust owns its GlobalRef/token)
+ * @param session opaque pointer to the per-capture Rust ingest state; valid
+ *   for this bridge's whole lifetime (Rust guarantees it outlives [stop])
+ * @param sampleRate requested capture rate in Hz (e.g. 48000)
+ * @param channels 1 (mono) or 2 (stereo)
+ * @param matchUid UID filter for per-app / process-tree capture, or a
+ *   negative value for no filter (system-wide capture)
+ * @param framesPerRead frames per read/push period (default ~10 ms at 48 kHz)
+ */
+class CaptureBridge(
+    projection: MediaProjection,
+    private val session: Long,
+    private val sampleRate: Int,
+    private val channels: Int,
+    matchUid: Int = NO_UID_FILTER,
+    framesPerRead: Int = DEFAULT_FRAMES_PER_READ,
+) {
+
+    private val audioRecord: AudioRecord
+
+    /** Allocated ONCE; reused for every read (ADR-0001 adapted — see class docs). */
+    private val readBuffer: FloatArray
+
+    private val running = AtomicBoolean(false)
+    private val released = AtomicBoolean(false)
+
+    @Volatile
+    private var thread: Thread? = null
+
+    init {
+        require(sampleRate > 0) { "sampleRate must be positive, got $sampleRate" }
+        require(channels == 1 || channels == 2) { "channels must be 1 or 2, got $channels" }
+        require(framesPerRead > 0) { "framesPerRead must be positive, got $framesPerRead" }
+
+        readBuffer = FloatArray(framesPerRead * channels)
+
+        // Fixed transport mapping (ADR-0013): all capturable playback usages.
+        // UID selection is the ONLY policy input, and it comes from Rust.
+        val captureConfig = AudioPlaybackCaptureConfiguration.Builder(projection)
+            .addMatchingUsage(AudioAttributes.USAGE_MEDIA)
+            .addMatchingUsage(AudioAttributes.USAGE_GAME)
+            .addMatchingUsage(AudioAttributes.USAGE_UNKNOWN)
+            .apply { if (matchUid >= 0) addMatchingUid(matchUid) }
+            .build()
+
+        val channelMask =
+            if (channels == 1) AudioFormat.CHANNEL_IN_MONO else AudioFormat.CHANNEL_IN_STEREO
+        val format = AudioFormat.Builder()
+            .setEncoding(AudioFormat.ENCODING_PCM_FLOAT)
+            .setSampleRate(sampleRate)
+            .setChannelMask(channelMask)
+            .build()
+
+        // Device buffer: at least the OS minimum, and at least two of our
+        // read periods so a briefly-descheduled reader doesn't overrun the
+        // AudioRecord's own ring.
+        val minBytes = AudioRecord.getMinBufferSize(
+            sampleRate, channelMask, AudioFormat.ENCODING_PCM_FLOAT
+        )
+        val periodBytes = readBuffer.size * BYTES_PER_FLOAT
+        val bufferBytes = maxOf(if (minBytes > 0) minBytes else 0, periodBytes * 2)
+
+        // NOTE: no setAudioSource() — it is mutually exclusive with
+        // setAudioPlaybackCaptureConfig (the config implies the source).
+        // Throws (UnsupportedOperationException / SecurityException) when
+        // RECORD_AUDIO is not granted or the projection is not usable —
+        // surfaced to the Rust caller as the JNI exception.
+        audioRecord = AudioRecord.Builder()
+            .setAudioPlaybackCaptureConfig(captureConfig)
+            .setAudioFormat(format)
+            .setBufferSizeInBytes(bufferBytes)
+            .build()
+
+        check(audioRecord.state == AudioRecord.STATE_INITIALIZED) {
+            "AudioRecord failed to initialize for playback capture " +
+                "($sampleRate Hz, $channels ch, uid=$matchUid)"
+        }
+    }
+
+    /**
+     * Starts recording and spawns the dedicated read thread. Idempotent —
+     * a second call while running is a no-op. Fails fast (before touching
+     * the AudioRecord) when the native push symbol is unavailable.
+     *
+     * @throws IllegalStateException if librsac.so is absent (rsac-77f1 not
+     *   packaged) or the record cannot start.
+     */
+    fun start() {
+        check(RsacProjection.isNativeAvailable()) {
+            "librsac.so is not available: nativePush (rsac-77f1) cannot be " +
+                "called. See mobile/android/README.md § Native library."
+        }
+        check(!released.get()) { "CaptureBridge already released" }
+        if (!running.compareAndSet(false, true)) return
+
+        try {
+            audioRecord.startRecording()
+            check(audioRecord.recordingState == AudioRecord.RECORDSTATE_RECORDING) {
+                "AudioRecord.startRecording() did not enter RECORDING state"
+            }
+        } catch (t: Throwable) {
+            running.set(false)
+            throw t
+        }
+
+        thread = Thread(::readLoop, "rsac-capture-bridge").apply {
+            // No policy here either: normal priority; the Rust ring absorbs
+            // scheduling jitter and surfaces sustained lag as overruns.
+            isDaemon = true
+            start()
+        }
+    }
+
+    /**
+     * The dedicated capture loop: blocking reads into the single reused
+     * buffer, one [nativePush] per successful period. On exit — error path
+     * or normal stop — exactly one [nativeSessionEnded] fires (the terminal
+     * handshake): Rust treats a still-registered session as a spontaneous
+     * death (projection revoked, service destroyed, record death) and
+     * drives its bridge to the fatal terminal (ADR-0010/ADR-0003); on a
+     * Rust-initiated stop the session is already unregistered and the call
+     * is a no-op.
+     */
+    private fun readLoop() {
+        val buf = readBuffer
+        try {
+            while (running.get()) {
+                val read = audioRecord.read(buf, 0, buf.size, AudioRecord.READ_BLOCKING)
+                when {
+                    read > 0 -> {
+                        // read() returns a float (sample) count; whole frames
+                        // only are forwarded (a partial trailing frame — not
+                        // expected from AudioRecord — is dropped, not split).
+                        val frames = read / channels
+                        if (frames > 0) {
+                            // Rust side: GetFloatArrayRegion into session-lifetime
+                            // scratch → push_samples_or_drop (ring-full ⇒ drop +
+                            // overrun count; never blocks this thread).
+                            nativePush(session, buf, frames, channels, sampleRate)
+                        }
+                    }
+                    read == 0 -> {
+                        // Spurious empty read (e.g. racing stop()) — loop.
+                    }
+                    else -> {
+                        // ERROR_INVALID_OPERATION / ERROR_DEAD_OBJECT / ERROR:
+                        // the record can no longer deliver. Exit; the finally
+                        // block signals the terminal handshake — no policy here.
+                        break
+                    }
+                }
+            }
+        } finally {
+            nativeSessionEnded(session)
+        }
+    }
+
+    /**
+     * Stops the loop, joins the thread (bounded), and releases the
+     * [AudioRecord]. Idempotent and safe from any thread except the read
+     * thread itself. After this returns, no further [nativePush] call for
+     * this bridge is in flight — the Rust side may then invalidate `session`.
+     */
+    fun stop() {
+        if (!released.compareAndSet(false, true)) return
+        running.set(false)
+        try {
+            // Unblocks a parked READ_BLOCKING read.
+            audioRecord.stop()
+        } catch (_: IllegalStateException) {
+            // Never started / already stopped — fine.
+        }
+        thread?.let {
+            it.join(JOIN_TIMEOUT_MS)
+            // CI-VERIFY: on-device, confirm AudioRecord.stop() reliably
+            // unblocks READ_BLOCKING within the timeout; if a device keeps
+            // the read parked, switch the loop to bounded reads or
+            // release() before join.
+        }
+        thread = null
+        audioRecord.release()
+    }
+
+    companion object {
+        /** Pass as `matchUid` for no UID filter (SystemDefault capture). */
+        const val NO_UID_FILTER: Int = -1
+
+        /** 480 frames = 10 ms at 48 kHz — a conventional capture period. */
+        const val DEFAULT_FRAMES_PER_READ: Int = 480
+
+        private const val BYTES_PER_FLOAT = 4
+        private const val JOIN_TIMEOUT_MS = 2_000L
+
+        /**
+         * Ingest entry point into Rust: copies `frames * channels` samples
+         * out of [buf] and pushes them into the capture's ring buffer.
+         *
+         * Registered from Rust via `RegisterNatives` (`JNI_OnLoad`,
+         * src/audio/android/jni.rs — rsac-77f1). **Lockstep contract**:
+         * renaming this method, its class, or its signature breaks the Rust
+         * registration — guarded by the host-run `jni_lockstep` tests in
+         * src/audio/mod.rs. Throws [UnsatisfiedLinkError] until librsac.so
+         * is loaded — guard with [RsacProjection.isNativeAvailable].
+         *
+         * @param session opaque per-capture ingest-session id (Rust-owned)
+         * @param buf interleaved f32 samples; only the first
+         *   `frames * channels` entries are read
+         * @param frames whole frames in this period
+         * @param channels interleaved channel count
+         * @param sampleRate delivery rate in Hz
+         */
+        @JvmStatic
+        external fun nativePush(
+            session: Long,
+            buf: FloatArray,
+            frames: Int,
+            channels: Int,
+            sampleRate: Int,
+        )
+
+        /**
+         * Terminal handshake into Rust: the read thread for [session] has
+         * exited (see [readLoop]). Fired exactly once per bridge, from the
+         * read thread's `finally`.
+         *
+         * Registered alongside [nativePush] (`RegisterNatives`, rsac-77f1)
+         * with signature `(J)V` — same **lockstep contract** and drift
+         * guard. Idempotent and safe for stale sessions on the Rust side.
+         */
+        @JvmStatic
+        external fun nativeSessionEnded(session: Long)
+    }
+}

--- a/mobile/android/src/main/kotlin/ai/codeseys/rsac/RsacProjection.kt
+++ b/mobile/android/src/main/kotlin/ai/codeseys/rsac/RsacProjection.kt
@@ -1,0 +1,186 @@
+package ai.codeseys.rsac
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.media.projection.MediaProjection
+import android.media.projection.MediaProjectionManager
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * MediaProjection consent flow — the "explicit builder token" half of the
+ * consent-token design (docs/MOBILE_BACKEND_DESIGN.md § consent-token flow,
+ * ADR-0012/ADR-0013).
+ *
+ * Flow:
+ *
+ * 1. The host app calls [request] with a [ComponentActivity]. rsac launches
+ *    the system consent dialog via the ActivityResult API.
+ * 2. On user approval, the resulting [MediaProjection] is handed to the
+ *    native side ([nativeRetainProjection]), which wraps it in a JNI
+ *    `GlobalRef` and returns an **opaque token** (`jlong`, pointer-sized
+ *    across FFI).
+ * 3. The token crosses into Rust and is given to
+ *    `AudioCaptureBuilder::with_android_projection(AndroidProjectionToken)`.
+ * 4. Token lifetime is owned by Rust: released (`DeleteGlobalRef` +
+ *    `MediaProjection.stop()`) when the owning capture is dropped.
+ *    **One token = one projection session** — do not reuse a token across
+ *    captures.
+ *
+ * There is deliberately no process-global token registry (no hidden state);
+ * the token is returned to the caller and nowhere else.
+ *
+ * ### Ordering on API 34+ (Android 14)
+ *
+ * Apps targeting SDK 34+ must have a `mediaProjection`-typed foreground
+ * service running before media-projection capture may start — start
+ * [RsacCaptureService] (or the host's own equivalent) before/around the
+ * consent flow. See README.md § Lifecycle ordering.
+ * // CI-VERIFY: whether MediaProjectionManager.getMediaProjection() itself
+ * // throws SecurityException on API 34+ without the running FGS, or whether
+ * // enforcement only triggers at capture start — adjust the KDoc/README
+ * // ordering guidance to match observed behavior on an API 34+ emulator.
+ *
+ * ### Native availability
+ *
+ * The native symbols ship with the Rust JNI layer (rsac-77f1), packaged as
+ * `librsac.so` in the AAR's jniLibs (rsac-0aa9). In a build without the
+ * native library (e.g. a stripped-down repackaging), calling
+ * [nativeRetainProjection] throws [UnsatisfiedLinkError]. Guard with
+ * [isNativeAvailable]; [request] fails fast with [IllegalStateException]
+ * when the native library is absent.
+ *
+ * No capture policy lives here (ADR-0012 §4.2): this object launches the
+ * consent dialog and forwards the projection to Rust — nothing more.
+ */
+object RsacProjection {
+
+    /**
+     * Name of the Rust cdylib, as passed to [System.loadLibrary]
+     * (`librsac.so` on disk).
+     */
+    // CI-VERIFY: must match the cdylib artifact name produced by cargo-ndk
+    // for the rsac crate (rsac-77f1 / rsac-1a6e); rename here + README table
+    // if the crate ships a differently-named mobile cdylib.
+    const val NATIVE_LIBRARY_NAME: String = "rsac"
+
+    /** Result callback for [request]. Invoked on the main thread. */
+    interface Callback {
+        /** Consent granted; [token] is the opaque projection token for Rust. */
+        fun onToken(token: Long)
+
+        /** Consent denied, cancelled, or the projection could not be created. */
+        fun onDenied(reason: String)
+    }
+
+    @Volatile
+    private var nativeLoadState: Boolean? = null
+
+    /**
+     * Returns `true` when `librsac.so` is present and loaded — i.e. the JNI
+     * symbols registered from Rust's `JNI_OnLoad` (rsac-77f1) are available.
+     *
+     * Loading is attempted at most once and the outcome cached; safe to call
+     * from any thread.
+     */
+    fun isNativeAvailable(): Boolean {
+        nativeLoadState?.let { return it }
+        synchronized(this) {
+            nativeLoadState?.let { return it }
+            val loaded = try {
+                System.loadLibrary(NATIVE_LIBRARY_NAME)
+                true
+            } catch (_: UnsatisfiedLinkError) {
+                false
+            }
+            nativeLoadState = loaded
+            return loaded
+        }
+    }
+
+    /**
+     * Launches the MediaProjection consent dialog and, on approval, converts
+     * the resulting [MediaProjection] into an opaque native token.
+     *
+     * Must be called from the main thread with a started [activity]. The
+     * [callback] fires on the main thread exactly once.
+     *
+     * @throws IllegalStateException if the rsac native library is not loaded
+     *   (see [isNativeAvailable]) — the token could not be retained anyway.
+     */
+    @JvmStatic
+    fun request(activity: ComponentActivity, callback: Callback) {
+        check(isNativeAvailable()) {
+            "librsac.so is not available: the JNI layer (rsac-77f1) is not " +
+                "packaged in this build, so a MediaProjection token cannot " +
+                "be retained. See mobile/android/README.md § Native library."
+        }
+
+        val manager = activity.getSystemService(Context.MEDIA_PROJECTION_SERVICE)
+            as MediaProjectionManager
+
+        // ActivityResultRegistry.register() is legal after onCreate; the
+        // trade-off (documented): if the consent dialog outlives the activity
+        // (process death / config change), this one-shot registration is not
+        // re-delivered — the host observes onDenied via a fresh request().
+        val delivered = AtomicBoolean(false)
+        var launcher: ActivityResultLauncher<Intent>? = null
+        launcher = activity.activityResultRegistry.register(
+            "rsac-projection-" + UUID.randomUUID(),
+            ActivityResultContracts.StartActivityForResult(),
+        ) { result ->
+            launcher?.unregister()
+            if (!delivered.compareAndSet(false, true)) return@register
+
+            val data = result.data
+            if (result.resultCode != Activity.RESULT_OK || data == null) {
+                callback.onDenied("user declined the media-projection consent dialog")
+                return@register
+            }
+
+            val projection: MediaProjection? = try {
+                manager.getMediaProjection(result.resultCode, data)
+            } catch (e: SecurityException) {
+                // API 34+: thrown when no mediaProjection foreground service
+                // is running, or the consent data was already consumed.
+                callback.onDenied(
+                    "getMediaProjection failed: ${e.message} (on API 34+ a " +
+                        "mediaProjection foreground service must be running " +
+                        "first — see README.md § Lifecycle ordering)"
+                )
+                return@register
+            }
+            if (projection == null) {
+                callback.onDenied("MediaProjectionManager returned no projection")
+                return@register
+            }
+
+            // Hand ownership to Rust: GlobalRef + opaque token. From here,
+            // release (DeleteGlobalRef + MediaProjection.stop()) is Rust's
+            // job, tied to the owning capture's Drop.
+            callback.onToken(nativeRetainProjection(projection))
+        }
+        launcher.launch(manager.createScreenCaptureIntent())
+    }
+
+    /**
+     * Wraps [projection] in a JNI `GlobalRef` and returns the opaque token
+     * consumed by `AudioCaptureBuilder::with_android_projection`.
+     *
+     * Registered from Rust via `RegisterNatives` (`JNI_OnLoad`,
+     * src/audio/android/jni.rs — rsac-77f1). **Lockstep contract**: renaming
+     * this method, its class, or its signature breaks the Rust registration
+     * — guarded by the host-run `jni_lockstep` tests in src/audio/mod.rs.
+     *
+     * Returns `0` when the projection could not be retained (a `0` token
+     * fails stream creation with an actionable error). Throws
+     * [UnsatisfiedLinkError] when the native library is absent — guard with
+     * [isNativeAvailable].
+     */
+    @JvmStatic
+    external fun nativeRetainProjection(projection: MediaProjection): Long
+}

--- a/scripts/check-module-dag.sh
+++ b/scripts/check-module-dag.sh
@@ -7,18 +7,20 @@
 #   - docs/ARCHITECTURE.md  (§1, "Known deviation (tracked)")
 #   - AGENTS.md             (§ Module layering / §6.6)
 #
-#       core/  →  bridge/  →  audio/  →  api/
+#       core/  →  bridge/  →  audio/  →  api/  →  compose/ (opt-in)
 #                                         ↘ sink/
 #
 # Dependencies may only point DOWN this chain. A layer must never `use` or
 # reference (`crate::<upper-layer>::…`) a layer that sits ABOVE it. Concretely:
 #
-#   core    must not reference  bridge | audio | api | sink
-#   bridge  must not reference  audio  | api   | sink
-#   audio   must not reference  api    | sink
+#   core    must not reference  bridge | audio | api | sink | compose
+#   bridge  must not reference  audio  | api   | sink | compose
+#   audio   must not reference  api    | sink  | compose
+#   api     must not reference  compose
+#   sink    must not reference  compose
 #
-# (api/ and sink/ are the top of the chain, so they have no forbidden edges to
-# guard here.)
+# (compose/ — ADR-0011, behind the `compose` feature — is the top of the chain,
+# so it has no forbidden edges to guard here.)
 #
 # This is the DAG-004 CI guard called for by
 # docs/reviews/rsac-architecture-critique-2026-05-30.md (findings DAG-001 /
@@ -79,6 +81,12 @@ ALLOWLIST=(
   "src/core/introspection.rs::crate::audio::macos::enumerate_audio_applications"
   "src/core/introspection.rs::crate::audio::windows::enumerate_application_audio_sessions"
   "src/core/introspection.rs::crate::audio::linux::enumerate_audio_applications"
+
+  # --- ADR-0015 (seed rsac-84b8): check_audio_capture_permission() reaches the
+  #     macOS TCC preflight shim under the opt-in `macos-tcc-spi` feature. Same
+  #     documented core→audio deviation class as the discovery edges above;
+  #     folds into the same audio/api relocation when DAG-001/002 is resolved.
+  "src/core/introspection.rs::crate::audio::macos::permission"
 
   # --- Test-only edge: the bridge/ integration-test module (#[cfg(test)]) wires
   #     the full stack (sink + bridge) together to exercise the pipeline end to
@@ -229,18 +237,21 @@ if [[ "${1:-}" == "--self-test" ]]; then
 fi
 
 echo "==> rsac module-DAG reverse-edge guard (DAG-004)"
-echo "    chain: core -> bridge -> audio -> api (-> sink)"
+echo "    chain: core -> bridge -> audio -> api (-> sink) -> compose"
 echo "    tool : $([[ ${have_rg} -eq 1 ]] && echo 'ripgrep' || echo 'grep -rn')"
 echo
 
-# ── The three forbidden-edge scans (one per layer that has things above it) ───
+# ── The forbidden-edge scans (one per layer that has things above it) ─────────
 # Layer source roots are REPO-RELATIVE (see scan_layer for why). NOTE: api/ is
-# the file src/api.rs, every other layer is a directory. sink/ is top-of-chain
-# so it is never a source scanned here.
+# the file src/api.rs, every other layer is a directory. compose/ (ADR-0011) is
+# top-of-chain so it is never a source scanned here; api/ and sink/ gained a
+# forbidden edge (compose) when it landed above them.
 declare -a SCAN_TARGETS=(
-  "core::src/core::bridge|audio|api|sink"
-  "bridge::src/bridge::audio|api|sink"
-  "audio::src/audio::api|sink"
+  "core::src/core::bridge|audio|api|sink|compose"
+  "bridge::src/bridge::audio|api|sink|compose"
+  "audio::src/audio::api|sink|compose"
+  "api::src/api.rs::compose"
+  "sink::src/sink::compose"
 )
 
 new_violations=0

--- a/src/api.rs
+++ b/src/api.rs
@@ -178,6 +178,30 @@ impl AudioCaptureBuilder {
         self
     }
 
+    /// Supplies the App Group identifier for iOS system-audio capture
+    /// *(iOS targets only)*.
+    ///
+    /// iOS serves [`CaptureTarget::SystemDefault`] through a ReplayKit
+    /// Broadcast Upload Extension writing into a ring in the **shared App
+    /// Group container** (ADR-0013, rsac-b3aa); the App Group id (e.g.
+    /// `"group.com.example.myapp.rsac"`) is the config-time consent artifact
+    /// this backend needs to find that container — see
+    /// [`StreamConfig::ios_app_group`](crate::core::config::StreamConfig::ios_app_group).
+    /// Pass it **before** [`build`](Self::build): `SystemDefault` builds
+    /// without one fail the preflight with
+    /// [`UserConsentRequired`](crate::core::error::AudioError::UserConsentRequired).
+    ///
+    /// Microphone ([`CaptureTarget::Device`]) targets never need an App
+    /// Group, and supplying one is harmless (it is simply unused). The value
+    /// is stored on the builder's [`StreamConfig`], so a later
+    /// [`with_config`](Self::with_config) replaces it along with everything
+    /// else.
+    #[cfg(target_os = "ios")]
+    pub fn with_ios_app_group(mut self, group: impl Into<String>) -> Self {
+        self.config.ios_app_group = Some(group.into());
+        self
+    }
+
     // ── Read-only accessors ──────────────────────────────────────────
 
     /// Returns the capture target configured so far.
@@ -359,7 +383,7 @@ impl AudioCaptureBuilder {
         }
 
         // ── Consent preflight (mobile, ADR-0013 / rsac-82d4) ─────────
-        // Dormant scaffolding until an Android backend exists: it fires only
+        // Live as of rsac-77f1 (the Android playback backend): it fires only
         // when the platform *claims* the requested playback-capture tier AND
         // reports `requires_user_consent` AND no token was supplied. The
         // capability checks above dominate, so a build with no compiled-in
@@ -385,6 +409,39 @@ impl AudioCaptureBuilder {
                     missing: "MediaProjection token — obtain one via the rsac Android \
                               consent helper and pass it to \
                               AudioCaptureBuilder::with_android_projection()"
+                        .to_string(),
+                });
+            }
+        }
+
+        // ── Consent preflight (iOS, ADR-0013 / rsac-b3aa) ────────────
+        // Mirror of the Android block above: it fires only when the platform
+        // *claims* the requested capture tier AND reports
+        // `requires_user_consent` AND no App Group was supplied. The
+        // capability checks above dominate (the per-app arms below are
+        // unreachable on iOS today, where those tiers are permanently
+        // unsupported), so a build with no compiled-in backend still reports
+        // PlatformNotSupported — never a misleading consent error.
+        #[cfg(target_os = "ios")]
+        {
+            let target_needs_consent = match &self.target {
+                CaptureTarget::SystemDefault => caps.supports_system_capture,
+                CaptureTarget::Application(_) | CaptureTarget::ApplicationByName(_) => {
+                    caps.supports_application_capture
+                }
+                CaptureTarget::ProcessTree(_) => caps.supports_process_tree_capture,
+                // Microphone capture never needs the App Group artifact.
+                CaptureTarget::Device(_) => false,
+            };
+            if caps.requires_user_consent
+                && target_needs_consent
+                && self.config.ios_app_group.is_none()
+            {
+                return Err(AudioError::UserConsentRequired {
+                    feature: "iOS broadcast capture".to_string(),
+                    missing: "App Group identifier — call \
+                              AudioCaptureBuilder::with_ios_app_group(\"group.…\") and \
+                              embed the RsacBroadcastKit extension"
                         .to_string(),
                 });
             }
@@ -433,6 +490,13 @@ impl AudioCaptureBuilder {
         // ── Build capture config ────────────────────────────────────
         let mut stream_config = self.config;
         stream_config.capture_target = self.target.clone();
+        // Propagate the Android consent token into the stream config so the
+        // backend's create_stream can resolve it back through JNI
+        // (rsac-77f1); mirrors the ios_app_group plumbing.
+        #[cfg(target_os = "android")]
+        {
+            stream_config.android_projection = self.android_projection;
+        }
         #[allow(unused_mut)] // mutated only in the non-Linux negotiation block
         let mut capture_config = AudioCaptureConfig {
             target: self.target,
@@ -2607,6 +2671,10 @@ mod tests {
             sample_format: SampleFormat::I16,
             buffer_size: Some(1024),
             capture_target: CaptureTarget::SystemDefault,
+            #[cfg(target_os = "ios")]
+            ios_app_group: None,
+            #[cfg(target_os = "android")]
+            android_projection: None,
         };
         let builder = AudioCaptureBuilder::new().with_config(config.clone());
         assert_eq!(builder.config, config);
@@ -2789,6 +2857,10 @@ mod tests {
             sample_format: SampleFormat::I32,
             buffer_size: Some(2048),
             capture_target: CaptureTarget::SystemDefault,
+            #[cfg(target_os = "ios")]
+            ios_app_group: None,
+            #[cfg(target_os = "android")]
+            android_projection: None,
         };
         let builder = AudioCaptureBuilder::new()
             .sample_rate(44100) // This should be overridden

--- a/src/api.rs
+++ b/src/api.rs
@@ -24,6 +24,8 @@
 use crate::audio::get_device_enumerator;
 use crate::core::buffer::AudioBuffer;
 use crate::core::capabilities::PlatformCapabilities;
+#[cfg(target_os = "android")]
+use crate::core::config::AndroidProjectionToken;
 use crate::core::config::{CaptureTarget, SampleFormat, StreamConfig};
 // `AudioFormat` is only referenced by `pick_supported_format` (and its tests),
 // which is itself `cfg(not(target_os = "linux"))`; gate the import to match so
@@ -41,7 +43,7 @@ use crate::core::introspection::{BackpressureReport, StreamStats};
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -69,6 +71,31 @@ const SUPPORTED_SAMPLE_RATES: [u32; 6] = PlatformCapabilities::SUPPORTED_SAMPLE_
 /// a narrower per-platform limit is enforced later by `PlatformCapabilities`.
 const MAX_CHANNELS: u16 = 32;
 
+/// Capacity, in buffers, of the **bounded** channel behind
+/// [`AudioCapture::subscribe`], [`AudioCapture::subscribe_with_errors`], and
+/// the `compose` feature's `Composition::subscribe{,_with_errors}`.
+///
+/// 128 buffers is deliberately the same order of magnitude as the bridge ring
+/// itself (the composed ring uses 128 slots; at the typical ~10 ms buffer
+/// cadence this is ~1.3 s of audio). A subscriber that stalls longer than that
+/// starts **losing** buffers — by design: the crate-wide backpressure policy is
+/// *drop, don't block, and count it* (ADR-0007). The previous unbounded
+/// `mpsc::channel()` instead grew without limit while `overrun_count()` /
+/// `backpressure_report()` read healthy, because the pump drained the ring
+/// promptly even when the subscriber never caught up (rsac-d6a8).
+pub(crate) const SUBSCRIBE_CHANNEL_CAPACITY: usize = 128;
+
+/// Minimum interval between two forwarded **same-variant** recoverable errors
+/// on a [`AudioCapture::subscribe_with_errors`] channel.
+///
+/// The pump polls at ~1 ms, so a persistently-recoverable stream would
+/// otherwise emit ~1000 identical advisory `Err` items per second, flooding
+/// the bounded channel and crowding out audio. Repeated recoverable errors of
+/// the same variant are therefore coalesced: forwarded at most once per this
+/// interval, while an error of a *different* variant is always forwarded
+/// immediately (rsac-d6a8).
+pub(crate) const RECOVERABLE_ERROR_FORWARD_INTERVAL: Duration = Duration::from_secs(1);
+
 /// A builder for creating [`AudioCapture`] instances.
 ///
 /// This builder allows for a flexible and clear way to specify audio capture parameters.
@@ -94,6 +121,11 @@ const MAX_CHANNELS: u16 = 32;
 pub struct AudioCaptureBuilder {
     target: CaptureTarget,
     config: StreamConfig,
+    /// Android `MediaProjection` consent token (rsac-82d4 / ADR-0013).
+    /// Present only on Android builds; playback-capture targets need it once
+    /// an Android backend advertises the capability.
+    #[cfg(target_os = "android")]
+    android_projection: Option<AndroidProjectionToken>,
 }
 
 impl Default for AudioCaptureBuilder {
@@ -101,6 +133,8 @@ impl Default for AudioCaptureBuilder {
         Self {
             target: CaptureTarget::SystemDefault,
             config: StreamConfig::default(),
+            #[cfg(target_os = "android")]
+            android_projection: None,
         }
     }
 }
@@ -119,6 +153,28 @@ impl AudioCaptureBuilder {
     /// Sets the capture target (system default, device, application, …).
     pub fn with_target(mut self, target: CaptureTarget) -> Self {
         self.target = target;
+        self
+    }
+
+    /// Supplies the Android `MediaProjection` consent token
+    /// *(Android targets only)*.
+    ///
+    /// Android gates playback capture (system / application / process-tree
+    /// targets) behind a user-consent dialog whose result the configuration
+    /// must carry — see
+    /// [`AndroidProjectionToken`](crate::core::config::AndroidProjectionToken)
+    /// and `docs/MOBILE_BACKEND_DESIGN.md`. Obtain the token from the rsac
+    /// Android consent helper and pass it here **before**
+    /// [`build`](Self::build); once an Android backend advertises
+    /// `requires_user_consent`, playback-capture targets without a token fail
+    /// the preflight with
+    /// [`UserConsentRequired`](crate::core::error::AudioError::UserConsentRequired).
+    ///
+    /// Microphone ([`CaptureTarget::Device`]) targets never need a token, and
+    /// supplying one is harmless (it is simply unused).
+    #[cfg(target_os = "android")]
+    pub fn with_android_projection(mut self, token: AndroidProjectionToken) -> Self {
+        self.android_projection = Some(token);
         self
     }
 
@@ -302,13 +358,46 @@ impl AudioCaptureBuilder {
             _ => {}
         }
 
+        // ── Consent preflight (mobile, ADR-0013 / rsac-82d4) ─────────
+        // Dormant scaffolding until an Android backend exists: it fires only
+        // when the platform *claims* the requested playback-capture tier AND
+        // reports `requires_user_consent` AND no token was supplied. The
+        // capability checks above dominate, so a build with no compiled-in
+        // backend still reports PlatformNotSupported — never a misleading
+        // consent error.
+        #[cfg(target_os = "android")]
+        {
+            let target_needs_consent = match &self.target {
+                CaptureTarget::SystemDefault => caps.supports_system_capture,
+                CaptureTarget::Application(_) | CaptureTarget::ApplicationByName(_) => {
+                    caps.supports_application_capture
+                }
+                CaptureTarget::ProcessTree(_) => caps.supports_process_tree_capture,
+                // Microphone capture never needs a projection token.
+                CaptureTarget::Device(_) => false,
+            };
+            if caps.requires_user_consent
+                && target_needs_consent
+                && self.android_projection.is_none()
+            {
+                return Err(AudioError::UserConsentRequired {
+                    feature: "Android playback capture".to_string(),
+                    missing: "MediaProjection token — obtain one via the rsac Android \
+                              consent helper and pass it to \
+                              AudioCaptureBuilder::with_android_projection()"
+                        .to_string(),
+                });
+            }
+        }
+
         // ── Validate sample rate ────────────────────────────────────
         if !SUPPORTED_SAMPLE_RATES.contains(&self.config.sample_rate) {
             return Err(AudioError::InvalidParameter {
                 param: "sample_rate".into(),
                 reason: format!(
-                    "Unsupported sample rate: {} Hz. Supported: 22050, 32000, 44100, 48000, 88200, 96000",
-                    self.config.sample_rate
+                    "Unsupported sample rate: {} Hz. Supported: {}",
+                    self.config.sample_rate,
+                    PlatformCapabilities::supported_sample_rates_display()
                 ),
             });
         }
@@ -382,6 +471,7 @@ impl AudioCaptureBuilder {
             callback: Mutex::new(None),
             callback_pump: None,
             start_instant: None,
+            subscriber_dropped: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -654,12 +744,27 @@ impl RunningCapture {
     /// from the same ring (a single logical consumer per buffer). **Do not** mix
     /// `drain_to` with manual reads on the same capture.
     ///
+    /// # Accepted stream states (drain-the-tail; rsac-7aa2)
+    ///
+    /// Accepted whenever a stream exists: `Running`, the drainable `Stopping`
+    /// window (a gracefully-ended stream's buffered tail is drained into the
+    /// sink before finalization), or even an already-terminal stream — the
+    /// drain thread then exits on its first read and still finalizes the sink
+    /// (`flush()` then `close()`), so e.g. a WAV header is written for an empty
+    /// capture. The gate is stream **presence** only, chosen over a
+    /// `Running || Stopping` state check because (a) `CapturingStream` cannot
+    /// distinguish `Stopping` from terminal without consuming a buffer, and
+    /// (b) a state check here merely races the stream's own lifecycle — the
+    /// drain loop already handles every state honestly, so rejecting at the
+    /// gate could strand a drainable tail while accepting adds no hazard.
+    /// `Composition::drain_to` (behind the `compose` feature) applies the same
+    /// policy, so the two handles agree.
+    ///
     /// # Errors
     ///
-    /// Returns [`AudioError::StreamReadError`] if the capture has no stream or is
-    /// not running, or [`AudioError::InternalError`] if the drain thread cannot
-    /// be spawned. (`RunningCapture` is normally started, but the underlying
-    /// stream may have reached a terminal state by the time this is called.)
+    /// Returns [`AudioError::StreamReadError`] if the capture has no stream
+    /// (never started, or stopped — `stop()` releases the stream), or
+    /// [`AudioError::InternalError`] if the drain thread cannot be spawned.
     ///
     /// # Example
     ///
@@ -687,91 +792,28 @@ impl RunningCapture {
     /// # #[cfg(not(feature = "sink-wav"))]
     /// # fn main() {}
     /// ```
-    pub fn drain_to<S>(&self, mut sink: S) -> AudioResult<DrainHandle>
+    pub fn drain_to<S>(&self, sink: S) -> AudioResult<DrainHandle>
     where
         S: crate::sink::AudioSink + 'static,
     {
-        // Require a live stream, exactly like subscribe(): a RunningCapture is
-        // normally started, but its stream may already have reached a terminal
-        // state. Read via `&self` (DerefMut not needed) so we never form a `&mut`
-        // alias to the handle — the drain thread only needs a stream Arc clone.
+        // Presence gate only (rsac-7aa2, same policy as subscribe()): Running
+        // AND the drainable Stopping window are accepted — drain-the-tail. On a
+        // stream already at its fatal terminal the drain thread exits on its
+        // first read and finalizes (flush + close) the sink immediately, which
+        // is the honest outcome of racing a natural end. Read via `&self`
+        // (DerefMut not needed) so we never form a `&mut` alias to the handle —
+        // the drain thread only needs a stream Arc clone.
         let stream_ref = self
             .0
             .stream
             .as_ref()
             .ok_or_else(|| AudioError::StreamReadError {
-                reason: "Stream is not initialized. Call start() first.".to_string(),
+                reason: "No active stream: the capture was never started, or has been \
+                         stopped (stop() releases the stream). Call start() to begin \
+                         (or restart) capturing."
+                    .to_string(),
             })?;
-        if !stream_ref.is_running() {
-            return Err(AudioError::StreamReadError {
-                reason: "Stream is not running".to_string(),
-            });
-        }
-        let stream = Arc::clone(stream_ref);
-
-        let stop_flag = Arc::new(AtomicBool::new(false));
-        let stop_flag_thread = Arc::clone(&stop_flag);
-        let handle = std::thread::Builder::new()
-            .name("rsac-drain".into())
-            .spawn(move || {
-                loop {
-                    if stop_flag_thread.load(Ordering::SeqCst) {
-                        break;
-                    }
-                    match stream.try_read_chunk() {
-                        // The drain thread OWNS `sink`, so no lock is held while
-                        // user sink code runs (it may block on I/O without
-                        // stalling anything else).
-                        Ok(Some(buffer)) => {
-                            if let Err(e) = sink.write(&buffer) {
-                                if e.is_fatal() {
-                                    log::error!(
-                                        "Drain sink write failed fatally; \
-                                         stopping drain: {:?}",
-                                        e
-                                    );
-                                    break;
-                                }
-                                // Recoverable write error: log and keep draining
-                                // (mirrors the read-side recoverable policy).
-                                log::warn!("Drain sink write error (continuing): {:?}", e);
-                            }
-                        }
-                        Ok(None) => {
-                            // No data right now — avoid busy-spinning. Mirrors
-                            // spawn_callback_pump's idle poll.
-                            std::thread::sleep(std::time::Duration::from_millis(1));
-                        }
-                        // Only a FATAL read error (e.g. StreamEnded — terminal)
-                        // ends the drain. A recoverable read error is logged and
-                        // retried, mirroring the callback pump and subscribe().
-                        Err(e) if e.is_fatal() => break,
-                        Err(e) => {
-                            log::warn!("Drain pump read error (retrying): {:?}", e);
-                            std::thread::sleep(std::time::Duration::from_millis(1));
-                        }
-                    }
-                }
-                // Loop exited (terminal stream, fatal write, or stop signal):
-                // finalize the sink. flush() then close() so a file sink's header
-                // is written even on the error paths. Both are best-effort here
-                // because the thread cannot return a Result; log any failure.
-                if let Err(e) = sink.flush() {
-                    log::error!("Drain sink flush failed: {:?}", e);
-                }
-                if let Err(e) = sink.close() {
-                    log::error!("Drain sink close failed: {:?}", e);
-                }
-            })
-            .map_err(|e| AudioError::InternalError {
-                message: format!("Failed to spawn drain thread: {}", e),
-                source: None,
-            })?;
-
-        Ok(DrainHandle {
-            stop_flag,
-            handle: Some(handle),
-        })
+        spawn_drain_thread(Arc::clone(stream_ref), sink)
     }
 
     /// Consumes the guard and returns the wrapped [`AudioCapture`], **without**
@@ -823,6 +865,263 @@ impl fmt::Debug for RunningCapture {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("RunningCapture").field(&self.0).finish()
     }
+}
+
+/// Shared drain-thread spawner behind [`RunningCapture::drain_to`] and the
+/// `compose` feature's `Composition::drain_to`: reads the stream's
+/// *terminal-observable* `try_read_chunk` path on a dedicated `rsac-drain`
+/// thread that **owns** the sink, writing each buffer and finalizing
+/// (`flush()` then `close()`) exactly once when the loop exits.
+///
+/// Policy (identical for both callers):
+/// - recoverable read/write errors are logged and retried — they never end
+///   draining;
+/// - a **fatal** read error (e.g. the terminal
+///   [`AudioError::StreamEnded`]) or a fatal write error ends the loop, after
+///   which `flush()`/`close()` still run so a file sink's header is written;
+/// - `Ok(None)` sleeps ~1 ms to avoid busy-spinning (mirrors the callback
+///   pump's idle poll).
+pub(crate) fn spawn_drain_thread<S>(
+    stream: Arc<dyn crate::core::interface::CapturingStream>,
+    mut sink: S,
+) -> AudioResult<DrainHandle>
+where
+    S: crate::sink::AudioSink + 'static,
+{
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    let stop_flag_thread = Arc::clone(&stop_flag);
+    let handle = std::thread::Builder::new()
+        .name("rsac-drain".into())
+        .spawn(move || {
+            loop {
+                if stop_flag_thread.load(Ordering::SeqCst) {
+                    break;
+                }
+                match stream.try_read_chunk() {
+                    // The drain thread OWNS `sink`, so no lock is held while
+                    // user sink code runs (it may block on I/O without
+                    // stalling anything else).
+                    Ok(Some(buffer)) => {
+                        if let Err(e) = sink.write(&buffer) {
+                            if e.is_fatal() {
+                                log::error!(
+                                    "Drain sink write failed fatally; \
+                                     stopping drain: {:?}",
+                                    e
+                                );
+                                break;
+                            }
+                            // Recoverable write error: log and keep draining
+                            // (mirrors the read-side recoverable policy).
+                            log::warn!("Drain sink write error (continuing): {:?}", e);
+                        }
+                    }
+                    Ok(None) => {
+                        // No data right now — avoid busy-spinning. Mirrors
+                        // spawn_callback_pump's idle poll.
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                    }
+                    // Only a FATAL read error (e.g. StreamEnded — terminal)
+                    // ends the drain. A recoverable read error is logged and
+                    // retried, mirroring the callback pump and subscribe().
+                    Err(e) if e.is_fatal() => break,
+                    Err(e) => {
+                        log::warn!("Drain pump read error (retrying): {:?}", e);
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                    }
+                }
+            }
+            // Loop exited (terminal stream, fatal write, or stop signal):
+            // finalize the sink. flush() then close() so a file sink's header
+            // is written even on the error paths. Both are best-effort here
+            // because the thread cannot return a Result; log any failure.
+            if let Err(e) = sink.flush() {
+                log::error!("Drain sink flush failed: {:?}", e);
+            }
+            if let Err(e) = sink.close() {
+                log::error!("Drain sink close failed: {:?}", e);
+            }
+        })
+        .map_err(|e| AudioError::InternalError {
+            message: format!("Failed to spawn drain thread: {}", e),
+            source: None,
+        })?;
+
+    Ok(DrainHandle {
+        stop_flag,
+        handle: Some(handle),
+    })
+}
+
+/// Shared push-subscription pump behind [`AudioCapture::subscribe`] and the
+/// `compose` feature's `Composition::subscribe`: a background `rsac-subscribe`
+/// thread reads the stream's terminal-observable `try_read_chunk` path and
+/// forwards each buffer over a **bounded** [`mpsc`] channel
+/// ([`SUBSCRIBE_CHANNEL_CAPACITY`] buffers).
+///
+/// Policy (identical for both callers; mirrors the callback pump and the
+/// iterator):
+/// - buffers are forwarded with a **non-blocking** `try_send`: when the
+///   subscriber has stalled long enough to fill the channel, the buffer is
+///   **dropped and counted** in `dropped` — the crate-wide "drop, don't
+///   block, and count it" backpressure policy. An unbounded channel would
+///   instead grow memory without limit while the ring-side `overrun_count()`
+///   read healthy (rsac-d6a8);
+/// - only a **fatal** terminal (e.g. [`AudioError::StreamEnded`]) ends the
+///   subscription — the channel then disconnects, which the receiver observes
+///   as a [`RecvError`](std::sync::mpsc::RecvError);
+/// - a **recoverable** read error is logged and retried, never ending delivery
+///   (FH-1/BP-6);
+/// - a momentarily-empty ring sleeps ~1 ms (the documented latency floor);
+/// - a dropped receiver ends the thread (observed on every send attempt,
+///   including the `Full` path's `Disconnected` variant).
+pub(crate) fn spawn_subscribe_thread(
+    stream: Arc<dyn crate::core::interface::CapturingStream>,
+    dropped: Arc<AtomicU64>,
+) -> AudioResult<mpsc::Receiver<AudioBuffer>> {
+    let (tx, rx) = mpsc::sync_channel(SUBSCRIBE_CHANNEL_CAPACITY);
+
+    std::thread::Builder::new()
+        .name("rsac-subscribe".into())
+        .spawn(move || loop {
+            match stream.try_read_chunk() {
+                Ok(Some(buffer)) => match tx.try_send(buffer) {
+                    Ok(()) => {}
+                    // Subscriber slower than real time: the bounded channel is
+                    // full. Drop the buffer (never block the pump, never queue
+                    // unbounded memory) and count the loss so it is visible via
+                    // subscriber_dropped_count() — the ring-side counters can't
+                    // see it, because the pump drained the ring successfully.
+                    Err(mpsc::TrySendError::Full(_)) => {
+                        dropped.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Err(mpsc::TrySendError::Disconnected(_)) => break, // Receiver dropped
+                },
+                Ok(None) => {
+                    // No data available, sleep briefly to avoid busy-spinning
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                }
+                // Only a FATAL terminal (e.g. StreamEnded) ends the
+                // subscription — the channel then disconnects, which the
+                // receiver observes as a RecvError. A recoverable read error
+                // (transient StreamReadError, BufferOverrun/Underrun) must
+                // NOT kill delivery; log and retry after a brief pause,
+                // mirroring the callback pump (spawn_callback_pump) and the
+                // iterator. This closes the prior bug where ANY error broke
+                // the loop and silently ended the subscription (FH-1/BP-6).
+                Err(e) if e.is_fatal() => break,
+                Err(e) => {
+                    log::warn!("Subscribe thread read error (retrying): {:?}", e);
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                }
+            }
+        })
+        .map_err(|e| AudioError::InternalError {
+            message: format!("Failed to spawn subscribe thread: {}", e),
+            source: None,
+        })?;
+
+    Ok(rx)
+}
+
+/// Error-carrying sibling of [`spawn_subscribe_thread`] behind
+/// [`AudioCapture::subscribe_with_errors`] and the `compose` feature's
+/// `Composition::subscribe_with_errors`: each item is an
+/// [`AudioResult<AudioBuffer>`], and the **fatal terminal** error is delivered
+/// as the final channel item *before* the disconnect, so the consumer never
+/// has to race a bare `RecvError` to learn why the stream ended.
+///
+/// On top of [`spawn_subscribe_thread`]'s bounded-channel policy (`try_send`
+/// buffers; on `Full` drop-and-count into `dropped`):
+/// - repeated **recoverable** errors are coalesced: a same-variant error is
+///   forwarded at most once per [`RECOVERABLE_ERROR_FORWARD_INTERVAL`] (a
+///   persistently-recoverable stream errors once per ~1 ms poll and would
+///   otherwise flood the channel with identical advisory items); an error of a
+///   *different* variant is always forwarded immediately. A recoverable error
+///   item that meets a full channel is simply not forwarded that round (it is
+///   advisory; it is **not** counted as a dropped buffer);
+/// - the **fatal terminal** is sent with a **blocking** `send` so it can never
+///   be lost to the `Full` path: the pump exits right after, so blocking on
+///   this one final item is acceptable, and delivery is guaranteed unless the
+///   receiver is already gone (in which case nobody is listening anyway).
+pub(crate) fn spawn_subscribe_with_errors_thread(
+    stream: Arc<dyn crate::core::interface::CapturingStream>,
+    dropped: Arc<AtomicU64>,
+) -> AudioResult<mpsc::Receiver<AudioResult<AudioBuffer>>> {
+    let (tx, rx) = mpsc::sync_channel(SUBSCRIBE_CHANNEL_CAPACITY);
+
+    std::thread::Builder::new()
+        .name("rsac-subscribe-err".into())
+        .spawn(move || {
+            // Coalescing state: the variant of the last forwarded recoverable
+            // error and when it was forwarded. Variant identity (discriminant)
+            // rather than full equality keeps the hot path allocation-free.
+            let mut last_recoverable: Option<(std::mem::Discriminant<AudioError>, Instant)> = None;
+            loop {
+                match stream.try_read_chunk() {
+                    Ok(Some(buffer)) => match tx.try_send(Ok(buffer)) {
+                        Ok(()) => {}
+                        // Full channel: drop the buffer, count it (see
+                        // spawn_subscribe_thread — same policy).
+                        Err(mpsc::TrySendError::Full(_)) => {
+                            dropped.fetch_add(1, Ordering::Relaxed);
+                        }
+                        Err(mpsc::TrySendError::Disconnected(_)) => break, // Receiver dropped
+                    },
+                    Ok(None) => {
+                        // No data available, sleep briefly to avoid busy-spinning
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                    }
+                    // Fatal terminal: forward the error as the FINAL item, THEN
+                    // exit. This is deliberately the BLOCKING send: the channel
+                    // may be full of unread buffers, and the terminal must never
+                    // be silently lost to the Full path (the consumer would then
+                    // see a bare disconnect and never learn why the stream
+                    // ended). Blocking here is fine — the pump exits right after
+                    // this send, and send() errors out (ignored) if the receiver
+                    // is already gone.
+                    Err(e) if e.is_fatal() => {
+                        let _ = tx.send(Err(e));
+                        break;
+                    }
+                    // Recoverable: surface it (best-effort, coalesced) AND keep
+                    // delivering — a transient hiccup must not end the
+                    // subscription.
+                    Err(e) => {
+                        let variant = std::mem::discriminant(&e);
+                        let now = Instant::now();
+                        let forward = match last_recoverable {
+                            Some((last_variant, last_at)) => {
+                                variant != last_variant
+                                    || now.duration_since(last_at)
+                                        >= RECOVERABLE_ERROR_FORWARD_INTERVAL
+                            }
+                            None => true,
+                        };
+                        if forward {
+                            last_recoverable = Some((variant, now));
+                            // Advisory item: non-blocking. If the channel is
+                            // full the error is not forwarded this round (and
+                            // NOT counted as a dropped buffer); a disconnect
+                            // still ends the pump.
+                            if matches!(
+                                tx.try_send(Err(e)),
+                                Err(mpsc::TrySendError::Disconnected(_))
+                            ) {
+                                break; // Receiver dropped
+                            }
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                    }
+                }
+            }
+        })
+        .map_err(|e| AudioError::InternalError {
+            message: format!("Failed to spawn subscribe thread: {}", e),
+            source: None,
+        })?;
+
+    Ok(rx)
 }
 
 /// Handle to the background thread spawned by
@@ -1168,6 +1467,21 @@ impl CallbackPump {
     }
 }
 
+/// The lifecycle handle for a configured capture session, returned by
+/// [`AudioCaptureBuilder::build`].
+///
+/// `AudioCapture` owns the platform stream and exposes the full capture
+/// lifecycle: [`start()`](AudioCapture::start), [`stop()`](AudioCapture::stop),
+/// pull-based reads ([`read_buffer()`](AudioCapture::read_buffer)), push-based
+/// delivery ([`subscribe()`](AudioCapture::subscribe),
+/// [`set_callback()`](AudioCapture::set_callback)), and runtime introspection
+/// ([`stream_stats()`](AudioCapture::stream_stats),
+/// [`overrun_count()`](AudioCapture::overrun_count),
+/// [`uptime()`](AudioCapture::uptime)).
+///
+/// The handle is `Send + Sync` (asserted at compile time below); see the
+/// [module docs](self) for the threading model and the multiple-captures
+/// guarantee.
 pub struct AudioCapture {
     config: AudioCaptureConfig,
     device: Option<Box<dyn crate::core::interface::AudioDevice>>,
@@ -1184,6 +1498,12 @@ pub struct AudioCapture {
     /// non-RT control path (a single `Instant` store), never on an idempotent
     /// restart of an already-running stream. Drives [`uptime`](AudioCapture::uptime).
     start_instant: Option<Instant>,
+    /// Total buffers dropped by this handle's subscribe pumps because a
+    /// subscriber's bounded channel was full (rsac-d6a8). Shared (aggregated)
+    /// across every subscription created from this handle and monotone for
+    /// the handle's lifetime — it survives `stop()`/restart. Surfaced via
+    /// [`subscriber_dropped_count`](AudioCapture::subscriber_dropped_count).
+    subscriber_dropped: Arc<AtomicU64>,
 }
 
 // ── Send + Sync assertion (AEG-5, rsac-6f1f) ──────────────────────────────
@@ -1222,21 +1542,45 @@ impl AudioCapture {
     /// Creates the underlying OS stream (if not already created) and marks
     /// the capture as running. In the new `CapturingStream` contract, the
     /// stream starts producing data upon creation.
+    ///
+    /// # Restart-by-recreation (rsac-7aa2)
+    ///
+    /// A handle whose stream was released by [`stop`](Self::stop) **can** be
+    /// started again: `start()` creates a *fresh* stream from the same
+    /// resolved device/config, so `stop() → start() → read` works. Notes:
+    ///
+    /// - the uptime anchor re-anchors at the restart —
+    ///   [`uptime`](Self::uptime) reports time since the *current* stream was
+    ///   created, not cumulative capture time;
+    /// - per-stream counters ([`overrun_count`](Self::overrun_count),
+    ///   [`stream_stats`](Self::stream_stats)) reset with the new stream,
+    ///   while [`subscriber_dropped_count`](Self::subscriber_dropped_count)
+    ///   is handle-lifetime and survives.
+    ///
+    /// Calling `start()` while a stream already exists is state-dependent:
+    /// a **running** stream makes it an idempotent no-op (`Ok`); a stream
+    /// that is present but **no longer running** (a naturally-ended stream
+    /// that was never `stop()`ped) returns
+    /// [`AudioError::StreamStartFailed`] — an individual *stream* can never be
+    /// restarted; call `stop()` first to release it, then `start()` to
+    /// restart with a fresh one.
     pub fn start(&mut self) -> AudioResult<()> {
         // If a stream already exists, decide based on its state:
         // - running  → no-op (idempotent restart of an active capture).
-        // - stopped  → error. A stream cannot be restarted (the OS capture
-        //   thread has exited); the docs direct callers to build a new
-        //   AudioCapture. Previously this fell through and spawned a callback
-        //   pump on a dead stream, then read_buffer() would fail confusingly
-        //   (audit L8).
+        // - stopped  → error. An individual stream cannot be restarted (the OS
+        //   capture thread has exited); the caller must first release it via
+        //   stop(), after which start() creates a fresh stream
+        //   (restart-by-recreation — see the rustdoc above). Previously this
+        //   fell through and spawned a callback pump on a dead stream, then
+        //   read_buffer() would fail confusingly (audit L8).
         if let Some(stream) = self.stream.as_ref() {
             if stream.is_running() {
                 return Ok(());
             }
             return Err(AudioError::StreamStartFailed {
-                reason: "Stream already created and is no longer running; a stopped \
-                         stream cannot be restarted — create a new AudioCapture."
+                reason: "Stream already created and is no longer running; an individual \
+                         stream cannot be restarted — call stop() to release it, then \
+                         start() again to restart with a fresh stream."
                     .to_string(),
             });
         }
@@ -1359,8 +1703,13 @@ impl AudioCapture {
 
     /// Stops the audio capture stream.
     ///
-    /// Stops the underlying OS stream and releases resources. After stopping,
-    /// the stream cannot be restarted — create a new `AudioCapture` instead.
+    /// Stops the underlying OS stream and **releases** it: the handle's stream
+    /// slot becomes empty and the uptime anchor is cleared. The handle itself
+    /// remains usable — a subsequent [`start`](Self::start) creates a fresh
+    /// stream from the same resolved device/config (*restart-by-recreation*;
+    /// see [`start`](Self::start) for what carries over). An individual
+    /// *stream* can never be restarted; the handle restarts by creating a new
+    /// one.
     ///
     /// Any active subscriber threads will terminate once they detect the stream
     /// has stopped. The underlying stream is released when all references
@@ -1410,10 +1759,28 @@ impl AudioCapture {
         &self.config
     }
 
-    /// Reads a buffer of audio data synchronously.
+    /// Reads a buffer of audio data synchronously (non-blocking).
     ///
     /// Uses `CapturingStream::try_read_chunk` for non-blocking reads.
     /// Returns `Ok(None)` if no data is currently available.
+    ///
+    /// # Terminal semantics (important)
+    ///
+    /// This is the **simple pull API**: it short-circuits with a **recoverable**
+    /// [`AudioError::StreamReadError`] the moment the stream leaves `Running`, so
+    /// it **never surfaces the fatal [`AudioError::StreamEnded`]** and does **not**
+    /// drain the buffered tail after `stop()`. A loop that branches on
+    /// [`is_fatal()`](AudioError::is_fatal) to detect end-of-stream will therefore
+    /// **never terminate** on this method (the downgraded error is recoverable);
+    /// it is intended for `while let Ok(Some(buf)) = capture.read_buffer()` style
+    /// loops that stop when the caller decides to.
+    ///
+    /// Prefer [`read_chunk_nonblocking`](Self::read_chunk_nonblocking) (its
+    /// terminal-observable sibling) when you need to observe the clean
+    /// end-of-stream signal or drain the tail after `stop()` — that is the path
+    /// the language bindings and the [`AudioBufferIterator`] use. `read_buffer` is
+    /// retained unchanged for backward compatibility; new terminal-aware code
+    /// should migrate to `read_chunk_nonblocking`.
     ///
     /// Takes `&self` (not `&mut self`): this path only reads `self.stream` and
     /// calls the stream's own `&self` methods, mutating no field of the handle.
@@ -1511,13 +1878,28 @@ impl AudioCapture {
     ///
     /// Uses `CapturingStream::read_chunk` which blocks until data arrives.
     ///
+    /// # Terminal semantics (important)
+    ///
+    /// Like [`read_buffer`](Self::read_buffer), this is the **simple pull API**:
+    /// it returns a **recoverable** [`AudioError::StreamReadError`] the instant the
+    /// stream leaves `Running`, so it **never surfaces the fatal
+    /// [`AudioError::StreamEnded`]**. Use
+    /// [`read_chunk_blocking`](Self::read_chunk_blocking) — the terminal-observable
+    /// sibling — when you need the clean end-of-stream signal (it delegates
+    /// straight to `read_chunk` and returns `StreamEnded` promptly on terminal).
+    /// `read_buffer_blocking` is retained unchanged for backward compatibility.
+    ///
     /// Takes `&self` (not `&mut self`) for the same reason as
     /// [`read_buffer`](Self::read_buffer): no field of the handle is mutated, so
     /// a parked `read_buffer_blocking` can be unblocked by a concurrent
     /// [`request_stop`](Self::request_stop) without ever aliasing the handle
     /// mutably. When the stream reaches a terminal state the underlying
     /// `read_chunk` returns [`AudioError::StreamEnded`] promptly instead of
-    /// blocking forever.
+    /// blocking forever — but the `is_running()` guard below means that terminal
+    /// is only observed when the transition happens *during* an already-parked
+    /// read; a call made after the stream is already terminal returns the
+    /// recoverable "not running" error instead (use `read_chunk_blocking` to
+    /// always see `StreamEnded`).
     pub fn read_buffer_blocking(&self) -> AudioResult<AudioBuffer> {
         // Get the stream first — if there's no stream, we're not running.
         let stream = self
@@ -1575,6 +1957,20 @@ impl AudioCapture {
     /// from the audio capture backend.
     ///
     /// The capture must be started (via [`start()`](Self::start)) before calling this method.
+    ///
+    /// # Single async consumer (waker contract; rsac-7aa2)
+    ///
+    /// The bridge holds exactly **one** waker slot (an
+    /// `atomic_waker::AtomicWaker`). Creating two `AsyncAudioStream`s over the
+    /// same capture and polling them from two tasks concurrently is
+    /// **unsupported**: each poll's waker registration displaces the other
+    /// task's waker (concurrent `AtomicWaker::register` is the documented
+    /// unsupported case — the displaced waker is dropped *without being
+    /// woken*), so the displaced task can park forever on a wake that was
+    /// promised but stolen. Use **at most one** async consumer per capture.
+    /// Two consumers would in any case compete for buffers from the same ring
+    /// (a single logical consumer per buffer), so there is nothing to gain
+    /// from a second stream.
     ///
     /// # Feature Flag
     ///
@@ -1676,8 +2072,21 @@ impl AudioCapture {
     /// Creates a subscription channel that delivers audio buffers as they are captured.
     ///
     /// Spawns a background thread that reads from the capture stream and sends
-    /// buffers over an [`mpsc`] channel. Returns the receiving
-    /// end of the channel.
+    /// buffers over a **bounded** [`mpsc`] channel (128 buffers — the same
+    /// order as the bridge ring itself; ~1.3 s of audio at the typical ~10 ms
+    /// buffer cadence). Returns the receiving end of the channel.
+    ///
+    /// # Backpressure: drop, don't block, and count it (rsac-d6a8)
+    ///
+    /// If the receiver stalls long enough for the channel to fill, further
+    /// buffers are **dropped** — the pump never blocks and never queues
+    /// unbounded memory — and each drop is counted in
+    /// [`subscriber_dropped_count`](Self::subscriber_dropped_count). This loss
+    /// happens *downstream* of the capture ring, so
+    /// [`overrun_count`](Self::overrun_count) and
+    /// [`backpressure_report`](Self::backpressure_report) do **not** reflect
+    /// it; a slow subscriber must watch `subscriber_dropped_count()` as the
+    /// complement.
     ///
     /// **Important:** The background thread competes with [`read_buffer()`](Self::read_buffer)
     /// and [`read_buffer_blocking()`](Self::read_buffer_blocking) for audio data
@@ -1696,6 +2105,18 @@ impl AudioCapture {
     ///
     /// Multiple subscriptions are allowed but each subscriber competes for buffers.
     ///
+    /// # Accepted stream states (rsac-7aa2)
+    ///
+    /// The subscription is accepted whenever a stream exists — while `Running`
+    /// **or** in the drainable `Stopping` window: a gracefully-ended stream
+    /// still holding a buffered tail can be subscribed to and drained (the old
+    /// `is_running()` gate stranded that tail). Subscribing to a stream that
+    /// already reached its fatal terminal also succeeds and simply yields a
+    /// channel that ends immediately — racing a natural end is inherently
+    /// indistinguishable from subscribing just before it. Only a capture with
+    /// **no** stream (never started, or [`stop`](Self::stop)ped — `stop()`
+    /// releases the stream) is rejected.
+    ///
     /// # Latency floor (audit L5)
     ///
     /// The background thread polls with a 1 ms sleep when the ring buffer is
@@ -1709,61 +2130,23 @@ impl AudioCapture {
     ///
     /// # Errors
     ///
-    /// Returns an error if the capture is not currently running.
+    /// Returns [`AudioError::StreamReadError`] if the capture has no stream
+    /// (never started, or stopped).
     pub fn subscribe(&self) -> AudioResult<mpsc::Receiver<AudioBuffer>> {
-        // Get the stream first — if there's no stream, we're not running.
+        // Presence gate only (rsac-7aa2): Running and the drainable Stopping
+        // window are both accepted; a stream already at its fatal terminal
+        // yields an immediately-ending channel. See the rustdoc above.
         let stream_ref = self
             .stream
             .as_ref()
             .ok_or_else(|| AudioError::StreamReadError {
-                reason: "Stream is not initialized. Call start() first.".to_string(),
+                reason: "No active stream: the capture was never started, or has been \
+                         stopped (stop() releases the stream). Call start() to begin \
+                         (or restart) capturing."
+                    .to_string(),
             })?;
 
-        // Check running state via the stream itself — single source of truth.
-        if !stream_ref.is_running() {
-            return Err(AudioError::StreamReadError {
-                reason: "Stream is not running".to_string(),
-            });
-        }
-
-        let stream = Arc::clone(stream_ref);
-
-        let (tx, rx) = mpsc::channel();
-
-        std::thread::Builder::new()
-            .name("rsac-subscribe".into())
-            .spawn(move || loop {
-                match stream.try_read_chunk() {
-                    Ok(Some(buffer)) => {
-                        if tx.send(buffer).is_err() {
-                            break; // Receiver dropped
-                        }
-                    }
-                    Ok(None) => {
-                        // No data available, sleep briefly to avoid busy-spinning
-                        std::thread::sleep(std::time::Duration::from_millis(1));
-                    }
-                    // Only a FATAL terminal (e.g. StreamEnded) ends the
-                    // subscription — the channel then disconnects, which the
-                    // receiver observes as a RecvError. A recoverable read error
-                    // (transient StreamReadError, BufferOverrun/Underrun) must
-                    // NOT kill delivery; log and retry after a brief pause,
-                    // mirroring the callback pump (spawn_callback_pump) and the
-                    // iterator. This closes the prior bug where ANY error broke
-                    // the loop and silently ended the subscription (FH-1/BP-6).
-                    Err(e) if e.is_fatal() => break,
-                    Err(e) => {
-                        log::warn!("Subscribe thread read error (retrying): {:?}", e);
-                        std::thread::sleep(std::time::Duration::from_millis(1));
-                    }
-                }
-            })
-            .map_err(|e| AudioError::InternalError {
-                message: format!("Failed to spawn subscribe thread: {}", e),
-                source: None,
-            })?;
-
-        Ok(rx)
+        spawn_subscribe_thread(Arc::clone(stream_ref), Arc::clone(&self.subscriber_dropped))
     }
 
     /// Like [`subscribe`](Self::subscribe), but delivers each item as an
@@ -1793,11 +2176,34 @@ impl AudioCapture {
     /// [`read_buffer`](Self::read_buffer) and the callback pump for buffers from
     /// the same ring — do not mix it with manual reads.
     ///
+    /// # Bounded channel, drops, and coalescing (rsac-d6a8)
+    ///
+    /// The channel is **bounded** (128 buffers, like [`subscribe`](Self::subscribe)):
+    /// a stalled receiver causes further buffers to be dropped and counted in
+    /// [`subscriber_dropped_count`](Self::subscriber_dropped_count). Repeated
+    /// **recoverable** errors of the same variant are *coalesced* — forwarded
+    /// at most once per second (a persistently-recoverable stream errors once
+    /// per ~1 ms poll and would otherwise flood the channel with identical
+    /// advisory items); an error of a different variant is always forwarded
+    /// immediately. The **fatal terminal** is exempt from all of this: it is
+    /// sent with a *blocking* send as the guaranteed final item, so it is never
+    /// lost even when the channel is full of unread buffers (the pump exits
+    /// right after; delivery fails only if the receiver is already gone).
+    ///
+    /// # Accepted stream states (rsac-7aa2)
+    ///
+    /// Same policy as [`subscribe`](Self::subscribe): accepted whenever a
+    /// stream exists (`Running` or the drainable `Stopping` window — the
+    /// buffered tail plus the terminal error are then delivered); a stream
+    /// already at its fatal terminal yields a channel whose only item is the
+    /// final `Err`. Only a capture with no stream is rejected.
+    ///
     /// # Errors
     ///
-    /// Returns an error if the capture is not currently running. (Once running,
-    /// the terminal stream error is delivered as the final channel *item*, not as
-    /// the return value of this method.)
+    /// Returns [`AudioError::StreamReadError`] if the capture has no stream
+    /// (never started, or stopped). Once a subscription exists, the terminal
+    /// stream error is delivered as the final channel *item*, not as the
+    /// return value of this method.
     ///
     /// # Backend caveat (FH-1)
     ///
@@ -1809,62 +2215,41 @@ impl AudioCapture {
     /// until the receiver is dropped — the recoverable-vs-fatal branching here is
     /// correct regardless.
     pub fn subscribe_with_errors(&self) -> AudioResult<mpsc::Receiver<AudioResult<AudioBuffer>>> {
-        // Get the stream first — if there's no stream, we're not running.
+        // Presence gate only (rsac-7aa2) — see subscribe() for the rationale.
         let stream_ref = self
             .stream
             .as_ref()
             .ok_or_else(|| AudioError::StreamReadError {
-                reason: "Stream is not initialized. Call start() first.".to_string(),
+                reason: "No active stream: the capture was never started, or has been \
+                         stopped (stop() releases the stream). Call start() to begin \
+                         (or restart) capturing."
+                    .to_string(),
             })?;
 
-        // Check running state via the stream itself — single source of truth.
-        if !stream_ref.is_running() {
-            return Err(AudioError::StreamReadError {
-                reason: "Stream is not running".to_string(),
-            });
-        }
+        spawn_subscribe_with_errors_thread(
+            Arc::clone(stream_ref),
+            Arc::clone(&self.subscriber_dropped),
+        )
+    }
 
-        let stream = Arc::clone(stream_ref);
-
-        let (tx, rx) = mpsc::channel();
-
-        std::thread::Builder::new()
-            .name("rsac-subscribe-err".into())
-            .spawn(move || loop {
-                match stream.try_read_chunk() {
-                    Ok(Some(buffer)) => {
-                        if tx.send(Ok(buffer)).is_err() {
-                            break; // Receiver dropped
-                        }
-                    }
-                    Ok(None) => {
-                        // No data available, sleep briefly to avoid busy-spinning
-                        std::thread::sleep(std::time::Duration::from_millis(1));
-                    }
-                    // Fatal terminal: forward the error as the FINAL item, THEN
-                    // exit. Send-then-break so the consumer always receives the
-                    // terminal AudioError before the channel disconnects (it never
-                    // has to race a bare RecvError to learn why the stream ended).
-                    Err(e) if e.is_fatal() => {
-                        let _ = tx.send(Err(e));
-                        break;
-                    }
-                    // Recoverable: surface it (best-effort) AND keep delivering —
-                    // a transient hiccup must not end the subscription.
-                    Err(e) => {
-                        if tx.send(Err(e)).is_err() {
-                            break; // Receiver dropped
-                        }
-                        std::thread::sleep(std::time::Duration::from_millis(1));
-                    }
-                }
-            })
-            .map_err(|e| AudioError::InternalError {
-                message: format!("Failed to spawn subscribe thread: {}", e),
-                source: None,
-            })?;
-
-        Ok(rx)
+    /// Returns the total number of buffers **dropped by subscribe pumps** on
+    /// this handle because a subscriber's bounded channel was full (rsac-d6a8).
+    ///
+    /// [`subscribe`](Self::subscribe) and
+    /// [`subscribe_with_errors`](Self::subscribe_with_errors) deliver over a
+    /// bounded channel (128 buffers) and, per the crate-wide backpressure
+    /// policy, **drop rather than block** when a subscriber stalls. Those
+    /// drops happen *downstream* of the capture ring, so they are invisible to
+    /// [`overrun_count`](Self::overrun_count) and
+    /// [`backpressure_report`](Self::backpressure_report) — this counter is
+    /// the subscriber-side complement. It aggregates across every subscription
+    /// created from this handle (mirroring how `overrun_count` aggregates the
+    /// ring) and is monotone for the handle's lifetime: unlike the per-stream
+    /// counters it survives [`stop`](Self::stop)/restart.
+    ///
+    /// `0` means no subscriber has ever fallen behind.
+    pub fn subscriber_dropped_count(&self) -> u64 {
+        self.subscriber_dropped.load(Ordering::Relaxed)
     }
 
     /// Returns the number of audio buffers dropped due to ring buffer overflow (overruns).
@@ -2668,6 +3053,24 @@ mod tests {
             callback: Mutex::new(None),
             callback_pump: None,
             start_instant: None,
+            subscriber_dropped: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Creates an AudioCapture with NO stream — the pre-start / post-stop
+    /// state — for gate and default-snapshot tests.
+    fn make_capture_without_stream() -> AudioCapture {
+        AudioCapture {
+            config: AudioCaptureConfig {
+                target: CaptureTarget::SystemDefault,
+                stream_config: StreamConfig::default(),
+            },
+            device: None,
+            stream: None,
+            callback: Mutex::new(None),
+            callback_pump: None,
+            start_instant: None,
+            subscriber_dropped: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -2720,21 +3123,87 @@ mod tests {
 
     // ── subscribe() tests ─────────────────────────────────────────────
 
+    /// rsac-7aa2(1): subscribe is gated on stream PRESENCE only. A stream that
+    /// already reached its fatal terminal (stopped, nothing buffered) is
+    /// accepted and yields a channel that ends immediately — racing a natural
+    /// end is indistinguishable from subscribing just before it, so an error
+    /// here would be arbitrary. A capture with NO stream at all still rejects,
+    /// with a message that is accurate for both never-started and post-stop.
     #[test]
-    fn subscribe_returns_error_when_not_running() {
+    fn subscribe_on_terminal_stream_yields_immediately_ending_channel() {
         let mock = Arc::new(MockCapturingStream::new());
-        // Signal the mock (stream-side) that it's no longer running — the
-        // stream's state is now the single source of truth.
-        mock.signal_stop();
+        mock.signal_stop(); // terminal, no buffered tail
         let capture = make_mock_capture(mock);
 
-        let result = capture.subscribe();
-        assert!(result.is_err());
-        match result.unwrap_err() {
-            AudioError::StreamReadError { reason } => {
-                assert!(reason.contains("not running"));
+        let rx = capture.subscribe().expect("terminal stream is accepted");
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_secs(2)).is_err(),
+            "channel must end immediately (no data, prompt disconnect)"
+        );
+
+        // No stream at all → rejected via the presence check.
+        let empty = make_capture_without_stream();
+        match empty.subscribe() {
+            Err(AudioError::StreamReadError { reason }) => {
+                assert!(
+                    reason.contains("start()"),
+                    "message must direct to start(): {reason}"
+                );
             }
-            e => panic!("Expected StreamReadError, got: {e:?}"),
+            other => panic!("expected StreamReadError, got: {other:?}"),
+        }
+    }
+
+    /// rsac-7aa2(1): the drainable Stopping window is accepted — a stream that
+    /// gracefully ended with a buffered tail can still be subscribed to, and
+    /// the tail is delivered before the channel ends. (The old `is_running()`
+    /// gate rejected this call and stranded the tail.)
+    #[test]
+    fn subscribe_accepts_stopping_window_and_drains_tail() {
+        let mock = Arc::new(MockCapturingStream::new());
+        for i in 0..3 {
+            mock.push_buffer(AudioBuffer::new(vec![i as f32 + 1.0; 4], 2, 48000));
+        }
+        // Not running, but the tail is still drainable — the mock models the
+        // bridge's Stopping window (drain first, terminal only when empty).
+        mock.signal_stop();
+        let capture = make_mock_capture(Arc::clone(&mock));
+        assert!(!capture.is_running());
+
+        let rx = capture
+            .subscribe()
+            .expect("the drainable Stopping window must be accepted");
+        let mut got = Vec::new();
+        while let Ok(buf) = rx.recv_timeout(std::time::Duration::from_secs(2)) {
+            got.push(buf.data()[0]);
+        }
+        assert_eq!(
+            got,
+            vec![1.0, 2.0, 3.0],
+            "the buffered tail is delivered, then the channel ends"
+        );
+    }
+
+    /// rsac-7aa2(3): the post-stop subscribe error is accurate — stop()
+    /// releases the stream, so subscribe() must not claim the stream "is not
+    /// initialized" (the old message) when it was in fact stopped.
+    #[test]
+    fn post_stop_subscribe_error_is_accurate() {
+        let mock = Arc::new(MockCapturingStream::new());
+        let mut capture = make_mock_capture(mock);
+        capture.stop().unwrap();
+        match capture.subscribe() {
+            Err(AudioError::StreamReadError { reason }) => {
+                assert!(
+                    reason.contains("stopped"),
+                    "post-stop message must mention the stopped state: {reason}"
+                );
+                assert!(
+                    !reason.contains("not initialized"),
+                    "the misleading pre-fix message must be gone: {reason}"
+                );
+            }
+            other => panic!("expected StreamReadError, got: {other:?}"),
         }
     }
 
@@ -2921,6 +3390,160 @@ mod tests {
         );
     }
 
+    // ── bounded subscribe channel tests (rsac-d6a8) ───────────────────
+
+    /// rsac-d6a8: a stalled receiver must NOT grow memory without bound. The
+    /// channel depth is capped at SUBSCRIBE_CHANNEL_CAPACITY, the overflow is
+    /// dropped, and every drop is counted in subscriber_dropped_count().
+    #[test]
+    fn subscribe_bounds_channel_and_counts_drops() {
+        const OVERFLOW: usize = 72;
+        let total = SUBSCRIBE_CHANNEL_CAPACITY + OVERFLOW;
+
+        let mock = Arc::new(MockCapturingStream::new());
+        for _ in 0..total {
+            mock.push_buffer(AudioBuffer::new(vec![0.5; 4], 2, 48000));
+        }
+        let capture = make_mock_capture(Arc::clone(&mock));
+        let rx = capture.subscribe().expect("subscribe should succeed");
+        // Stall the receiver: never recv while the pump floods the channel.
+
+        // The pump drains all `total` buffers from the mock; the first
+        // SUBSCRIBE_CHANNEL_CAPACITY fill the channel and the rest are dropped
+        // and counted. Poll (bounded) until the counter reaches the overflow.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while capture.subscriber_dropped_count() < OVERFLOW as u64
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        assert_eq!(
+            capture.subscriber_dropped_count(),
+            OVERFLOW as u64,
+            "every overflowed buffer is dropped and counted, exactly once"
+        );
+
+        // End the stream so the pump exits, then drain: the channel holds
+        // EXACTLY the cap — bounded depth, not the full flood.
+        mock.signal_stop();
+        let mut received = 0usize;
+        while rx.recv_timeout(std::time::Duration::from_secs(2)).is_ok() {
+            received += 1;
+        }
+        assert_eq!(
+            received, SUBSCRIBE_CHANNEL_CAPACITY,
+            "channel depth is capped at the documented bound"
+        );
+    }
+
+    /// rsac-d6a8: the fatal terminal is NEVER lost to a full channel. After
+    /// drops, subscribe_with_errors still delivers the terminal Err as the
+    /// final item (the pump uses a blocking send for that one item).
+    #[test]
+    fn subscribe_with_errors_terminal_survives_full_channel() {
+        const OVERFLOW: usize = 10;
+        let total = SUBSCRIBE_CHANNEL_CAPACITY + OVERFLOW;
+
+        let mock = Arc::new(MockCapturingStream::new());
+        for _ in 0..total {
+            mock.push_buffer(AudioBuffer::new(vec![0.25; 4], 2, 48000));
+        }
+        let capture = make_mock_capture(Arc::clone(&mock));
+        let rx = capture
+            .subscribe_with_errors()
+            .expect("subscribe_with_errors should succeed");
+
+        // Let the pump flood the (unread) channel and drop the overflow.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while capture.subscriber_dropped_count() < OVERFLOW as u64
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        assert_eq!(capture.subscriber_dropped_count(), OVERFLOW as u64);
+
+        // Now end the stream: the pump's terminal send blocks on the full
+        // channel until we drain — the terminal must arrive as the FINAL item.
+        mock.signal_stop();
+        let mut oks = 0usize;
+        let terminal = loop {
+            match rx.recv_timeout(std::time::Duration::from_secs(2)) {
+                Ok(Ok(_)) => oks += 1,
+                Ok(Err(e)) => break e,
+                Err(e) => panic!("channel ended before the terminal Err arrived: {e:?}"),
+            }
+        };
+        assert_eq!(
+            oks, SUBSCRIBE_CHANNEL_CAPACITY,
+            "all channel-buffered items are delivered before the terminal"
+        );
+        assert!(
+            terminal.is_fatal() && matches!(terminal, AudioError::StreamEnded { .. }),
+            "the final item is the fatal terminal, got: {terminal:?}"
+        );
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_secs(1)).is_err(),
+            "channel disconnects after the terminal item"
+        );
+    }
+
+    /// rsac-d6a8: repeated recoverable errors of the same variant are
+    /// coalesced (≈1/s), not forwarded once per ~1 ms poll — a persistently-
+    /// recoverable stream must not flood the channel with identical advisory
+    /// items. The audio behind the error burst is still delivered.
+    #[test]
+    fn subscribe_with_errors_coalesces_repeated_recoverable_errors() {
+        const BURST: usize = 50;
+        let mock = Arc::new(MockCapturingStream::new());
+        for _ in 0..BURST {
+            mock.inject_recoverable_error(AudioError::StreamReadError {
+                reason: "persistent transient".into(),
+            });
+        }
+        mock.push_buffer(AudioBuffer::new(vec![0.7; 4], 2, 48000));
+
+        let capture = make_mock_capture(Arc::clone(&mock));
+        let rx = capture
+            .subscribe_with_errors()
+            .expect("subscribe_with_errors should succeed");
+
+        // Collect items until the buffer behind the burst arrives.
+        let mut err_items = 0usize;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the buffer behind the error burst never arrived"
+            );
+            match rx.recv_timeout(std::time::Duration::from_secs(2)) {
+                Ok(Err(e)) => {
+                    assert!(e.is_recoverable(), "burst items are recoverable");
+                    err_items += 1;
+                }
+                Ok(Ok(buf)) => {
+                    assert_eq!(buf.data()[0], 0.7);
+                    break;
+                }
+                Err(e) => panic!("channel ended prematurely: {e:?}"),
+            }
+        }
+        // 50 identical errors ~1 ms apart span well under the 1 s coalescing
+        // interval, so ~1 forwarded item is expected. Allow a little slack for
+        // pathological CI scheduling (a >1 s stall between two polls legally
+        // forwards again) — the point is "far fewer than the burst".
+        assert!(
+            (1..=3).contains(&err_items),
+            "repeated same-variant recoverable errors must be coalesced \
+             (expected 1..=3 forwarded, got {err_items} of {BURST})"
+        );
+        assert_eq!(
+            capture.subscriber_dropped_count(),
+            0,
+            "advisory error items are never counted as dropped buffers"
+        );
+        mock.signal_stop();
+    }
+
     // ── read_chunk_nonblocking() tests (terminal-observable read) ─────
 
     /// read_chunk_nonblocking() yields Ok(Some(buf)) when data is available and
@@ -2992,21 +3615,131 @@ mod tests {
         );
     }
 
+    // ── terminal-read propagation: read_buffer* (simple pull) vs
+    //    read_chunk_* (terminal-observable) — the documented divergence ─────
+
+    /// The load-bearing contract: on a stopped stream, `read_chunk_nonblocking`
+    /// surfaces the FATAL `StreamEnded` while `read_buffer` DOWNGRADES to a
+    /// RECOVERABLE `StreamReadError`. A read loop that ends on `is_fatal()` must
+    /// therefore terminate on `read_chunk_nonblocking` but would spin forever on
+    /// `read_buffer`. This pins the exact behavior their rustdoc promises so it
+    /// cannot silently drift.
+    #[test]
+    fn read_buffer_downgrades_terminal_but_read_chunk_nonblocking_preserves_it() {
+        // read_chunk_nonblocking → fatal StreamEnded on a stopped, empty stream.
+        let mock = Arc::new(MockCapturingStream::new());
+        mock.signal_stop();
+        let capture = make_mock_capture(Arc::clone(&mock));
+        match capture.read_chunk_nonblocking() {
+            Err(e) => {
+                assert!(
+                    e.is_fatal(),
+                    "read_chunk_nonblocking terminal must be fatal"
+                );
+                assert!(matches!(e, AudioError::StreamEnded { .. }));
+            }
+            other => panic!("expected fatal StreamEnded, got: {other:?}"),
+        }
+
+        // read_buffer → recoverable StreamReadError on the same stopped stream
+        // (never StreamEnded), because it short-circuits on !is_running().
+        let mock2 = Arc::new(MockCapturingStream::new());
+        mock2.signal_stop();
+        let capture2 = make_mock_capture(Arc::clone(&mock2));
+        match capture2.read_buffer() {
+            Err(e) => {
+                assert!(
+                    e.is_recoverable(),
+                    "read_buffer downgrades terminal to a recoverable error"
+                );
+                assert!(
+                    matches!(e, AudioError::StreamReadError { .. }),
+                    "read_buffer must report StreamReadError, not StreamEnded"
+                );
+                assert!(
+                    !matches!(e, AudioError::StreamEnded { .. }),
+                    "read_buffer must NEVER surface the fatal terminal"
+                );
+            }
+            other => panic!("expected recoverable StreamReadError, got: {other:?}"),
+        }
+    }
+
+    /// The blocking pair mirrors the non-blocking pair: `read_chunk_blocking`
+    /// surfaces the FATAL `StreamEnded` on a stopped stream, while
+    /// `read_buffer_blocking` short-circuits to a RECOVERABLE `StreamReadError`.
+    #[test]
+    fn read_buffer_blocking_downgrades_terminal_but_read_chunk_blocking_preserves_it() {
+        // read_chunk_blocking → fatal StreamEnded (delegates to read_chunk,
+        // whose MockCapturingStream loop returns StreamEnded once stopped+empty).
+        let mock = Arc::new(MockCapturingStream::new());
+        mock.signal_stop();
+        let capture = make_mock_capture(Arc::clone(&mock));
+        match capture.read_chunk_blocking() {
+            Err(e) => {
+                assert!(e.is_fatal(), "read_chunk_blocking terminal must be fatal");
+                assert!(matches!(e, AudioError::StreamEnded { .. }));
+            }
+            other => panic!("expected fatal StreamEnded, got: {other:?}"),
+        }
+
+        // read_buffer_blocking → recoverable StreamReadError (is_running guard).
+        let mock2 = Arc::new(MockCapturingStream::new());
+        mock2.signal_stop();
+        let capture2 = make_mock_capture(Arc::clone(&mock2));
+        match capture2.read_buffer_blocking() {
+            Err(e) => {
+                assert!(
+                    e.is_recoverable(),
+                    "read_buffer_blocking downgrades terminal to recoverable"
+                );
+                assert!(matches!(e, AudioError::StreamReadError { .. }));
+            }
+            other => panic!("expected recoverable StreamReadError, got: {other:?}"),
+        }
+    }
+
+    /// Both terminal-observable read paths (`read_chunk_nonblocking` and
+    /// `read_chunk_blocking`) must NOT end on a *recoverable* read error: a
+    /// transient `StreamReadError` injected ahead of data is surfaced as-is (and
+    /// is `is_recoverable()`), and the buffer behind it is still delivered on the
+    /// retry — so a correct consumer loop that retries recoverable errors keeps
+    /// going and only stops on `is_fatal()`. This guards the recoverable-vs-fatal
+    /// split end-to-end through the AudioCapture read surface.
+    #[test]
+    fn read_chunk_paths_treat_recoverable_error_as_retryable_not_terminal() {
+        let mock = Arc::new(MockCapturingStream::new());
+        // One transient hiccup, then a real buffer behind it.
+        mock.inject_recoverable_error(AudioError::StreamReadError {
+            reason: "transient hiccup".into(),
+        });
+        mock.push_buffer(AudioBuffer::new(vec![0.9; 4], 2, 48000));
+        let capture = make_mock_capture(Arc::clone(&mock));
+
+        // First read observes the recoverable error (NOT fatal, NOT terminal).
+        match capture.read_chunk_nonblocking() {
+            Err(e) => {
+                assert!(e.is_recoverable(), "injected error must be recoverable");
+                assert!(!e.is_fatal());
+                assert!(!matches!(e, AudioError::StreamEnded { .. }));
+            }
+            other => panic!("expected a recoverable error first, got: {other:?}"),
+        }
+        // Retry delivers the buffer that was queued behind the hiccup.
+        let buf = capture
+            .read_chunk_nonblocking()
+            .expect("read ok on retry")
+            .expect("buffer behind the recoverable error is delivered");
+        assert_eq!(buf.data()[0], 0.9);
+
+        mock.signal_stop();
+    }
+
     // ── overrun_count() tests ─────────────────────────────────────────
 
     #[test]
     fn overrun_count_returns_zero_when_no_stream() {
-        let capture = AudioCapture {
-            config: AudioCaptureConfig {
-                target: CaptureTarget::SystemDefault,
-                stream_config: StreamConfig::default(),
-            },
-            device: None,
-            stream: None,
-            callback: Mutex::new(None),
-            callback_pump: None,
-            start_instant: None,
-        };
+        let capture = make_capture_without_stream();
         assert_eq!(capture.overrun_count(), 0);
     }
 
@@ -3200,6 +3933,75 @@ mod tests {
         );
     }
 
+    /// rsac-7aa2(3): restart-by-recreation is the blessed lifecycle — stop()
+    /// releases the stream and a later start() creates a FRESH stream from the
+    /// same resolved device; reads work again and the uptime anchor re-anchors.
+    #[test]
+    fn stop_then_start_restarts_by_recreation() {
+        /// A device whose create_stream() hands out a fresh running mock with
+        /// one buffered chunk, so the restarted capture demonstrably serves
+        /// data end-to-end.
+        struct RestartDevice;
+        impl crate::core::interface::AudioDevice for RestartDevice {
+            fn id(&self) -> crate::core::config::DeviceId {
+                crate::core::config::DeviceId("restart-mock".to_string())
+            }
+            fn name(&self) -> String {
+                "RestartMockDevice".to_string()
+            }
+            fn is_default(&self) -> bool {
+                true
+            }
+            fn supported_formats(&self) -> Vec<AudioFormat> {
+                vec![]
+            }
+            fn create_stream(
+                &self,
+                _config: &StreamConfig,
+            ) -> AudioResult<Box<dyn CapturingStream>> {
+                let mock = MockCapturingStream::new();
+                mock.push_buffer(AudioBuffer::new(vec![0.6; 4], 2, 48000));
+                Ok(Box::new(mock))
+            }
+        }
+
+        let first = Arc::new(MockCapturingStream::new());
+        let mut capture = AudioCapture {
+            config: AudioCaptureConfig {
+                target: CaptureTarget::SystemDefault,
+                stream_config: StreamConfig::default(),
+            },
+            device: Some(Box::new(RestartDevice)),
+            stream: Some(first),
+            callback: Mutex::new(None),
+            callback_pump: None,
+            start_instant: Some(Instant::now()),
+            subscriber_dropped: Arc::new(AtomicU64::new(0)),
+        };
+        assert!(capture.is_running());
+
+        capture.stop().expect("stop ok");
+        assert!(!capture.is_running());
+        assert!(capture.uptime().is_none(), "stop clears the uptime anchor");
+
+        // Restart: start() re-creates a stream from the resolved device.
+        capture.start().expect("restart-by-recreation must succeed");
+        assert!(capture.is_running(), "fresh stream is running");
+        assert!(
+            capture.uptime().is_some(),
+            "the uptime anchor re-anchors on restart"
+        );
+
+        // The recreated stream serves data end-to-end.
+        let buf = capture
+            .read_chunk_nonblocking()
+            .expect("read ok")
+            .expect("data from the recreated stream");
+        assert_eq!(buf.data()[0], 0.6);
+
+        capture.stop().expect("second stop ok");
+    }
+
     /// The pump thread exits when the stream stops (try_read_chunk → Err), and
     /// shutdown() is safe to call afterwards (idempotent join).
     #[test]
@@ -3257,17 +4059,7 @@ mod tests {
     /// Before any start(), there is no stream and therefore no uptime.
     #[test]
     fn uptime_is_none_before_start() {
-        let capture = AudioCapture {
-            config: AudioCaptureConfig {
-                target: CaptureTarget::SystemDefault,
-                stream_config: StreamConfig::default(),
-            },
-            device: None,
-            stream: None,
-            callback: Mutex::new(None),
-            callback_pump: None,
-            start_instant: None,
-        };
+        let capture = make_capture_without_stream();
         assert!(capture.uptime().is_none());
     }
 
@@ -3336,17 +4128,7 @@ mod tests {
     /// Before start() there is no stream, so format() reports None.
     #[test]
     fn format_is_none_before_start() {
-        let capture = AudioCapture {
-            config: AudioCaptureConfig {
-                target: CaptureTarget::SystemDefault,
-                stream_config: StreamConfig::default(),
-            },
-            device: None,
-            stream: None,
-            callback: Mutex::new(None),
-            callback_pump: None,
-            start_instant: None,
-        };
+        let capture = make_capture_without_stream();
         assert!(capture.format().is_none());
     }
 
@@ -3434,17 +4216,7 @@ mod tests {
     /// does not panic.
     #[test]
     fn stream_stats_default_when_no_stream() {
-        let capture = AudioCapture {
-            config: AudioCaptureConfig {
-                target: CaptureTarget::SystemDefault,
-                stream_config: StreamConfig::default(),
-            },
-            device: None,
-            stream: None,
-            callback: Mutex::new(None),
-            callback_pump: None,
-            start_instant: None,
-        };
+        let capture = make_capture_without_stream();
         let s = capture.stream_stats();
         assert!(!s.is_running);
         assert_eq!(s.uptime, Duration::ZERO);
@@ -3515,17 +4287,7 @@ mod tests {
     /// backpressure_report() on a capture with no stream is the all-zero default.
     #[test]
     fn backpressure_report_default_when_no_stream() {
-        let capture = AudioCapture {
-            config: AudioCaptureConfig {
-                target: CaptureTarget::SystemDefault,
-                stream_config: StreamConfig::default(),
-            },
-            device: None,
-            stream: None,
-            callback: Mutex::new(None),
-            callback_pump: None,
-            start_instant: None,
-        };
+        let capture = make_capture_without_stream();
         let r = capture.backpressure_report();
         assert_eq!(r.pushed, 0);
         assert_eq!(r.dropped, 0);
@@ -4044,17 +4806,7 @@ mod tests {
     /// request_stop() on a capture with no stream is a no-op (does not panic).
     #[test]
     fn request_stop_no_stream_is_noop() {
-        let capture = AudioCapture {
-            config: AudioCaptureConfig {
-                target: CaptureTarget::SystemDefault,
-                stream_config: StreamConfig::default(),
-            },
-            device: None,
-            stream: None,
-            callback: Mutex::new(None),
-            callback_pump: None,
-            start_instant: None,
-        };
+        let capture = make_capture_without_stream();
         // Must not panic when there is no stream to signal.
         capture.request_stop();
     }
@@ -4223,29 +4975,70 @@ mod tests {
         );
     }
 
-    /// drain_to() returns an error when the underlying stream is not running
-    /// (mirrors subscribe()'s precondition).
+    /// rsac-7aa2(2): drain_to on a stream already at its fatal terminal is
+    /// ACCEPTED (presence-only gate, drain-the-tail policy): the drain thread
+    /// exits on its first read, writes nothing, and still finalizes the sink
+    /// (flush + close) so e.g. a WAV header is written for an empty capture.
     #[test]
-    fn drain_to_errors_when_not_running() {
+    fn drain_to_on_terminal_stream_finalizes_immediately() {
         let mock = Arc::new(MockCapturingStream::new());
-        mock.signal_stop();
+        mock.signal_stop(); // already terminal, no tail
         let capture = RunningCapture(make_mock_capture(mock));
 
         let (writes, frames, flushes, closes) = CountingSink::shared();
         let sink = CountingSink {
-            writes,
+            writes: Arc::clone(&writes),
             frames,
-            flushes,
-            closes,
+            flushes: Arc::clone(&flushes),
+            closes: Arc::clone(&closes),
             fail_first_write_fatal: false,
             first_write_seen: false,
         };
-        let result = capture.drain_to(sink);
-        assert!(result.is_err());
-        match result.unwrap_err() {
-            AudioError::StreamReadError { reason } => assert!(reason.contains("not running")),
-            e => panic!("expected StreamReadError, got: {e:?}"),
+        let drain = capture
+            .drain_to(sink)
+            .expect("a terminal stream is accepted (drain-the-tail policy)");
+        drain.shutdown(); // joins → the finalize has completed
+
+        assert_eq!(writes.load(Ordering::SeqCst), 0, "nothing to drain");
+        assert_eq!(flushes.load(Ordering::SeqCst), 1, "sink still flushed");
+        assert_eq!(closes.load(Ordering::SeqCst), 1, "sink still closed");
+    }
+
+    /// rsac-7aa2(2): drain_to accepts the drainable Stopping window and drains
+    /// the buffered tail into the sink before finalizing — the old is_running()
+    /// gate rejected this call and stranded the tail.
+    #[test]
+    fn drain_to_accepts_stopping_window_and_drains_tail() {
+        let mock = Arc::new(MockCapturingStream::new());
+        mock.push_buffer(AudioBuffer::new(vec![0.1; 4], 2, 48000));
+        mock.push_buffer(AudioBuffer::new(vec![0.2; 4], 2, 48000));
+        mock.signal_stop(); // not running, tail still drainable
+        let capture = RunningCapture(make_mock_capture(Arc::clone(&mock)));
+
+        let (writes, frames, flushes, closes) = CountingSink::shared();
+        let sink = CountingSink {
+            writes: Arc::clone(&writes),
+            frames: Arc::clone(&frames),
+            flushes: Arc::clone(&flushes),
+            closes: Arc::clone(&closes),
+            fail_first_write_fatal: false,
+            first_write_seen: false,
+        };
+        let drain = capture
+            .drain_to(sink)
+            .expect("the Stopping window must be accepted");
+
+        // Poll until the tail is drained (bounded), then join.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while writes.load(Ordering::SeqCst) < 2 && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(1));
         }
+        drain.shutdown();
+
+        assert_eq!(writes.load(Ordering::SeqCst), 2, "the tail is drained");
+        assert_eq!(frames.load(Ordering::SeqCst), 4, "2 frames per buffer × 2");
+        assert_eq!(flushes.load(Ordering::SeqCst), 1);
+        assert_eq!(closes.load(Ordering::SeqCst), 1);
     }
 
     /// A FATAL write() error ends the drain loop early, but flush() and close()

--- a/src/audio/android/aaudio.rs
+++ b/src/audio/android/aaudio.rs
@@ -1,0 +1,469 @@
+//! Minimal in-tree FFI bindings for the stable **AAudio** NDK ABI (mic
+//! slice, rsac-20cd).
+//!
+//! AAudio is Android's native (C) audio API, available since API 26 and part
+//! of the NDK's stable ABI (`libaaudio.so`). rsac binds it directly instead
+//! of pulling a binding crate: the mic slice needs a handful of functions,
+//! and an in-tree `extern "C"` block keeps the dependency tree unchanged
+//! (see `Cargo.toml` — the Android backend deliberately adds **no** crate
+//! dependencies).
+//!
+//! # Scope
+//!
+//! Only the declarations the mic slice actually uses are bound — builder
+//! creation/configuration, open/start/stop/close, the delivered-format
+//! getters, and the state-wait pair the teardown path uses to quiesce the
+//! callback before reclaiming its context. Every type, constant, and
+//! function is documented against its exact `aaudio/AAudio.h` name and value
+//! so the block can be audited against the NDK header 1:1.
+//!
+//! # Verification status
+//!
+//! These declarations are checked against the NDK r27 `aaudio/AAudio.h`
+//! header *by eye* and compile-checked for `aarch64-linux-android`; they are
+//! **not yet exercised on a device or emulator** (no NDK link step runs in
+//! this repo's Windows-host check). Values are pinned by unit tests below so
+//! an accidental edit cannot silently drift.
+
+#![cfg(all(target_os = "android", feature = "feat_android"))]
+// NDK-name fidelity: the types, constants, and functions below keep their
+// exact `aaudio/AAudio.h` spellings so every declaration can be diffed
+// against the header. The C naming conventions (`aaudio_result_t`,
+// `AAudioStream_dataCallback`) trip Rust's type-case lint, so it is allowed
+// for this FFI module only.
+#![allow(non_camel_case_types)]
+
+use std::ffi::c_void;
+
+use crate::core::error::{AudioError, BackendContext};
+
+// ── Opaque handle types ──────────────────────────────────────────────────
+
+/// Opaque AAudio stream handle — `AAudioStream` in `aaudio/AAudio.h`.
+///
+/// Zero-sized, non-constructible opaque-FFI pattern (the form recommended by
+/// the Rustonomicon): rsac only ever holds `*mut AAudioStream` values
+/// returned by [`AAudioStreamBuilder_openStream`] and passes them back to
+/// the `AAudioStream_*` functions.
+#[repr(C)]
+pub struct AAudioStream {
+    _private: [u8; 0],
+}
+
+/// Opaque AAudio stream-builder handle — `AAudioStreamBuilder` in
+/// `aaudio/AAudio.h`.
+///
+/// Created by [`AAudio_createStreamBuilder`], consumed by
+/// [`AAudioStreamBuilder_openStream`], and released with
+/// [`AAudioStreamBuilder_delete`].
+#[repr(C)]
+pub struct AAudioStreamBuilder {
+    _private: [u8; 0],
+}
+
+// ── Scalar typedefs (all `int32_t` in the header) ────────────────────────
+
+/// `aaudio_result_t` — the AAudio result/error code type (`int32_t`).
+/// [`AAUDIO_OK`] (0) is success; errors are negative (see the
+/// `AAUDIO_ERROR_*` constants).
+pub type aaudio_result_t = i32;
+
+/// `aaudio_direction_t` — stream direction (`int32_t`).
+/// See [`AAUDIO_DIRECTION_INPUT`].
+pub type aaudio_direction_t = i32;
+
+/// `aaudio_format_t` — sample data format (`int32_t`).
+/// See [`AAUDIO_FORMAT_PCM_I16`] / [`AAUDIO_FORMAT_PCM_FLOAT`].
+pub type aaudio_format_t = i32;
+
+/// `aaudio_performance_mode_t` — performance-mode hint (`int32_t`).
+/// See [`AAUDIO_PERFORMANCE_MODE_LOW_LATENCY`].
+pub type aaudio_performance_mode_t = i32;
+
+/// `aaudio_data_callback_result_t` — value a data callback returns to keep
+/// or stop the callback stream (`int32_t`). See
+/// [`AAUDIO_CALLBACK_RESULT_CONTINUE`] / [`AAUDIO_CALLBACK_RESULT_STOP`].
+pub type aaudio_data_callback_result_t = i32;
+
+/// `aaudio_stream_state_t` — stream lifecycle state (`int32_t`).
+/// Only the states the teardown quiesce-loop inspects are declared (see
+/// [`AAUDIO_STREAM_STATE_STOPPING`] and siblings).
+pub type aaudio_stream_state_t = i32;
+
+// ── Constants (each documented against its NDK header name) ─────────────
+
+/// `AAUDIO_OK` = 0 — the success value of [`aaudio_result_t`].
+pub const AAUDIO_OK: aaudio_result_t = 0;
+
+/// `AAUDIO_UNSPECIFIED` = 0 — "let AAudio choose" sentinel accepted by the
+/// builder's sample-rate / channel-count setters (and, as
+/// [`AAUDIO_FORMAT_UNSPECIFIED`], the format setter).
+pub const AAUDIO_UNSPECIFIED: i32 = 0;
+
+// aaudio_result_t error values. The header anchors the block at
+// `AAUDIO_ERROR_BASE` (-900) and counts up, skipping reserved slots; the
+// effective values below match NDK r27's `aaudio/AAudio.h`.
+
+/// `AAUDIO_ERROR_DISCONNECTED` = -899 — the stream's device is gone
+/// (unplugged headset, route change without automatic recovery). This is the
+/// code the error callback most commonly delivers.
+pub const AAUDIO_ERROR_DISCONNECTED: aaudio_result_t = -899;
+/// `AAUDIO_ERROR_ILLEGAL_ARGUMENT` = -898.
+pub const AAUDIO_ERROR_ILLEGAL_ARGUMENT: aaudio_result_t = -898;
+/// `AAUDIO_ERROR_INTERNAL` = -896.
+pub const AAUDIO_ERROR_INTERNAL: aaudio_result_t = -896;
+/// `AAUDIO_ERROR_INVALID_STATE` = -895.
+pub const AAUDIO_ERROR_INVALID_STATE: aaudio_result_t = -895;
+/// `AAUDIO_ERROR_INVALID_HANDLE` = -892.
+pub const AAUDIO_ERROR_INVALID_HANDLE: aaudio_result_t = -892;
+/// `AAUDIO_ERROR_UNIMPLEMENTED` = -890.
+pub const AAUDIO_ERROR_UNIMPLEMENTED: aaudio_result_t = -890;
+/// `AAUDIO_ERROR_UNAVAILABLE` = -889.
+pub const AAUDIO_ERROR_UNAVAILABLE: aaudio_result_t = -889;
+/// `AAUDIO_ERROR_NO_FREE_HANDLES` = -888.
+pub const AAUDIO_ERROR_NO_FREE_HANDLES: aaudio_result_t = -888;
+/// `AAUDIO_ERROR_NO_MEMORY` = -887.
+pub const AAUDIO_ERROR_NO_MEMORY: aaudio_result_t = -887;
+/// `AAUDIO_ERROR_NULL` = -886.
+pub const AAUDIO_ERROR_NULL: aaudio_result_t = -886;
+/// `AAUDIO_ERROR_TIMEOUT` = -885.
+pub const AAUDIO_ERROR_TIMEOUT: aaudio_result_t = -885;
+/// `AAUDIO_ERROR_WOULD_BLOCK` = -884.
+pub const AAUDIO_ERROR_WOULD_BLOCK: aaudio_result_t = -884;
+/// `AAUDIO_ERROR_INVALID_FORMAT` = -883.
+pub const AAUDIO_ERROR_INVALID_FORMAT: aaudio_result_t = -883;
+/// `AAUDIO_ERROR_OUT_OF_RANGE` = -882.
+pub const AAUDIO_ERROR_OUT_OF_RANGE: aaudio_result_t = -882;
+/// `AAUDIO_ERROR_NO_SERVICE` = -881 — the AAudio service is not running.
+pub const AAUDIO_ERROR_NO_SERVICE: aaudio_result_t = -881;
+/// `AAUDIO_ERROR_INVALID_RATE` = -880 — the requested sample rate is not
+/// supported (relevant to the open-with-requested-rate first attempt).
+pub const AAUDIO_ERROR_INVALID_RATE: aaudio_result_t = -880;
+
+/// `AAUDIO_DIRECTION_INPUT` = 1 — capture (recording) stream
+/// (`AAUDIO_DIRECTION_OUTPUT` = 0 is playback; not declared — unused).
+pub const AAUDIO_DIRECTION_INPUT: aaudio_direction_t = 1;
+
+/// `AAUDIO_FORMAT_UNSPECIFIED` = 0 — let AAudio pick the device-native
+/// sample format (used by the second open attempt).
+pub const AAUDIO_FORMAT_UNSPECIFIED: aaudio_format_t = 0;
+/// `AAUDIO_FORMAT_PCM_I16` = 1 — interleaved signed 16-bit PCM.
+pub const AAUDIO_FORMAT_PCM_I16: aaudio_format_t = 1;
+/// `AAUDIO_FORMAT_PCM_FLOAT` = 2 — interleaved 32-bit float PCM (rsac's
+/// preferred delivery; requested on the first open attempt).
+pub const AAUDIO_FORMAT_PCM_FLOAT: aaudio_format_t = 2;
+
+/// `AAUDIO_PERFORMANCE_MODE_LOW_LATENCY` = 12 — request the low-latency
+/// (potentially real-time-thread) data path. This is why the data callback
+/// obeys the full ADR-0001 rules: with this mode AAudio may invoke it on a
+/// real-time thread.
+pub const AAUDIO_PERFORMANCE_MODE_LOW_LATENCY: aaudio_performance_mode_t = 12;
+
+/// `AAUDIO_CALLBACK_RESULT_CONTINUE` = 0 — keep delivering data callbacks.
+pub const AAUDIO_CALLBACK_RESULT_CONTINUE: aaudio_data_callback_result_t = 0;
+/// `AAUDIO_CALLBACK_RESULT_STOP` = 1 — stop delivering data callbacks (the
+/// data callback returns this once the bridge has reached a terminal state).
+pub const AAUDIO_CALLBACK_RESULT_STOP: aaudio_data_callback_result_t = 1;
+
+// aaudio_stream_state_t values (header enum, counting from
+// AAUDIO_STREAM_STATE_UNINITIALIZED = 0). Only the three *transitional*
+// states the teardown quiesce-loop must wait out are declared.
+
+/// `AAUDIO_STREAM_STATE_STARTING` = 3 — start requested, not yet running.
+pub const AAUDIO_STREAM_STATE_STARTING: aaudio_stream_state_t = 3;
+/// `AAUDIO_STREAM_STATE_STARTED` = 4 — running; data callbacks are firing.
+pub const AAUDIO_STREAM_STATE_STARTED: aaudio_stream_state_t = 4;
+/// `AAUDIO_STREAM_STATE_STOPPING` = 9 — stop requested, callbacks may still
+/// be in flight until the state advances past this.
+pub const AAUDIO_STREAM_STATE_STOPPING: aaudio_stream_state_t = 9;
+
+// ── Callback typedefs ────────────────────────────────────────────────────
+
+/// `AAudioStream_dataCallback` — invoked by AAudio with each period of
+/// captured audio. With [`AAUDIO_PERFORMANCE_MODE_LOW_LATENCY`] this may run
+/// on a **real-time** thread: the callback must not allocate, lock, or
+/// panic (ADR-0001). `Option<..>` is the nullable-function-pointer FFI form;
+/// rsac always passes `Some`.
+///
+/// C signature:
+/// `aaudio_data_callback_result_t (*)(AAudioStream*, void* userData,
+/// void* audioData, int32_t numFrames)`.
+pub type AAudioStream_dataCallback = Option<
+    unsafe extern "C" fn(
+        stream: *mut AAudioStream,
+        user_data: *mut c_void,
+        audio_data: *mut c_void,
+        num_frames: i32,
+    ) -> aaudio_data_callback_result_t,
+>;
+
+/// `AAudioStream_errorCallback` — invoked by AAudio (on a dedicated
+/// non-real-time thread it creates) when the stream can no longer function,
+/// e.g. [`AAUDIO_ERROR_DISCONNECTED`]. The stream must not be closed from
+/// inside this callback.
+///
+/// C signature:
+/// `void (*)(AAudioStream*, void* userData, aaudio_result_t error)`.
+pub type AAudioStream_errorCallback = Option<
+    unsafe extern "C" fn(stream: *mut AAudioStream, user_data: *mut c_void, error: aaudio_result_t),
+>;
+
+// ── Foreign functions ────────────────────────────────────────────────────
+
+#[link(name = "aaudio")]
+#[allow(non_snake_case)]
+extern "C" {
+    /// `AAudio_createStreamBuilder(AAudioStreamBuilder** builder)` — allocate
+    /// a new stream builder. On [`AAUDIO_OK`] the out-pointer receives a
+    /// non-null builder that must be released with
+    /// [`AAudioStreamBuilder_delete`].
+    pub fn AAudio_createStreamBuilder(builder: *mut *mut AAudioStreamBuilder) -> aaudio_result_t;
+
+    /// `AAudioStreamBuilder_setDirection` — request capture
+    /// ([`AAUDIO_DIRECTION_INPUT`]) or playback.
+    pub fn AAudioStreamBuilder_setDirection(
+        builder: *mut AAudioStreamBuilder,
+        direction: aaudio_direction_t,
+    );
+
+    /// `AAudioStreamBuilder_setFormat` — request a sample format
+    /// ([`AAUDIO_FORMAT_PCM_FLOAT`] / [`AAUDIO_FORMAT_PCM_I16`] /
+    /// [`AAUDIO_FORMAT_UNSPECIFIED`]). The delivered format is read back
+    /// after open via [`AAudioStream_getFormat`].
+    pub fn AAudioStreamBuilder_setFormat(
+        builder: *mut AAudioStreamBuilder,
+        format: aaudio_format_t,
+    );
+
+    /// `AAudioStreamBuilder_setSampleRate` — request a sample rate in Hz, or
+    /// [`AAUDIO_UNSPECIFIED`] for the device-native rate.
+    pub fn AAudioStreamBuilder_setSampleRate(builder: *mut AAudioStreamBuilder, sample_rate: i32);
+
+    /// `AAudioStreamBuilder_setChannelCount` — request a channel count, or
+    /// [`AAUDIO_UNSPECIFIED`] for the device-native count.
+    pub fn AAudioStreamBuilder_setChannelCount(
+        builder: *mut AAudioStreamBuilder,
+        channel_count: i32,
+    );
+
+    /// `AAudioStreamBuilder_setPerformanceMode` — request
+    /// [`AAUDIO_PERFORMANCE_MODE_LOW_LATENCY`] (or another mode hint).
+    pub fn AAudioStreamBuilder_setPerformanceMode(
+        builder: *mut AAudioStreamBuilder,
+        mode: aaudio_performance_mode_t,
+    );
+
+    /// `AAudioStreamBuilder_setDataCallback` — register the per-period data
+    /// callback and its opaque `user_data` pointer (delivered back verbatim
+    /// on every invocation).
+    pub fn AAudioStreamBuilder_setDataCallback(
+        builder: *mut AAudioStreamBuilder,
+        callback: AAudioStream_dataCallback,
+        user_data: *mut c_void,
+    );
+
+    /// `AAudioStreamBuilder_setErrorCallback` — register the stream-error
+    /// callback and its (independent) opaque `user_data` pointer.
+    pub fn AAudioStreamBuilder_setErrorCallback(
+        builder: *mut AAudioStreamBuilder,
+        callback: AAudioStream_errorCallback,
+        user_data: *mut c_void,
+    );
+
+    /// `AAudioStreamBuilder_openStream(AAudioStreamBuilder*, AAudioStream**)`
+    /// — open a stream with the builder's current configuration. On
+    /// [`AAUDIO_OK`] the out-pointer receives a non-null stream. The builder
+    /// remains reusable (and must still be deleted).
+    pub fn AAudioStreamBuilder_openStream(
+        builder: *mut AAudioStreamBuilder,
+        stream: *mut *mut AAudioStream,
+    ) -> aaudio_result_t;
+
+    /// `AAudioStreamBuilder_delete` — release the builder. Safe to call once
+    /// the stream is open (or after a failed open).
+    pub fn AAudioStreamBuilder_delete(builder: *mut AAudioStreamBuilder) -> aaudio_result_t;
+
+    /// `AAudioStream_requestStart` — asynchronously start the stream; data
+    /// callbacks begin after this.
+    pub fn AAudioStream_requestStart(stream: *mut AAudioStream) -> aaudio_result_t;
+
+    /// `AAudioStream_requestStop` — asynchronously stop the stream (drains,
+    /// then ceases data callbacks).
+    pub fn AAudioStream_requestStop(stream: *mut AAudioStream) -> aaudio_result_t;
+
+    /// `AAudioStream_close` — stop (if needed) and delete the stream's
+    /// internal data structures. The stream pointer is invalid afterwards.
+    /// Must not be called from within one of the stream's own callbacks.
+    pub fn AAudioStream_close(stream: *mut AAudioStream) -> aaudio_result_t;
+
+    /// `AAudioStream_getFormat` — the **actual** sample format of the open
+    /// stream (may differ from the requested one).
+    pub fn AAudioStream_getFormat(stream: *mut AAudioStream) -> aaudio_format_t;
+
+    /// `AAudioStream_getSampleRate` — the **actual** sample rate in Hz of
+    /// the open stream.
+    pub fn AAudioStream_getSampleRate(stream: *mut AAudioStream) -> i32;
+
+    /// `AAudioStream_getChannelCount` — the **actual** channel count of the
+    /// open stream.
+    pub fn AAudioStream_getChannelCount(stream: *mut AAudioStream) -> i32;
+
+    /// `AAudioStream_getState` — the stream's current lifecycle state.
+    pub fn AAudioStream_getState(stream: *mut AAudioStream) -> aaudio_stream_state_t;
+
+    /// `AAudioStream_waitForStateChange(AAudioStream*, aaudio_stream_state_t
+    /// inputState, aaudio_stream_state_t* nextState, int64_t
+    /// timeoutNanoseconds)` — block (bounded by the timeout) until the state
+    /// differs from `input_state`, writing the new state to `next_state`.
+    /// Used by the teardown path to quiesce callbacks before the callback
+    /// context is reclaimed.
+    pub fn AAudioStream_waitForStateChange(
+        stream: *mut AAudioStream,
+        input_state: aaudio_stream_state_t,
+        next_state: *mut aaudio_stream_state_t,
+        timeout_nanoseconds: i64,
+    ) -> aaudio_result_t;
+}
+
+// ── Result helpers ───────────────────────────────────────────────────────
+
+/// Returns the `aaudio/AAudio.h` constant name for a known
+/// [`aaudio_result_t`], or a fixed placeholder for unknown codes.
+///
+/// Pure lookup — no allocation — so it is also safe to call when formatting
+/// diagnostics from the (non-real-time) error-callback thread.
+pub(crate) fn result_name(code: aaudio_result_t) -> &'static str {
+    match code {
+        AAUDIO_OK => "AAUDIO_OK",
+        AAUDIO_ERROR_DISCONNECTED => "AAUDIO_ERROR_DISCONNECTED",
+        AAUDIO_ERROR_ILLEGAL_ARGUMENT => "AAUDIO_ERROR_ILLEGAL_ARGUMENT",
+        AAUDIO_ERROR_INTERNAL => "AAUDIO_ERROR_INTERNAL",
+        AAUDIO_ERROR_INVALID_STATE => "AAUDIO_ERROR_INVALID_STATE",
+        AAUDIO_ERROR_INVALID_HANDLE => "AAUDIO_ERROR_INVALID_HANDLE",
+        AAUDIO_ERROR_UNIMPLEMENTED => "AAUDIO_ERROR_UNIMPLEMENTED",
+        AAUDIO_ERROR_UNAVAILABLE => "AAUDIO_ERROR_UNAVAILABLE",
+        AAUDIO_ERROR_NO_FREE_HANDLES => "AAUDIO_ERROR_NO_FREE_HANDLES",
+        AAUDIO_ERROR_NO_MEMORY => "AAUDIO_ERROR_NO_MEMORY",
+        AAUDIO_ERROR_NULL => "AAUDIO_ERROR_NULL",
+        AAUDIO_ERROR_TIMEOUT => "AAUDIO_ERROR_TIMEOUT",
+        AAUDIO_ERROR_WOULD_BLOCK => "AAUDIO_ERROR_WOULD_BLOCK",
+        AAUDIO_ERROR_INVALID_FORMAT => "AAUDIO_ERROR_INVALID_FORMAT",
+        AAUDIO_ERROR_OUT_OF_RANGE => "AAUDIO_ERROR_OUT_OF_RANGE",
+        AAUDIO_ERROR_NO_SERVICE => "AAUDIO_ERROR_NO_SERVICE",
+        AAUDIO_ERROR_INVALID_RATE => "AAUDIO_ERROR_INVALID_RATE",
+        _ => "unknown aaudio_result_t",
+    }
+}
+
+/// Maps a failed AAudio call to a categorized [`AudioError`].
+///
+/// `operation` is the NDK function that failed (e.g.
+/// `"AAudioStream_requestStart"`); `code` is the returned
+/// [`aaudio_result_t`]. Produces [`AudioError::BackendError`] (kind
+/// `Backend`, recoverability `TransientRetry` per the existing taxonomy)
+/// with a [`BackendContext`] carrying the raw code and its header name, so
+/// diagnostics survive across the API boundary.
+pub(crate) fn result_to_error(operation: &str, code: aaudio_result_t) -> AudioError {
+    AudioError::BackendError {
+        backend: "aaudio".to_string(),
+        operation: operation.to_string(),
+        message: format!("{} ({})", result_name(code), code),
+        context: Some(BackendContext {
+            backend_name: "AAudio".to_string(),
+            os_error_code: Some(i64::from(code)),
+            os_error_message: Some(result_name(code).to_string()),
+        }),
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// Tests — pure logic only (no FFI calls): constant values pinned against the
+// NDK header and the error-mapping helpers. They compile for the Android
+// target under `--tests` and will run on a future emulator job.
+// ══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins every declared constant to its `aaudio/AAudio.h` value so an
+    /// accidental edit cannot silently drift from the stable ABI.
+    #[test]
+    fn constants_match_ndk_header_values() {
+        assert_eq!(AAUDIO_OK, 0);
+        assert_eq!(AAUDIO_UNSPECIFIED, 0);
+
+        assert_eq!(AAUDIO_ERROR_DISCONNECTED, -899);
+        assert_eq!(AAUDIO_ERROR_ILLEGAL_ARGUMENT, -898);
+        assert_eq!(AAUDIO_ERROR_INTERNAL, -896);
+        assert_eq!(AAUDIO_ERROR_INVALID_STATE, -895);
+        assert_eq!(AAUDIO_ERROR_INVALID_HANDLE, -892);
+        assert_eq!(AAUDIO_ERROR_UNIMPLEMENTED, -890);
+        assert_eq!(AAUDIO_ERROR_UNAVAILABLE, -889);
+        assert_eq!(AAUDIO_ERROR_NO_FREE_HANDLES, -888);
+        assert_eq!(AAUDIO_ERROR_NO_MEMORY, -887);
+        assert_eq!(AAUDIO_ERROR_NULL, -886);
+        assert_eq!(AAUDIO_ERROR_TIMEOUT, -885);
+        assert_eq!(AAUDIO_ERROR_WOULD_BLOCK, -884);
+        assert_eq!(AAUDIO_ERROR_INVALID_FORMAT, -883);
+        assert_eq!(AAUDIO_ERROR_OUT_OF_RANGE, -882);
+        assert_eq!(AAUDIO_ERROR_NO_SERVICE, -881);
+        assert_eq!(AAUDIO_ERROR_INVALID_RATE, -880);
+
+        assert_eq!(AAUDIO_DIRECTION_INPUT, 1);
+
+        assert_eq!(AAUDIO_FORMAT_UNSPECIFIED, 0);
+        assert_eq!(AAUDIO_FORMAT_PCM_I16, 1);
+        assert_eq!(AAUDIO_FORMAT_PCM_FLOAT, 2);
+
+        assert_eq!(AAUDIO_PERFORMANCE_MODE_LOW_LATENCY, 12);
+
+        assert_eq!(AAUDIO_CALLBACK_RESULT_CONTINUE, 0);
+        assert_eq!(AAUDIO_CALLBACK_RESULT_STOP, 1);
+
+        assert_eq!(AAUDIO_STREAM_STATE_STARTING, 3);
+        assert_eq!(AAUDIO_STREAM_STATE_STARTED, 4);
+        assert_eq!(AAUDIO_STREAM_STATE_STOPPING, 9);
+    }
+
+    #[test]
+    fn result_name_maps_known_and_unknown_codes() {
+        assert_eq!(result_name(AAUDIO_OK), "AAUDIO_OK");
+        assert_eq!(
+            result_name(AAUDIO_ERROR_DISCONNECTED),
+            "AAUDIO_ERROR_DISCONNECTED"
+        );
+        assert_eq!(
+            result_name(AAUDIO_ERROR_NO_SERVICE),
+            "AAUDIO_ERROR_NO_SERVICE"
+        );
+        assert_eq!(result_name(12345), "unknown aaudio_result_t");
+        assert_eq!(result_name(-1), "unknown aaudio_result_t");
+    }
+
+    #[test]
+    fn result_to_error_carries_operation_code_and_context() {
+        let err = result_to_error("AAudioStream_requestStart", AAUDIO_ERROR_DISCONNECTED);
+        match err {
+            AudioError::BackendError {
+                backend,
+                operation,
+                message,
+                context,
+            } => {
+                assert_eq!(backend, "aaudio");
+                assert_eq!(operation, "AAudioStream_requestStart");
+                assert!(message.contains("AAUDIO_ERROR_DISCONNECTED"), "{message}");
+                assert!(message.contains("-899"), "{message}");
+                let ctx = context.expect("BackendContext must be populated");
+                assert_eq!(ctx.backend_name, "AAudio");
+                assert_eq!(ctx.os_error_code, Some(-899));
+                assert_eq!(
+                    ctx.os_error_message.as_deref(),
+                    Some("AAUDIO_ERROR_DISCONNECTED")
+                );
+            }
+            other => panic!("expected BackendError, got {other:?}"),
+        }
+    }
+}

--- a/src/audio/android/jni.rs
+++ b/src/audio/android/jni.rs
@@ -1,0 +1,1249 @@
+//! JNI layer for the Android playback-capture path (rsac-77f1).
+//!
+//! The playback-capture tiers (`SystemDefault`, `Application*`,
+//! `ProcessTree`) ride `AudioPlaybackCaptureConfiguration`, which can only
+//! be attached to a **Java** `AudioRecord` — so the capture loop lives in
+//! the rsac AAR (`mobile/android`, `CaptureBridge.kt`) and this module is
+//! the boundary between that Java loop and the Rust bridge:
+//!
+//! ```text
+//! Kotlin (AAR)                              Rust (this module)
+//! ────────────                              ──────────────────
+//! CaptureBridge.readLoop()
+//!   audioRecord.read(FloatArray)
+//!   nativePush(session, buf, …)   ────────► native_push():
+//!                                             GetFloatArrayRegion into the
+//!                                             session-lifetime scratch,
+//!                                             push_samples_guarded_stamped()
+//!   loop exits (error / stop)     ────────► native_session_ended():
+//!                                             spontaneous ⇒ terminal Error
+//!                                             (ADR-0010 / ADR-0003)
+//! RsacProjection consent flow     ────────► native_retain_projection():
+//!                                             NewGlobalRef ⇒ opaque token
+//! ```
+//!
+//! # Dependency decision: `jni-sys` (raw), not the `jni` crate, not in-tree
+//!
+//! This module calls ~15 JNI functions. The full `jni` crate would add
+//! cesu8/combine/thiserror for conveniences we don't need; hand-transcribing
+//! the 233-entry `JNIEnv` vtable in-tree (the `aaudio.rs` convention) is the
+//! one place where the in-tree-FFI convention *inverts* its own rationale —
+//! a single misplaced vtable field silently calls the wrong JVM function
+//! (UB with no compiler diagnostic). `jni-sys` is the canonical,
+//! declarations-only transcription (no transitive deps, no build.rs). See
+//! the manifest note next to the dependency.
+//!
+//! # Session registry (why tokens are ids, not pointers)
+//!
+//! `CaptureBridge.stop()` joins its read thread with a **bounded** timeout —
+//! it cannot *prove* no `nativePush` is still in flight when it returns. A
+//! raw `Box`-pointer session token (the aaudio callback-context pattern)
+//! would therefore be a use-after-free hazard on the reclaim path. Instead
+//! the session token is a **registry id**: `native_push` looks the id up in
+//! a process-global map and clones the `Arc<IngestSession>` — a late call
+//! after unregistration finds nothing (no-op), and an in-flight call keeps
+//! the session alive via its `Arc` until the push completes. Ids come from a
+//! monotonically increasing counter, so ABA reuse is impossible.
+//!
+//! The registry `Mutex` + per-session `Mutex` are acceptable here because
+//! the Java capture thread is **not** an OS real-time callback thread
+//! (`AudioRecord.read` is a buffered blocking read — the ADR-0001 adaptation
+//! recorded in `docs/MOBILE_BACKEND_DESIGN.md`). The no-alloc rule *does*
+//! bind: the copy target is the session-lifetime scratch buffer, sized once
+//! at registration and never grown in `native_push` (an oversized period is
+//! dropped + counted, exactly like the AAudio callback's discipline).
+//!
+//! # Class caching (why `FindClass` only happens in `JNI_OnLoad`)
+//!
+//! `FindClass` on a Rust-attached thread uses the *system* class loader,
+//! which cannot see the host app's (or the AAR's) classes — a classic JNI
+//! trap. `JNI_OnLoad` runs with the class loader that called
+//! `System.loadLibrary` (the app loader, via `RsacProjection`), so every
+//! class this module ever needs is resolved there and cached as a
+//! `GlobalRef`; method ids are cached alongside (valid for the class's
+//! lifetime per the JNI spec). If the AAR classes are absent — an NDK-only
+//! consumer that ships `librsac.so` without the Kotlin glue — the cache
+//! records that honestly and the playback factory fails with guidance,
+//! while the mic slice keeps working.
+//!
+//! # Lockstep contract (CI-guarded)
+//!
+//! The method names + signatures registered here must match the `external
+//! fun` declarations in `CaptureBridge.kt` / `RsacProjection.kt`. The
+//! host-run drift guard in `src/audio/mod.rs`
+//! (`jni_lockstep` tests) asserts both sides of the contract from the
+//! source text, so a rename on either side fails `cargo test --lib` on
+//! every platform.
+
+#![cfg(all(target_os = "android", feature = "feat_android"))]
+
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::os::raw::c_char;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::ptr;
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicPtr, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use jni_sys::{
+    jclass, jfloatArray, jint, jlong, jmethodID, jobject, jvalue, JNIEnv, JNINativeMethod, JavaVM,
+    JNI_EDETACHED, JNI_ERR, JNI_OK, JNI_VERSION_1_6,
+};
+
+use crate::bridge::ring_buffer::{BridgeProducer, BridgeShared};
+use crate::bridge::state::StreamState;
+use crate::core::error::{AudioError, AudioResult};
+
+use super::thread::count_external_drop;
+
+// ── JNI vtable access ────────────────────────────────────────────────────
+
+/// Calls a `JNIEnv` vtable entry by name.
+///
+/// Every entry in `jni-sys` is an `Option<fn>`; on ART the table is fully
+/// populated, so a `None` here means the process is unrecoverably broken —
+/// the `expect` panic is contained by the `catch_unwind` at every
+/// JVM-entered boundary and surfaces as an error on Rust-entered paths.
+macro_rules! jni_call {
+    ($env:expr, $name:ident $(, $arg:expr)*) => {
+        ((**$env).$name.expect(concat!("JNI vtable missing ", stringify!($name))))(
+            $env $(, $arg)*
+        )
+    };
+}
+
+// ── Cached JavaVM ────────────────────────────────────────────────────────
+
+/// The process-global `JavaVM`, cached by [`JNI_OnLoad`].
+///
+/// Null until the library is loaded via `System.loadLibrary` from Java. A
+/// pure-NDK process (no ART) never runs `JNI_OnLoad`, and every entry point
+/// in this module fails softly in that state.
+static JAVA_VM: AtomicPtr<JavaVM> = AtomicPtr::new(ptr::null_mut());
+
+/// Returns the cached `JavaVM`, or an actionable error when the library was
+/// never loaded through Java.
+fn java_vm() -> AudioResult<*mut JavaVM> {
+    let vm = JAVA_VM.load(Ordering::Acquire);
+    if vm.is_null() {
+        return Err(AudioError::StreamCreationFailed {
+            reason: "JNI is not initialized: librsac.so was not loaded through \
+                     Java (System.loadLibrary), so no JavaVM is available. \
+                     Android playback capture requires the rsac AAR \
+                     (mobile/android) to load the native library — see \
+                     mobile/android/README.md"
+                .to_string(),
+            context: None,
+        });
+    }
+    Ok(vm)
+}
+
+// ── Class / method-id cache ──────────────────────────────────────────────
+
+/// Framework + AAR classes and method ids resolved once in [`JNI_OnLoad`].
+///
+/// `jclass` fields are JNI **GlobalRefs** (process-wide, valid on any
+/// thread, never freed — the cache lives for the process). `jmethodID`s are
+/// valid as long as their class is not unloaded, which the GlobalRefs
+/// prevent.
+pub(super) struct JniCache {
+    /// `java/lang/Integer` GlobalRef. Never read after `JNI_OnLoad` — held
+    /// (like the other `_`-prefixed class refs) purely to pin the class
+    /// loaded so the cached method ids stay valid for the process lifetime.
+    pub _integer_class: jclass,
+    /// `Integer.intValue()I`.
+    pub integer_int_value: jmethodID,
+    /// `android/app/ActivityThread` (GlobalRef) — application-context lookup.
+    pub activity_thread_class: jclass,
+    /// `ActivityThread.currentApplication()Landroid/app/Application;` (static).
+    pub current_application: jmethodID,
+    /// `android/media/projection/MediaProjection` GlobalRef (validity anchor).
+    pub _projection_class: jclass,
+    /// `MediaProjection.stop()V`.
+    pub projection_stop: jmethodID,
+    /// `java/lang/Throwable` GlobalRef (validity anchor).
+    pub _throwable_class: jclass,
+    /// `Throwable.toString()Ljava/lang/String;`.
+    pub throwable_to_string: jmethodID,
+    /// The AAR half — `None` when the rsac AAR classes are not on the
+    /// application class path (NDK-only consumer). Playback capture is then
+    /// unavailable (actionable error); the mic slice is unaffected.
+    pub aar: Option<AarCache>,
+}
+
+/// The `ai.codeseys.rsac` (AAR) classes + method ids.
+pub(super) struct AarCache {
+    /// `ai/codeseys/rsac/CaptureBridge` (GlobalRef).
+    pub capture_bridge_class: jclass,
+    /// `CaptureBridge.<init>(Landroid/media/projection/MediaProjection;JIIII)V`.
+    pub bridge_ctor: jmethodID,
+    /// `CaptureBridge.start()V`.
+    pub bridge_start: jmethodID,
+    /// `CaptureBridge.stop()V`.
+    pub bridge_stop: jmethodID,
+    /// `ai/codeseys/rsac/RsacCaptureService` (GlobalRef).
+    pub service_class: jclass,
+    /// `RsacCaptureService.registerBridge(Lai/codeseys/rsac/CaptureBridge;)V` (static).
+    pub service_register_bridge: jmethodID,
+    /// `RsacCaptureService.unregisterBridge(Lai/codeseys/rsac/CaptureBridge;)V` (static).
+    pub service_unregister_bridge: jmethodID,
+    /// `ai/codeseys/rsac/PackageResolver` (GlobalRef).
+    pub resolver_class: jclass,
+    /// `PackageResolver.uidForPackage(Landroid/content/Context;Ljava/lang/String;)Ljava/lang/Integer;` (static).
+    pub resolver_uid_for_package: jmethodID,
+}
+
+// SAFETY: the raw pointers in the cache are JNI GlobalRefs and method ids —
+// both are process-global and explicitly valid across threads per the JNI
+// spec (GlobalRefs until deleted, which never happens for this
+// process-lifetime cache; method ids while their class stays loaded, which
+// the GlobalRefs guarantee). No interior mutation occurs after `JNI_OnLoad`
+// publishes the cache through the `OnceLock`.
+unsafe impl Send for JniCache {}
+// SAFETY: see the `Send` justification — immutable after publication.
+unsafe impl Sync for JniCache {}
+
+/// The cache, populated exactly once by [`JNI_OnLoad`].
+static CACHE: OnceLock<JniCache> = OnceLock::new();
+
+/// Returns the populated cache, or an actionable error when `JNI_OnLoad`
+/// never ran (library not loaded through Java).
+pub(super) fn cache() -> AudioResult<&'static JniCache> {
+    CACHE.get().ok_or_else(|| AudioError::StreamCreationFailed {
+        reason: "JNI class cache is empty: JNI_OnLoad has not run (librsac.so \
+                 was not loaded via System.loadLibrary). Load the library \
+                 through the rsac AAR (RsacProjection.isNativeAvailable()) \
+                 before creating a playback capture"
+            .to_string(),
+        context: None,
+    })
+}
+
+/// Returns the AAR class cache, or an actionable error when the Kotlin glue
+/// is not on the class path.
+pub(super) fn aar_cache() -> AudioResult<&'static AarCache> {
+    cache()?
+        .aar
+        .as_ref()
+        .ok_or_else(|| AudioError::StreamCreationFailed {
+            reason: "the rsac AAR classes (ai.codeseys.rsac.*) were not found \
+                     on the application class path when librsac.so was loaded. \
+                     Android playback capture is orchestrated through the AAR's \
+                     CaptureBridge/RsacCaptureService (mobile/android) — add \
+                     the rsac AAR to the app. Microphone capture \
+                     (CaptureTarget::Device) does not need the AAR"
+                .to_string(),
+            context: None,
+        })
+}
+
+// ── Thread attachment ────────────────────────────────────────────────────
+
+/// A `JNIEnv` valid for the current thread, detaching on drop **only** when
+/// this guard performed the attachment (a thread that was already attached
+/// — e.g. a JVM thread calling into Rust — must not be detached out from
+/// under its Java frames).
+pub(super) struct AttachedEnv {
+    env: *mut JNIEnv,
+    attached_here: bool,
+}
+
+impl AttachedEnv {
+    /// The raw env pointer, valid on the current thread for the guard's
+    /// lifetime.
+    pub(super) fn env(&self) -> *mut JNIEnv {
+        self.env
+    }
+}
+
+impl Drop for AttachedEnv {
+    fn drop(&mut self) {
+        if self.attached_here {
+            if let Ok(vm) = java_vm() {
+                // SAFETY: `vm` is the live process JavaVM; this thread was
+                // attached by this guard and holds no Java frames above us.
+                unsafe {
+                    let _ = ((**vm)
+                        .DetachCurrentThread
+                        .expect("JNI vtable missing DetachCurrentThread"))(
+                        vm
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Attaches the current thread to the JVM (or reuses an existing
+/// attachment) and returns the env guard.
+pub(super) fn attach_current_thread() -> AudioResult<AttachedEnv> {
+    let vm = java_vm()?;
+    let mut env: *mut c_void = ptr::null_mut();
+    // SAFETY: `vm` is the live process JavaVM; `env` is a valid out-pointer.
+    let res = unsafe {
+        ((**vm).GetEnv.expect("JNI vtable missing GetEnv"))(vm, &mut env, JNI_VERSION_1_6)
+    };
+    if res == JNI_OK && !env.is_null() {
+        return Ok(AttachedEnv {
+            env: env.cast::<JNIEnv>(),
+            attached_here: false,
+        });
+    }
+    if res != JNI_EDETACHED {
+        return Err(AudioError::InternalError {
+            message: format!("JavaVM::GetEnv failed with JNI error {}", res),
+            source: None,
+        });
+    }
+    // SAFETY: as above; null args selects the default attachment.
+    let res = unsafe {
+        ((**vm)
+            .AttachCurrentThread
+            .expect("JNI vtable missing AttachCurrentThread"))(vm, &mut env, ptr::null_mut())
+    };
+    if res != JNI_OK || env.is_null() {
+        return Err(AudioError::InternalError {
+            message: format!("JavaVM::AttachCurrentThread failed with JNI error {}", res),
+            source: None,
+        });
+    }
+    Ok(AttachedEnv {
+        env: env.cast::<JNIEnv>(),
+        attached_here: true,
+    })
+}
+
+// ── Exception handling ───────────────────────────────────────────────────
+
+/// Clears any pending Java exception, returning its `toString()` rendering
+/// when one was pending.
+///
+/// # Safety
+///
+/// `env` must be a valid `JNIEnv` for the current thread.
+pub(super) unsafe fn take_exception_message(env: *mut JNIEnv) -> Option<String> {
+    // SAFETY: ExceptionOccurred/ExceptionClear are legal with a pending
+    // exception (they are the query/clear primitives themselves).
+    let throwable = unsafe { jni_call!(env, ExceptionOccurred) };
+    if throwable.is_null() {
+        return None;
+    }
+    unsafe { jni_call!(env, ExceptionClear) };
+
+    let mut message = None;
+    if let Some(cache) = CACHE.get() {
+        // SAFETY: exception is cleared (calls are legal again); `throwable`
+        // is a live local ref; the method id matches Throwable.toString().
+        let jstr = unsafe {
+            jni_call!(
+                env,
+                CallObjectMethodA,
+                throwable,
+                cache.throwable_to_string,
+                ptr::null()
+            )
+        };
+        // toString itself may throw — clear and fall back to the generic text.
+        let nested = unsafe { jni_call!(env, ExceptionOccurred) };
+        if !nested.is_null() {
+            unsafe {
+                jni_call!(env, ExceptionClear);
+                jni_call!(env, DeleteLocalRef, nested);
+            }
+        } else if !jstr.is_null() {
+            // SAFETY: `jstr` is a live java.lang.String local ref; the chars
+            // are released before the ref is deleted.
+            let chars = unsafe { jni_call!(env, GetStringUTFChars, jstr, ptr::null_mut()) };
+            if !chars.is_null() {
+                // SAFETY: `chars` is a valid NUL-terminated (modified-)UTF-8
+                // buffer owned by the JVM until released.
+                let text = unsafe { std::ffi::CStr::from_ptr(chars) }
+                    .to_string_lossy()
+                    .into_owned();
+                unsafe { jni_call!(env, ReleaseStringUTFChars, jstr, chars) };
+                message = Some(text);
+            }
+        }
+        if !jstr.is_null() {
+            unsafe { jni_call!(env, DeleteLocalRef, jstr) };
+        }
+    }
+    unsafe { jni_call!(env, DeleteLocalRef, throwable) };
+    Some(message.unwrap_or_else(|| "a Java exception with no readable message".to_string()))
+}
+
+// ── Session registry ─────────────────────────────────────────────────────
+
+/// Per-capture ingest state shared between the playback stream and the
+/// Java-entered natives ([`native_push`] / [`native_session_ended`]).
+pub(super) struct IngestSession {
+    /// Producer + scratch, locked per push. Uncontended in practice: exactly
+    /// one Java capture thread pushes per session.
+    inner: Mutex<IngestInner>,
+    /// Bridge shared state — terminal signaling from
+    /// [`native_session_ended`] (ADR-0010).
+    shared: Arc<BridgeShared>,
+    /// Liveness flag shared with `AndroidPlaybackStream::is_active`.
+    is_active: Arc<AtomicBool>,
+}
+
+struct IngestInner {
+    producer: BridgeProducer,
+    /// Session-lifetime copy target for `GetFloatArrayRegion` — sized once
+    /// at registration, never grown in `native_push` (ADR-0001 adapted: an
+    /// oversized period is dropped + counted, not allocated for).
+    scratch: Vec<f32>,
+}
+
+/// The live-session registry. See the module docs for why sessions are
+/// registry ids rather than raw pointers.
+static SESSIONS: OnceLock<Mutex<HashMap<i64, Arc<IngestSession>>>> = OnceLock::new();
+
+/// Monotonic session-id source (ids are never reused — ABA-proof).
+static NEXT_SESSION_ID: AtomicI64 = AtomicI64::new(1);
+
+fn sessions() -> &'static Mutex<HashMap<i64, Arc<IngestSession>>> {
+    SESSIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Registers a new ingest session and returns its opaque id (the `session`
+/// argument the Kotlin `CaptureBridge` passes back on every `nativePush`).
+pub(super) fn register_session(
+    producer: BridgeProducer,
+    shared: Arc<BridgeShared>,
+    is_active: Arc<AtomicBool>,
+    scratch_capacity_samples: usize,
+) -> i64 {
+    let id = NEXT_SESSION_ID.fetch_add(1, Ordering::Relaxed);
+    let session = Arc::new(IngestSession {
+        inner: Mutex::new(IngestInner {
+            producer,
+            scratch: Vec::with_capacity(scratch_capacity_samples),
+        }),
+        shared,
+        is_active,
+    });
+    sessions()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(id, session);
+    id
+}
+
+/// Removes a session from the registry (idempotent).
+///
+/// A `nativePush`/`nativeSessionEnded` racing this call either already
+/// cloned the `Arc` (the session outlives the in-flight call) or finds
+/// nothing (no-op) — both are safe; that is the point of the registry.
+pub(super) fn unregister_session(id: i64) {
+    sessions()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&id);
+}
+
+/// Looks up a live session by id.
+fn find_session(id: i64) -> Option<Arc<IngestSession>> {
+    sessions()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&id)
+        .cloned()
+}
+
+// ── JVM-entered natives ──────────────────────────────────────────────────
+
+/// `CaptureBridge.nativePush` — ingests one read period from the Java
+/// capture loop.
+///
+/// Copies `frames * channels` samples out of the Java array into the
+/// session-lifetime scratch (no per-call allocation) and pushes them via
+/// [`BridgeProducer::push_samples_guarded_stamped`] (ring-full ⇒ drop +
+/// overrun count; never blocks the Java thread). Degenerate arguments, an
+/// unknown session id, or a period larger than the scratch are counted as
+/// drops or ignored — this function never throws back into Java and never
+/// lets a panic cross the JNI boundary.
+///
+/// # Safety
+///
+/// Invoked only by the JVM through the `RegisterNatives` registration with
+/// the lockstep signature `(J[FIII)V`: `env` is valid for the current
+/// thread and `buf` is a live `float[]` local reference.
+unsafe extern "system" fn native_push(
+    env: *mut JNIEnv,
+    _class: jclass,
+    session: jlong,
+    buf: jfloatArray,
+    frames: jint,
+    channels: jint,
+    sample_rate: jint,
+) {
+    // Unwind containment: a panic crossing a JNI frame is UB.
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        if buf.is_null() || frames <= 0 || channels <= 0 || sample_rate <= 0 {
+            return;
+        }
+        let Some(session) = find_session(session) else {
+            // Unknown/stale session (normal during teardown) — drop silently.
+            return;
+        };
+        let Some(samples) = (frames as usize).checked_mul(channels as usize) else {
+            let inner = session
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            count_external_drop(&inner.producer);
+            return;
+        };
+
+        // Bounds-check against the actual Java array so GetFloatArrayRegion
+        // can never raise ArrayIndexOutOfBounds (which would leave a pending
+        // exception on the Java capture thread).
+        // SAFETY: `buf` is a live float[] reference per the JVM contract.
+        let array_len = unsafe { jni_call!(env, GetArrayLength, buf) };
+        if array_len < 0 || samples > array_len as usize {
+            let inner = session
+                .inner
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            count_external_drop(&inner.producer);
+            return;
+        }
+
+        let mut inner = session
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if samples > inner.scratch.capacity() {
+            // Oversized period: drop + count instead of growing the scratch
+            // (ADR-0001 adapted — see the module docs).
+            count_external_drop(&inner.producer);
+            return;
+        }
+        // Within capacity ⇒ resize never reallocates.
+        inner.scratch.resize(samples, 0.0);
+        // SAFETY: `buf` holds at least `samples` floats (checked above) and
+        // the scratch holds exactly `samples` writable f32s.
+        unsafe {
+            jni_call!(
+                env,
+                GetFloatArrayRegion,
+                buf,
+                0,
+                samples as jint,
+                inner.scratch.as_mut_ptr()
+            );
+        }
+        // A JVM error during the region copy (e.g. OOME) leaves a pending
+        // exception; clear it and drop the period rather than pushing torn
+        // data or throwing back into the capture loop.
+        // SAFETY: env is valid; take_exception_message only clears/queries.
+        if unsafe { take_exception_message(env) }.is_some() {
+            count_external_drop(&inner.producer);
+            return;
+        }
+
+        let IngestInner { producer, scratch } = &mut *inner;
+        producer.push_samples_guarded_stamped(scratch, channels as u16, sample_rate as u32);
+    }));
+}
+
+/// `CaptureBridge.nativeSessionEnded` — the Java read loop has exited.
+///
+/// Called exactly once per bridge when the capture thread terminates. Two
+/// cases:
+///
+/// - **rsac-initiated stop**: `AndroidPlaybackStream` unregisters the
+///   session *before* asking Kotlin to stop, so this lookup finds nothing —
+///   no-op (the graceful `Running → Stopping` transition was already driven
+///   by the stop path).
+/// - **Spontaneous end** (projection revoked, foreground service destroyed,
+///   `AudioRecord` death): the session is still registered — drive the
+///   bridge to the terminal `Error` state (ADR-0010's "producer died"
+///   contract) so a parked reader observes the Fatal `StreamEnded`
+///   (ADR-0003) instead of hanging, and clear the liveness flag.
+///
+/// # Safety
+///
+/// Invoked only by the JVM through the `RegisterNatives` registration with
+/// the lockstep signature `(J)V`.
+unsafe extern "system" fn native_session_ended(_env: *mut JNIEnv, _class: jclass, session: jlong) {
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        let Some(session) = find_session(session) else {
+            return;
+        };
+        unregister_session_arc(&session);
+        session.is_active.store(false, Ordering::SeqCst);
+        // Terminal poison (fatal sibling of signal_done — same tail as the
+        // AAudio error callback): sticky Error + wake both reader kinds.
+        session.shared.state.force_set(StreamState::Error);
+        session.shared.notify_wake();
+        #[cfg(feature = "async-stream")]
+        session.shared.waker.wake();
+        log::warn!(
+            "Android playback capture ended spontaneously (projection revoked, \
+             foreground service destroyed, or AudioRecord death); bridge driven \
+             to terminal Error (ADR-0010)"
+        );
+    }));
+}
+
+/// Removes a session by identity (used by [`native_session_ended`], which
+/// holds the `Arc` rather than knowing its id).
+fn unregister_session_arc(session: &Arc<IngestSession>) {
+    sessions()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .retain(|_, live| !Arc::ptr_eq(live, session));
+}
+
+/// `RsacProjection.nativeRetainProjection` — wraps the consent-granted
+/// `MediaProjection` in a JNI `GlobalRef` and returns it as the opaque
+/// [`AndroidProjectionToken`](crate::core::config::AndroidProjectionToken)
+/// value.
+///
+/// Ownership transfers to Rust: the ref is released (`DeleteGlobalRef` +
+/// `MediaProjection.stop()`) when the owning capture is dropped
+/// (`AndroidPlaybackStream::stop_and_close`). Returns `0` when the ref
+/// cannot be created — a `0` token later fails stream creation with an
+/// actionable error rather than being interpreted.
+///
+/// # Safety
+///
+/// Invoked only by the JVM through the `RegisterNatives` registration with
+/// the lockstep signature `(Landroid/media/projection/MediaProjection;)J`.
+unsafe extern "system" fn native_retain_projection(
+    env: *mut JNIEnv,
+    _class: jclass,
+    projection: jobject,
+) -> jlong {
+    catch_unwind(AssertUnwindSafe(|| {
+        if projection.is_null() {
+            return 0;
+        }
+        // SAFETY: `projection` is a live local ref per the JVM contract.
+        let global = unsafe { jni_call!(env, NewGlobalRef, projection) };
+        global as jlong
+    }))
+    .unwrap_or(0)
+}
+
+// ── JNI_OnLoad ───────────────────────────────────────────────────────────
+
+/// Resolves a class as a GlobalRef, or `None` (exception cleared) when it
+/// is not on the class path.
+///
+/// # Safety
+///
+/// `env` must be valid for the current thread; `name` must be a
+/// NUL-terminated binary class name.
+unsafe fn find_class_global(env: *mut JNIEnv, name: &'static std::ffi::CStr) -> Option<jclass> {
+    // SAFETY: per the function contract.
+    let local = unsafe { jni_call!(env, FindClass, name.as_ptr()) };
+    if local.is_null() {
+        unsafe {
+            jni_call!(env, ExceptionClear);
+        }
+        return None;
+    }
+    // SAFETY: `local` is a live local ref.
+    let global = unsafe { jni_call!(env, NewGlobalRef, local) };
+    unsafe { jni_call!(env, DeleteLocalRef, local) };
+    if global.is_null() {
+        return None;
+    }
+    Some(global)
+}
+
+/// Resolves a (static or instance) method id, clearing the exception and
+/// returning `None` on failure.
+///
+/// # Safety
+///
+/// `env` valid for the current thread; `class` a live class ref; `name`/
+/// `sig` NUL-terminated.
+unsafe fn get_method(
+    env: *mut JNIEnv,
+    class: jclass,
+    name: &'static std::ffi::CStr,
+    sig: &'static std::ffi::CStr,
+    is_static: bool,
+) -> Option<jmethodID> {
+    // SAFETY: per the function contract.
+    let id = unsafe {
+        if is_static {
+            jni_call!(env, GetStaticMethodID, class, name.as_ptr(), sig.as_ptr())
+        } else {
+            jni_call!(env, GetMethodID, class, name.as_ptr(), sig.as_ptr())
+        }
+    };
+    if id.is_null() {
+        unsafe {
+            jni_call!(env, ExceptionClear);
+        }
+        return None;
+    }
+    Some(id)
+}
+
+/// Builds the AAR half of the cache, registering the natives on
+/// `CaptureBridge` / `RsacProjection`. Returns `None` (exceptions cleared)
+/// when any AAR class/method/registration is unavailable.
+///
+/// # Safety
+///
+/// `env` must be valid for the current thread and running under the
+/// application class loader (i.e. called from `JNI_OnLoad`).
+unsafe fn build_aar_cache(env: *mut JNIEnv) -> Option<AarCache> {
+    // SAFETY: all calls below follow the find_class_global/get_method
+    // contracts; env comes from JNI_OnLoad.
+    unsafe {
+        let capture_bridge_class = find_class_global(env, c"ai/codeseys/rsac/CaptureBridge")?;
+        let bridge_ctor = get_method(
+            env,
+            capture_bridge_class,
+            c"<init>",
+            c"(Landroid/media/projection/MediaProjection;JIIII)V",
+            false,
+        )?;
+        let bridge_start = get_method(env, capture_bridge_class, c"start", c"()V", false)?;
+        let bridge_stop = get_method(env, capture_bridge_class, c"stop", c"()V", false)?;
+
+        let service_class = find_class_global(env, c"ai/codeseys/rsac/RsacCaptureService")?;
+        let service_register_bridge = get_method(
+            env,
+            service_class,
+            c"registerBridge",
+            c"(Lai/codeseys/rsac/CaptureBridge;)V",
+            true,
+        )?;
+        let service_unregister_bridge = get_method(
+            env,
+            service_class,
+            c"unregisterBridge",
+            c"(Lai/codeseys/rsac/CaptureBridge;)V",
+            true,
+        )?;
+
+        let resolver_class = find_class_global(env, c"ai/codeseys/rsac/PackageResolver")?;
+        let resolver_uid_for_package = get_method(
+            env,
+            resolver_class,
+            c"uidForPackage",
+            c"(Landroid/content/Context;Ljava/lang/String;)Ljava/lang/Integer;",
+            true,
+        )?;
+
+        // Natives on CaptureBridge (companion `@JvmStatic external` methods
+        // compile to static natives on the enclosing class).
+        //
+        // LOCKSTEP: names + signatures must match the `external fun`
+        // declarations in CaptureBridge.kt / RsacProjection.kt — guarded by
+        // the host-run `jni_lockstep` tests in src/audio/mod.rs.
+        let bridge_natives = [
+            JNINativeMethod {
+                name: c"nativePush".as_ptr() as *mut c_char,
+                signature: c"(J[FIII)V".as_ptr() as *mut c_char,
+                fnPtr: native_push as *mut c_void,
+            },
+            JNINativeMethod {
+                name: c"nativeSessionEnded".as_ptr() as *mut c_char,
+                signature: c"(J)V".as_ptr() as *mut c_char,
+                fnPtr: native_session_ended as *mut c_void,
+            },
+        ];
+        let res = jni_call!(
+            env,
+            RegisterNatives,
+            capture_bridge_class,
+            bridge_natives.as_ptr(),
+            bridge_natives.len() as jint
+        );
+        if res != JNI_OK {
+            jni_call!(env, ExceptionClear);
+            return None;
+        }
+
+        let projection_helper_class = find_class_global(env, c"ai/codeseys/rsac/RsacProjection")?;
+        let projection_natives = [JNINativeMethod {
+            name: c"nativeRetainProjection".as_ptr() as *mut c_char,
+            signature: c"(Landroid/media/projection/MediaProjection;)J".as_ptr() as *mut c_char,
+            fnPtr: native_retain_projection as *mut c_void,
+        }];
+        let res = jni_call!(
+            env,
+            RegisterNatives,
+            projection_helper_class,
+            projection_natives.as_ptr(),
+            projection_natives.len() as jint
+        );
+        // The helper-object class ref is only needed for registration.
+        jni_call!(env, DeleteGlobalRef, projection_helper_class);
+        if res != JNI_OK {
+            jni_call!(env, ExceptionClear);
+            return None;
+        }
+
+        Some(AarCache {
+            capture_bridge_class,
+            bridge_ctor,
+            bridge_start,
+            bridge_stop,
+            service_class,
+            service_register_bridge,
+            service_unregister_bridge,
+            resolver_class,
+            resolver_uid_for_package,
+        })
+    }
+}
+
+/// JVM library-load hook: caches the `JavaVM`, resolves + caches every
+/// class/method this module uses (under the application class loader — see
+/// the module docs), and registers the natives on the AAR classes.
+///
+/// Never fails the load: a missing AAR (NDK-only consumer) or even a
+/// missing framework class leaves the corresponding cache half empty and
+/// the playback factory failing with actionable guidance, while the AAudio
+/// mic slice (which needs no JNI) keeps working.
+///
+/// # Safety
+///
+/// Called only by the JVM during `System.loadLibrary` with a valid `vm`.
+#[no_mangle]
+pub unsafe extern "system" fn JNI_OnLoad(vm: *mut JavaVM, _reserved: *mut c_void) -> jint {
+    catch_unwind(AssertUnwindSafe(|| {
+        JAVA_VM.store(vm, Ordering::Release);
+
+        let mut env: *mut c_void = ptr::null_mut();
+        // SAFETY: `vm` is the live JavaVM handed to JNI_OnLoad; `env` is a
+        // valid out-pointer. JNI_OnLoad runs on an attached thread.
+        let res = unsafe {
+            ((**vm).GetEnv.expect("JNI vtable missing GetEnv"))(vm, &mut env, JNI_VERSION_1_6)
+        };
+        if res != JNI_OK || env.is_null() {
+            // JNI < 1.6 has been extinct on Android forever; refuse the load.
+            return JNI_ERR;
+        }
+        let env = env.cast::<JNIEnv>();
+
+        // SAFETY: env is valid (above) and this is the OnLoad thread, so
+        // FindClass resolves against the application class loader.
+        let cache_value = unsafe {
+            let integer_class = find_class_global(env, c"java/lang/Integer");
+            let activity_thread_class = find_class_global(env, c"android/app/ActivityThread");
+            let projection_class =
+                find_class_global(env, c"android/media/projection/MediaProjection");
+            let throwable_class = find_class_global(env, c"java/lang/Throwable");
+            match (
+                integer_class,
+                activity_thread_class,
+                projection_class,
+                throwable_class,
+            ) {
+                (
+                    Some(integer_class),
+                    Some(activity_thread_class),
+                    Some(projection_class),
+                    Some(throwable_class),
+                ) => {
+                    let integer_int_value =
+                        get_method(env, integer_class, c"intValue", c"()I", false);
+                    let current_application = get_method(
+                        env,
+                        activity_thread_class,
+                        c"currentApplication",
+                        c"()Landroid/app/Application;",
+                        true,
+                    );
+                    let projection_stop = get_method(env, projection_class, c"stop", c"()V", false);
+                    let throwable_to_string = get_method(
+                        env,
+                        throwable_class,
+                        c"toString",
+                        c"()Ljava/lang/String;",
+                        false,
+                    );
+                    match (
+                        integer_int_value,
+                        current_application,
+                        projection_stop,
+                        throwable_to_string,
+                    ) {
+                        (
+                            Some(integer_int_value),
+                            Some(current_application),
+                            Some(projection_stop),
+                            Some(throwable_to_string),
+                        ) => Some(JniCache {
+                            _integer_class: integer_class,
+                            integer_int_value,
+                            activity_thread_class,
+                            current_application,
+                            _projection_class: projection_class,
+                            projection_stop,
+                            _throwable_class: throwable_class,
+                            throwable_to_string,
+                            aar: build_aar_cache(env),
+                        }),
+                        _ => None,
+                    }
+                }
+                _ => None,
+            }
+        };
+
+        match cache_value {
+            Some(cache) => {
+                let aar_present = cache.aar.is_some();
+                let _ = CACHE.set(cache);
+                log::debug!(
+                    "rsac JNI_OnLoad: class cache ready (AAR classes {})",
+                    if aar_present {
+                        "present — playback capture available"
+                    } else {
+                        "absent — playback capture unavailable, mic slice unaffected"
+                    }
+                );
+            }
+            None => {
+                // Framework classes missing — leave the cache empty; every
+                // playback entry point reports the actionable cache error.
+                log::warn!(
+                    "rsac JNI_OnLoad: could not resolve framework classes; \
+                     playback capture will be unavailable"
+                );
+            }
+        }
+        JNI_VERSION_1_6
+    }))
+    .unwrap_or(JNI_ERR)
+}
+
+// ── Typed call wrappers (used by playback.rs) ────────────────────────────
+
+/// Constructs, registers, and starts a Kotlin `CaptureBridge`, returning a
+/// GlobalRef to it.
+///
+/// Mirrors the documented Kotlin lifecycle:
+/// `CaptureBridge(...)` → `RsacCaptureService.registerBridge` → `start()`.
+/// On any failure every partial step is rolled back (unregister + local ref
+/// cleanup) and the pending Java exception is folded into the error.
+pub(super) fn create_and_start_bridge(
+    projection: jobject,
+    session: i64,
+    sample_rate: u32,
+    channels: u16,
+    match_uid: i32,
+    frames_per_read: i32,
+) -> AudioResult<jobject> {
+    let aar = aar_cache()?;
+    let guard = attach_current_thread()?;
+    let env = guard.env();
+
+    // ── Construct ────────────────────────────────────────────────────
+    let args = [
+        jvalue { l: projection },
+        jvalue { j: session },
+        jvalue {
+            i: sample_rate.min(i32::MAX as u32) as jint,
+        },
+        jvalue {
+            i: jint::from(channels),
+        },
+        jvalue { i: match_uid },
+        jvalue { i: frames_per_read },
+    ];
+    // SAFETY: class/ctor come from the cache (valid for the process);
+    // `args` matches the ctor signature (MediaProjection, long, int, int,
+    // int, int); `projection` is a live GlobalRef owned by the caller.
+    let bridge = unsafe {
+        jni_call!(
+            env,
+            NewObjectA,
+            aar.capture_bridge_class,
+            aar.bridge_ctor,
+            args.as_ptr()
+        )
+    };
+    // SAFETY: env valid; queries/clears the pending exception only.
+    if let Some(msg) = unsafe { take_exception_message(env) } {
+        return Err(AudioError::StreamCreationFailed {
+            reason: format!(
+                "CaptureBridge construction failed: {}. Common causes: the \
+                 RECORD_AUDIO runtime permission is not granted, the \
+                 MediaProjection token was already consumed by another \
+                 capture (one token = one session), or no mediaProjection \
+                 foreground service is running (API 34+ requires \
+                 RsacCaptureService.start() before capture)",
+                msg
+            ),
+            context: None,
+        });
+    }
+    if bridge.is_null() {
+        return Err(AudioError::StreamCreationFailed {
+            reason: "CaptureBridge construction returned null without an exception".to_string(),
+            context: None,
+        });
+    }
+
+    // ── Anchor to the foreground service ─────────────────────────────
+    let reg_args = [jvalue { l: bridge }];
+    // SAFETY: static method on the cached service class; one object arg.
+    unsafe {
+        jni_call!(
+            env,
+            CallStaticVoidMethodA,
+            aar.service_class,
+            aar.service_register_bridge,
+            reg_args.as_ptr()
+        );
+    }
+    if let Some(msg) = unsafe { take_exception_message(env) } {
+        // SAFETY: bridge is a live local ref.
+        unsafe { jni_call!(env, DeleteLocalRef, bridge) };
+        return Err(AudioError::StreamCreationFailed {
+            reason: format!("RsacCaptureService.registerBridge failed: {}", msg),
+            context: None,
+        });
+    }
+
+    // ── Start the read loop ──────────────────────────────────────────
+    // SAFETY: instance method on the live bridge object; no args.
+    unsafe {
+        jni_call!(env, CallVoidMethodA, bridge, aar.bridge_start, ptr::null());
+    }
+    if let Some(msg) = unsafe { take_exception_message(env) } {
+        // Roll back the registration; ignore secondary failures.
+        unsafe {
+            jni_call!(
+                env,
+                CallStaticVoidMethodA,
+                aar.service_class,
+                aar.service_unregister_bridge,
+                reg_args.as_ptr()
+            );
+            let _ = take_exception_message(env);
+            jni_call!(env, DeleteLocalRef, bridge);
+        }
+        return Err(AudioError::StreamStartFailed {
+            reason: format!(
+                "CaptureBridge.start() failed: {}. Common causes: \
+                 AudioRecord.startRecording() rejected (another app holds an \
+                 exclusive capture, or the projection was revoked)",
+                msg
+            ),
+        });
+    }
+
+    // ── Promote to a GlobalRef the stream can hold across threads ────
+    // SAFETY: bridge is a live local ref.
+    let global = unsafe { jni_call!(env, NewGlobalRef, bridge) };
+    unsafe { jni_call!(env, DeleteLocalRef, bridge) };
+    if global.is_null() {
+        return Err(AudioError::InternalError {
+            message: "NewGlobalRef failed for the CaptureBridge handle".to_string(),
+            source: None,
+        });
+    }
+    Ok(global)
+}
+
+/// Stops a Kotlin `CaptureBridge` (idempotent on the Kotlin side),
+/// detaches it from the foreground service, and releases the GlobalRef.
+///
+/// Exceptions are folded into log warnings — teardown always runs to
+/// completion.
+pub(super) fn stop_and_release_bridge(bridge: jobject) {
+    if bridge.is_null() {
+        return;
+    }
+    let Ok(aar) = aar_cache() else { return };
+    let Ok(guard) = attach_current_thread() else {
+        return;
+    };
+    let env = guard.env();
+    // SAFETY: `bridge` is the live GlobalRef produced by
+    // create_and_start_bridge; the cached method ids match its class.
+    unsafe {
+        jni_call!(env, CallVoidMethodA, bridge, aar.bridge_stop, ptr::null());
+        if let Some(msg) = take_exception_message(env) {
+            log::warn!("CaptureBridge.stop() threw: {}; continuing teardown", msg);
+        }
+        let args = [jvalue { l: bridge }];
+        jni_call!(
+            env,
+            CallStaticVoidMethodA,
+            aar.service_class,
+            aar.service_unregister_bridge,
+            args.as_ptr()
+        );
+        if let Some(msg) = take_exception_message(env) {
+            log::warn!(
+                "RsacCaptureService.unregisterBridge threw: {}; continuing teardown",
+                msg
+            );
+        }
+        jni_call!(env, DeleteGlobalRef, bridge);
+    }
+}
+
+/// Stops the `MediaProjection` behind a consent token and releases its
+/// GlobalRef — the "one token = one projection session" release contract.
+pub(super) fn stop_and_release_projection(token_raw: i64) {
+    if token_raw == 0 {
+        return;
+    }
+    let Ok(cache) = cache() else { return };
+    let Ok(guard) = attach_current_thread() else {
+        return;
+    };
+    let env = guard.env();
+    let projection = token_raw as jobject;
+    // SAFETY: the token is the GlobalRef minted by native_retain_projection
+    // (a 0/stale token is the producer's contract violation, documented on
+    // AndroidProjectionToken); stop() is idempotent on MediaProjection.
+    unsafe {
+        jni_call!(
+            env,
+            CallVoidMethodA,
+            projection,
+            cache.projection_stop,
+            ptr::null()
+        );
+        if let Some(msg) = take_exception_message(env) {
+            log::warn!("MediaProjection.stop() threw: {}; releasing anyway", msg);
+        }
+        jni_call!(env, DeleteGlobalRef, projection);
+    }
+}
+
+/// Resolves an installed package's UID via the AAR's `PackageResolver`
+/// (`PackageManager` lookup), using `ActivityThread.currentApplication()`
+/// as the context.
+pub(super) fn resolve_uid_for_package(package: &str) -> AudioResult<i32> {
+    let cache = cache()?;
+    let aar = aar_cache()?;
+    let guard = attach_current_thread()?;
+    let env = guard.env();
+
+    // ── Application context ──────────────────────────────────────────
+    // SAFETY: static method on the cached ActivityThread class; no args.
+    let context = unsafe {
+        jni_call!(
+            env,
+            CallStaticObjectMethodA,
+            cache.activity_thread_class,
+            cache.current_application,
+            ptr::null()
+        )
+    };
+    let exception = unsafe { take_exception_message(env) };
+    if context.is_null() || exception.is_some() {
+        return Err(AudioError::ApplicationNotFound {
+            identifier: format!(
+                "{} (could not obtain an application Context via \
+                 ActivityThread.currentApplication(){}; resolve the package's \
+                 UID yourself and use CaptureTarget::Application(uid) instead)",
+                package,
+                exception.map(|m| format!(": {}", m)).unwrap_or_default()
+            ),
+        });
+    }
+
+    // ── Package → UID ────────────────────────────────────────────────
+    let package_cstr =
+        std::ffi::CString::new(package).map_err(|_| AudioError::InvalidParameter {
+            param: "application name".to_string(),
+            reason: "package name contains an interior NUL byte".to_string(),
+        })?;
+    // SAFETY: NewStringUTF takes a NUL-terminated modified-UTF-8 string;
+    // plain ASCII/UTF-8 package names are valid modified UTF-8.
+    let jname = unsafe { jni_call!(env, NewStringUTF, package_cstr.as_ptr()) };
+    if jname.is_null() {
+        unsafe {
+            let _ = take_exception_message(env);
+            jni_call!(env, DeleteLocalRef, context);
+        }
+        return Err(AudioError::InternalError {
+            message: "NewStringUTF failed for the package name".to_string(),
+            source: None,
+        });
+    }
+    let args = [jvalue { l: context }, jvalue { l: jname }];
+    // SAFETY: static method on the cached resolver class; (Context, String)
+    // args as cached.
+    let boxed_uid = unsafe {
+        jni_call!(
+            env,
+            CallStaticObjectMethodA,
+            aar.resolver_class,
+            aar.resolver_uid_for_package,
+            args.as_ptr()
+        )
+    };
+    let exception = unsafe { take_exception_message(env) };
+    let result = if let Some(msg) = exception {
+        Err(AudioError::ApplicationNotFound {
+            identifier: format!("{} (PackageResolver.uidForPackage threw: {})", package, msg),
+        })
+    } else if boxed_uid.is_null() {
+        Err(AudioError::ApplicationNotFound {
+            identifier: format!(
+                "{} (no installed package with that name is visible to this \
+                 app; on API 30+ package visibility filtering may require a \
+                 <queries> manifest declaration)",
+                package
+            ),
+        })
+    } else {
+        // SAFETY: boxed_uid is a live java.lang.Integer; intValue()I.
+        let uid = unsafe {
+            jni_call!(
+                env,
+                CallIntMethodA,
+                boxed_uid,
+                cache.integer_int_value,
+                ptr::null()
+            )
+        };
+        match unsafe { take_exception_message(env) } {
+            Some(msg) => Err(AudioError::InternalError {
+                message: format!("Integer.intValue() threw: {}", msg),
+                source: None,
+            }),
+            None => Ok(uid),
+        }
+    };
+
+    // SAFETY: live local refs from this frame.
+    unsafe {
+        if !boxed_uid.is_null() {
+            jni_call!(env, DeleteLocalRef, boxed_uid);
+        }
+        jni_call!(env, DeleteLocalRef, jname);
+        jni_call!(env, DeleteLocalRef, context);
+    }
+    result
+}
+
+// ── Compile-time assertions ──────────────────────────────────────────────
+
+/// The registered native fn pointers must have the exact JNI-expected
+/// shapes; assigning them to typed fn pointers makes a signature drift a
+/// compile error rather than a runtime crash.
+const _NATIVE_PUSH: unsafe extern "system" fn(
+    *mut JNIEnv,
+    jclass,
+    jlong,
+    jfloatArray,
+    jint,
+    jint,
+    jint,
+) = native_push;
+const _NATIVE_SESSION_ENDED: unsafe extern "system" fn(*mut JNIEnv, jclass, jlong) =
+    native_session_ended;
+const _NATIVE_RETAIN_PROJECTION: unsafe extern "system" fn(*mut JNIEnv, jclass, jobject) -> jlong =
+    native_retain_projection;

--- a/src/audio/android/mod.rs
+++ b/src/audio/android/mod.rs
@@ -1,0 +1,384 @@
+//! Android audio capture backend — AAudio **microphone slice** (rsac-20cd).
+//!
+//! # Current scope (honest status)
+//!
+//! This backend captures the **default audio input** (microphone, or
+//! whatever input the OS currently routes — wired headset, BT, USB) via a
+//! pure-NDK AAudio input stream. That is the *entire* shipped surface today:
+//!
+//! | `CaptureTarget` | Android behaviour |
+//! |---|---|
+//! | `Device(DeviceId("default"))` | ✅ default-input capture via AAudio |
+//! | `SystemDefault` | ❌ pending — on Android this means **playback capture** (`AudioPlaybackCapture`, ADR-0013), NOT the microphone; arrives with rsac-77f1 |
+//! | `Application` / `ApplicationByName` / `ProcessTree` | ❌ pending — UID-filtered playback capture + MediaProjection consent (rsac-77f1; on Android tree ≡ app, all of an app's processes share one UID) |
+//! | `Device(other id)` | ❌ real input-device ids (mic/USB/BT from `AudioManager.getDevices`) need the Java `AudioManager` — arrives with the rsac AAR (rsac-c4b8) |
+//!
+//! [`PlatformCapabilities::query`](crate::core::capabilities::PlatformCapabilities::query)
+//! reports exactly this (`backend_name = "AAudio"`, playback-capture flags
+//! `false` until rsac-77f1).
+//!
+//! # Host-app responsibilities (NOT this library's job)
+//!
+//! Microphone capture requires the **`RECORD_AUDIO` runtime permission**:
+//! the host app must declare it in the manifest and obtain the runtime
+//! grant before building a capture (the Kotlin helpers shipped in
+//! `mobile/android/` — ADR-0012's AAR — wrap this flow). Without the grant,
+//! stream creation fails with an actionable
+//! [`AudioError::StreamCreationFailed`](crate::core::error::AudioError::StreamCreationFailed)
+//! rather than delivering silence.
+//!
+//! # Architecture
+//!
+//! Same shape as every other rsac backend (no bespoke stream type):
+//!
+//! ```text
+//! AAudio data callback (may be RT)          Consumer thread
+//! ────────────────────────────────          ───────────────
+//! extern "C" data_callback                  BridgeStream<AndroidPlatformStream>
+//!   → f32: push the slice directly            ::read_chunk()
+//!   → i16: convert into pre-alloc scratch
+//!   → BridgeProducer::push_samples_…
+//! ```
+//!
+//! - `aaudio` holds the minimal in-tree `extern "C"` bindings for the
+//!   stable AAudio NDK ABI (`libaaudio.so`) — no binding crates.
+//! - `thread` provides `AndroidPlatformStream` (the internal
+//!   [`PlatformStream`](crate::bridge::stream::PlatformStream) impl), the
+//!   panic-free/alloc-free data callback (full ADR-0001 rules — AAudio may
+//!   invoke it on a real-time thread), the error callback that drives the
+//!   bridge terminal on device disconnect (ADR-0010), and the open/start
+//!   factory.
+
+pub(crate) mod aaudio;
+pub(crate) mod thread;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::bridge::state::StreamState;
+use crate::bridge::{calculate_capacity, create_bridge, BridgeStream};
+use crate::core::config::{AudioFormat, DeviceId, SampleFormat, StreamConfig};
+use crate::core::error::{AudioError, AudioResult};
+use crate::core::interface::{AudioDevice, CapturingStream, DeviceEnumerator, DeviceKind};
+
+/// The [`DeviceId`] string of the single logical Android input device.
+///
+/// Real input-device enumeration (built-in mic vs USB vs BT ids) requires
+/// the Java `AudioManager.getDevices` list, which arrives with the rsac AAR
+/// (rsac-c4b8). Until then rsac exposes exactly one logical device,
+/// `"default"`, meaning "the default AAudio input route". The empty string
+/// is also accepted as an alias when resolving a [`CaptureTarget::Device`]
+/// (matching the Windows and iOS backends' default-endpoint convention).
+///
+/// [`CaptureTarget::Device`]: crate::core::config::CaptureTarget::Device
+pub(crate) const DEFAULT_INPUT_DEVICE_ID: &str = "default";
+
+// ── AndroidDeviceEnumerator ──────────────────────────────────────────────
+
+/// [`DeviceEnumerator`] for Android (AAudio backend, mic slice).
+///
+/// Enumeration is intentionally minimal: without the Java `AudioManager`
+/// (AAR, rsac-c4b8) the NDK cannot list input devices, so exactly **one
+/// logical input device** — `"default"` — is reported, representing the
+/// default AAudio input route. See
+/// [`DeviceEnumerator::default_device`] for why the *default device*
+/// (rsac's loopback-oriented notion) is an error on Android today.
+#[derive(Debug, Clone, Copy)]
+pub struct AndroidDeviceEnumerator;
+
+impl AndroidDeviceEnumerator {
+    /// Creates a new Android device enumerator.
+    ///
+    /// Non-fallible: no OS resources are touched until a stream is created
+    /// (matching the factory contract in
+    /// [`get_device_enumerator`](crate::audio::get_device_enumerator)).
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for AndroidDeviceEnumerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeviceEnumerator for AndroidDeviceEnumerator {
+    /// Lists the single logical Android audio input device.
+    ///
+    /// Returns exactly one device — `DeviceId("default")`, the default
+    /// AAudio input. A real device list (built-in mic / USB / BT ids via
+    /// `AudioManager.getDevices`) needs the Java side and arrives with the
+    /// rsac AAR (rsac-c4b8); it is deliberately not faked here.
+    fn enumerate_devices(&self) -> AudioResult<Vec<Box<dyn AudioDevice>>> {
+        Ok(vec![Box::new(AndroidAudioDevice::new())])
+    }
+
+    /// The rsac *default device* is not available on Android yet — errors
+    /// with guidance.
+    ///
+    /// On desktop backends `default_device()` returns the default **output**
+    /// endpoint because rsac's headline capability there is system-audio
+    /// loopback. On Android, system audio (`CaptureTarget::SystemDefault`)
+    /// means `AudioPlaybackCapture` behind the MediaProjection consent flow
+    /// (ADR-0013), which is **not wired yet** (rsac-77f1). Pretending the
+    /// microphone is "the default device" would silently deliver different
+    /// audio than the desktop contract promises (the dishonest-fallback
+    /// option ADR-0013 explicitly rejected) — and `api.rs` routes
+    /// `SystemDefault` / `Application*` / `ProcessTree` through this method,
+    /// so this is the honest refusal point. It returns
+    /// [`AudioError::PlatformNotSupported`] with the honest state:
+    ///
+    /// - **Supported now:** microphone capture via
+    ///   `CaptureTarget::Device(DeviceId("default".into()))`.
+    /// - **Pending:** playback capture (`SystemDefault` and the per-app /
+    ///   process-tree targets) via `AudioPlaybackCapture` + MediaProjection
+    ///   consent (rsac-77f1).
+    fn default_device(&self) -> AudioResult<Box<dyn AudioDevice>> {
+        Err(AudioError::PlatformNotSupported {
+            feature: "default-device (system audio) capture on Android: \
+                      SystemDefault maps to AudioPlaybackCapture — all \
+                      capturable playback, NOT the microphone (ADR-0013) — \
+                      which is not wired yet (rsac-77f1, MediaProjection \
+                      consent flow; per-app and process-tree capture arrive \
+                      with the same seed). Use \
+                      CaptureTarget::Device(DeviceId(\"default\".into())) to \
+                      capture the microphone (the default AAudio input)"
+                .to_string(),
+            platform: "android".to_string(),
+        })
+    }
+
+    // watch(): inherits the trait default (PlatformNotSupported) —
+    // consistent with `supports_device_change_notifications: false` in
+    // PlatformCapabilities::android(). Input-route change notifications are
+    // AudioManager/AudioDeviceCallback territory, which belongs to the Java
+    // side (AAR, rsac-c4b8).
+}
+
+// ── AndroidAudioDevice ───────────────────────────────────────────────────
+
+/// The single logical Android audio input device (the default AAudio
+/// input).
+///
+/// A metadata-only handle: constructing it touches no OS resources. The
+/// AAudio stream is created lazily in
+/// [`create_stream`](AudioDevice::create_stream).
+#[derive(Debug, Clone, Copy)]
+pub struct AndroidAudioDevice;
+
+impl AndroidAudioDevice {
+    /// Creates the logical default-input device handle.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for AndroidAudioDevice {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AudioDevice for AndroidAudioDevice {
+    fn id(&self) -> DeviceId {
+        DeviceId(DEFAULT_INPUT_DEVICE_ID.to_string())
+    }
+
+    fn name(&self) -> String {
+        "Default audio input (AAudio)".to_string()
+    }
+
+    fn is_default(&self) -> bool {
+        true
+    }
+
+    /// Advisory format list: F32 and I16 at common Android rates,
+    /// mono/stereo.
+    ///
+    /// AAudio negotiates the *actual* rate/channels/wire-format at
+    /// stream-open time (the backend requests the configured shape and
+    /// falls back to the device-native one), so this list is a hint, not a
+    /// contract. The **delivered** format is read back from the open stream
+    /// and reported authoritatively via [`CapturingStream::format`]; the
+    /// bridge payload is always interleaved f32 (an I16 wire format is
+    /// converted in the callback), so consumers see `F32` regardless of the
+    /// entry that matched.
+    fn supported_formats(&self) -> Vec<AudioFormat> {
+        const RATES_STEREO: [u32; 2] = [48_000, 44_100];
+        const RATES_MONO: [u32; 4] = [48_000, 44_100, 16_000, 8_000];
+        let mut formats = Vec::with_capacity((RATES_STEREO.len() + RATES_MONO.len()) * 2);
+        // F32 first: the first entry seeds DeviceInfo::default_format, and
+        // f32 is rsac's canonical delivery.
+        for sample_format in [SampleFormat::F32, SampleFormat::I16] {
+            for rate in RATES_STEREO {
+                formats.push(AudioFormat {
+                    sample_rate: rate,
+                    channels: 2,
+                    sample_format,
+                });
+            }
+            for rate in RATES_MONO {
+                formats.push(AudioFormat {
+                    sample_rate: rate,
+                    channels: 1,
+                    sample_format,
+                });
+            }
+        }
+        formats
+    }
+
+    fn kind(&self) -> AudioResult<DeviceKind> {
+        Ok(DeviceKind::Input)
+    }
+
+    /// Creates a live microphone capture stream through the ring-buffer
+    /// bridge.
+    ///
+    /// Wiring (identical shape to the desktop and iOS backends): create the
+    /// bridge (ring depth honours `config.buffer_size`, ADR-0007 pattern),
+    /// transition it to `Running`, open + start the AAudio input stream
+    /// ([`thread::create_android_capture`]), and wrap everything in a
+    /// `BridgeStream`. The stream's [`format`](CapturingStream::format)
+    /// reports the **delivered** format, which may differ from the requested
+    /// one — see [`AudioDevice::supported_formats`].
+    ///
+    /// # Errors
+    ///
+    /// - [`AudioError::PlatformNotSupported`] for `SystemDefault` and
+    ///   `Application*` / `ProcessTree` (playback-capture tiers, pending
+    ///   rsac-77f1 — see the module docs).
+    /// - [`AudioError::DeviceNotFound`] for a `Device` id other than
+    ///   `"default"` (real ids arrive with the AAR, rsac-c4b8).
+    /// - [`AudioError::StreamCreationFailed`] /
+    ///   [`AudioError::StreamStartFailed`] from the AAudio open/start path
+    ///   (typically: the `RECORD_AUDIO` runtime permission is missing — a
+    ///   host-app responsibility; see the module docs).
+    fn create_stream(&self, config: &StreamConfig) -> AudioResult<Box<dyn CapturingStream>> {
+        let requested = config.to_audio_format();
+
+        // Ring sizing: honour the requested slot count like Windows/Linux
+        // do (ADR-0007 direction), defaulting to
+        // calculate_capacity(None, 4) = 64.
+        let capacity = calculate_capacity(config.buffer_size, 4);
+        let (producer, consumer) = create_bridge(capacity, requested.clone());
+
+        // Transition bridge state Created → Running before the callback
+        // starts pushing, so the first period's buffers are readable.
+        consumer
+            .shared()
+            .state
+            .transition(StreamState::Created, StreamState::Running)
+            .map_err(|actual| AudioError::InternalError {
+                message: format!(
+                    "Failed to transition bridge state to Running (was {:?})",
+                    actual
+                ),
+                source: None,
+            })?;
+
+        // Producer-terminal-signal handle (ADR-0010): the platform stream's
+        // stop/Drop choke point (and the AAudio error callback, for
+        // disconnects) drives the bridge to its ending state so a parked
+        // reader observes end-of-stream instead of hanging.
+        let terminal = Arc::clone(consumer.shared());
+
+        // Resolve the target, open + start the AAudio stream. `delivered`
+        // is the REAL negotiated format (also published on the bridge as
+        // the negotiated format before the first push).
+        let (platform_stream, delivered) =
+            thread::create_android_capture(&config.capture_target, &requested, producer, terminal)?;
+
+        let bridge_stream =
+            BridgeStream::new(consumer, platform_stream, delivered, Duration::from_secs(1));
+
+        Ok(Box::new(bridge_stream))
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// Tests — metadata-only (no FFI): they compile for the Android target under
+// `--tests` and will run on a future emulator job. They never touch AAudio.
+// ══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::error::ErrorKind;
+
+    #[test]
+    fn enumerate_devices_returns_single_default_input() {
+        let enumerator = AndroidDeviceEnumerator::new();
+        let devices = enumerator
+            .enumerate_devices()
+            .expect("enumeration is infallible metadata");
+        assert_eq!(devices.len(), 1, "exactly one logical Android input device");
+
+        let device = &devices[0];
+        assert_eq!(device.id(), DeviceId(DEFAULT_INPUT_DEVICE_ID.to_string()));
+        assert_eq!(device.name(), "Default audio input (AAudio)");
+        assert!(device.is_default());
+        assert_eq!(device.kind().unwrap(), DeviceKind::Input);
+    }
+
+    #[test]
+    fn default_device_is_honest_platform_not_supported() {
+        let enumerator = AndroidDeviceEnumerator::new();
+        let err = match enumerator.default_device() {
+            Ok(_) => panic!("default_device must error until rsac-77f1"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), ErrorKind::Platform);
+        match err {
+            AudioError::PlatformNotSupported { feature, platform } => {
+                assert_eq!(platform, "android");
+                // The honesty pillars: what SystemDefault really means on
+                // Android, which seed delivers it, and what works today.
+                assert!(
+                    feature.contains("AudioPlaybackCapture"),
+                    "real meaning: {feature}"
+                );
+                assert!(feature.contains("NOT the"), "not-the-mic: {feature}");
+                assert!(feature.contains("rsac-77f1"), "pending seed: {feature}");
+                assert!(
+                    feature.contains("Device(DeviceId(\"default\""),
+                    "mic guidance: {feature}"
+                );
+            }
+            other => panic!("expected PlatformNotSupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn supported_formats_are_advisory_f32_and_i16() {
+        let device = AndroidAudioDevice::new();
+        let formats = device.supported_formats();
+        assert!(!formats.is_empty());
+        for fmt in &formats {
+            assert!(
+                fmt.sample_format == SampleFormat::F32 || fmt.sample_format == SampleFormat::I16,
+                "AAudio delivers PCM_FLOAT or PCM_I16 only, got {:?}",
+                fmt.sample_format
+            );
+            assert!(fmt.sample_rate > 0);
+            assert!(fmt.channels == 1 || fmt.channels == 2);
+        }
+        // First entry (the DeviceInfo::default_format seed) is 48 kHz
+        // stereo F32.
+        assert_eq!(formats[0].sample_rate, 48_000);
+        assert_eq!(formats[0].channels, 2);
+        assert_eq!(formats[0].sample_format, SampleFormat::F32);
+        // Both wire formats are represented.
+        assert!(formats.iter().any(|f| f.sample_format == SampleFormat::I16));
+    }
+
+    #[test]
+    fn describe_snapshot_is_consistent() {
+        let info = AndroidAudioDevice::new().describe();
+        assert_eq!(info.id, DeviceId(DEFAULT_INPUT_DEVICE_ID.to_string()));
+        assert_eq!(info.kind, DeviceKind::Input);
+        assert!(info.is_default);
+        assert!(info.default_format.is_some());
+    }
+}

--- a/src/audio/android/mod.rs
+++ b/src/audio/android/mod.rs
@@ -1,55 +1,66 @@
-//! Android audio capture backend — AAudio **microphone slice** (rsac-20cd).
+//! Android audio capture backend — AAudio microphone slice (rsac-20cd) +
+//! `AudioPlaybackCapture` playback tiers (rsac-77f1).
 //!
 //! # Current scope (honest status)
 //!
-//! This backend captures the **default audio input** (microphone, or
-//! whatever input the OS currently routes — wired headset, BT, USB) via a
-//! pure-NDK AAudio input stream. That is the *entire* shipped surface today:
+//! Two data paths (docs/MOBILE_BACKEND_DESIGN.md § two data paths):
 //!
 //! | `CaptureTarget` | Android behaviour |
 //! |---|---|
-//! | `Device(DeviceId("default"))` | ✅ default-input capture via AAudio |
-//! | `SystemDefault` | ❌ pending — on Android this means **playback capture** (`AudioPlaybackCapture`, ADR-0013), NOT the microphone; arrives with rsac-77f1 |
-//! | `Application` / `ApplicationByName` / `ProcessTree` | ❌ pending — UID-filtered playback capture + MediaProjection consent (rsac-77f1; on Android tree ≡ app, all of an app's processes share one UID) |
-//! | `Device(other id)` | ❌ real input-device ids (mic/USB/BT from `AudioManager.getDevices`) need the Java `AudioManager` — arrives with the rsac AAR (rsac-c4b8) |
+//! | `Device(DeviceId("default"))` | ✅ default-input (microphone) capture via AAudio — pure NDK, no Java |
+//! | `SystemDefault` | 🟡 **playback capture** (`AudioPlaybackCapture`, ADR-0013 — all capturable playback, NOT the microphone) via the rsac AAR's Kotlin loop ([`playback`]); requires API 29+, `RECORD_AUDIO`, and a MediaProjection consent token ([`with_android_projection`]) — compiled, unverified on-device (rsac-e6d3) |
+//! | `Application` / `ApplicationByName` / `ProcessTree` | 🟡 UID-filtered playback capture (tree ≡ app: all of an Android app's processes share one UID) — same requirements/status as `SystemDefault` |
+//! | `Device(other id)` | ❌ real input-device ids (mic/USB/BT from `AudioManager.getDevices`) need the Java `AudioManager` list — rsac-ad8a |
 //!
 //! [`PlatformCapabilities::query`](crate::core::capabilities::PlatformCapabilities::query)
-//! reports exactly this (`backend_name = "AAudio"`, playback-capture flags
-//! `false` until rsac-77f1).
+//! reports exactly this (`backend_name = "AAudio"`; the playback-capture
+//! flags are `true` on API 29+ with `requires_user_consent = true`).
 //!
 //! # Host-app responsibilities (NOT this library's job)
 //!
-//! Microphone capture requires the **`RECORD_AUDIO` runtime permission**:
-//! the host app must declare it in the manifest and obtain the runtime
-//! grant before building a capture (the Kotlin helpers shipped in
-//! `mobile/android/` — ADR-0012's AAR — wrap this flow). Without the grant,
-//! stream creation fails with an actionable
-//! [`AudioError::StreamCreationFailed`](crate::core::error::AudioError::StreamCreationFailed)
-//! rather than delivering silence.
+//! - **`RECORD_AUDIO` runtime permission** — required for the microphone
+//!   *and* for playback capture; the host app must declare it and obtain
+//!   the runtime grant (the Kotlin helpers in `mobile/android/` wrap the
+//!   flow). Without it, stream creation fails actionably.
+//! - **MediaProjection consent** (playback capture only) — obtain a token
+//!   via `RsacProjection.request(activity)` and pass it to
+//!   [`with_android_projection`]; playback builds without one fail the
+//!   preflight with `UserConsentRequired`.
+//! - **Foreground service** (playback capture, API 34+) — a
+//!   `mediaProjection`-typed FGS must be running before capture starts;
+//!   `RsacCaptureService.start(context)` provides one.
+//!
+//! [`with_android_projection`]: crate::api::AudioCaptureBuilder::with_android_projection
 //!
 //! # Architecture
 //!
 //! Same shape as every other rsac backend (no bespoke stream type):
 //!
 //! ```text
-//! AAudio data callback (may be RT)          Consumer thread
-//! ────────────────────────────────          ───────────────
-//! extern "C" data_callback                  BridgeStream<AndroidPlatformStream>
-//!   → f32: push the slice directly            ::read_chunk()
-//!   → i16: convert into pre-alloc scratch
-//!   → BridgeProducer::push_samples_…
+//! Mic (AAudio, may be RT)                Playback (Java loop, non-RT)
+//! ───────────────────────                ────────────────────────────
+//! extern "C" data_callback               Kotlin AudioRecord.read loop
+//!   → BridgeProducer::push_…              → nativePush (JNI, jni.rs)
+//!                                          → BridgeProducer::push_…
+//!            └────────────┬────────────────────────┘
+//!                         ▼
+//!            BridgeStream<…>::read_chunk()   (consumer thread)
 //! ```
 //!
-//! - `aaudio` holds the minimal in-tree `extern "C"` bindings for the
+//! - [`aaudio`] holds the minimal in-tree `extern "C"` bindings for the
 //!   stable AAudio NDK ABI (`libaaudio.so`) — no binding crates.
-//! - `thread` provides `AndroidPlatformStream` (the internal
-//!   [`PlatformStream`](crate::bridge::stream::PlatformStream) impl), the
-//!   panic-free/alloc-free data callback (full ADR-0001 rules — AAudio may
-//!   invoke it on a real-time thread), the error callback that drives the
-//!   bridge terminal on device disconnect (ADR-0010), and the open/start
-//!   factory.
+//! - [`thread`] provides `AndroidPlatformStream` (mic slice) and the
+//!   panic-free/alloc-free AAudio callbacks (full ADR-0001 rules).
+//! - [`jni`] is the JNI boundary for the playback path: `JNI_OnLoad`
+//!   registration, the ingest-session registry, and the natives the AAR's
+//!   `CaptureBridge`/`RsacProjection` call.
+//! - [`playback`] orchestrates the AAR's Kotlin capture pipeline
+//!   (`AndroidPlaybackDevice` + `AndroidPlaybackStream`) and owns the
+//!   ADR-0013 target → UID mapping.
 
 pub(crate) mod aaudio;
+pub(crate) mod jni;
+pub(crate) mod playback;
 pub(crate) mod thread;
 
 use std::sync::Arc;
@@ -60,6 +71,8 @@ use crate::bridge::{calculate_capacity, create_bridge, BridgeStream};
 use crate::core::config::{AudioFormat, DeviceId, SampleFormat, StreamConfig};
 use crate::core::error::{AudioError, AudioResult};
 use crate::core::interface::{AudioDevice, CapturingStream, DeviceEnumerator, DeviceKind};
+
+pub use playback::AndroidPlaybackDevice;
 
 /// The [`DeviceId`] string of the single logical Android input device.
 ///
@@ -75,14 +88,20 @@ pub(crate) const DEFAULT_INPUT_DEVICE_ID: &str = "default";
 
 // ── AndroidDeviceEnumerator ──────────────────────────────────────────────
 
-/// [`DeviceEnumerator`] for Android (AAudio backend, mic slice).
+/// [`DeviceEnumerator`] for Android (AAudio mic + `AudioPlaybackCapture`
+/// playback).
 ///
-/// Enumeration is intentionally minimal: without the Java `AudioManager`
-/// (AAR, rsac-c4b8) the NDK cannot list input devices, so exactly **one
-/// logical input device** — `"default"` — is reported, representing the
-/// default AAudio input route. See
-/// [`DeviceEnumerator::default_device`] for why the *default device*
-/// (rsac's loopback-oriented notion) is an error on Android today.
+/// Enumeration lists exactly **two logical devices** (mirroring the iOS
+/// enumerator's mic + broadcast shape):
+///
+/// - `"default"` ([`AndroidAudioDevice`]): the default AAudio input route
+///   (microphone / headset / BT / USB — whatever the OS routes).
+/// - `"playback-capture"` ([`AndroidPlaybackDevice`]): the playback-capture
+///   endpoint (`AudioPlaybackCapture` behind MediaProjection consent),
+///   serving `SystemDefault` and the per-app tiers.
+///
+/// Real input-device ids (`AudioManager.getDevices`) need the Java side and
+/// arrive with rsac-ad8a; they are deliberately not faked here.
 #[derive(Debug, Clone, Copy)]
 pub struct AndroidDeviceEnumerator;
 
@@ -104,56 +123,37 @@ impl Default for AndroidDeviceEnumerator {
 }
 
 impl DeviceEnumerator for AndroidDeviceEnumerator {
-    /// Lists the single logical Android audio input device.
-    ///
-    /// Returns exactly one device — `DeviceId("default")`, the default
-    /// AAudio input. A real device list (built-in mic / USB / BT ids via
-    /// `AudioManager.getDevices`) needs the Java side and arrives with the
-    /// rsac AAR (rsac-c4b8); it is deliberately not faked here.
+    /// Lists the two logical Android devices: the default AAudio input
+    /// (microphone) and the playback-capture endpoint.
     fn enumerate_devices(&self) -> AudioResult<Vec<Box<dyn AudioDevice>>> {
-        Ok(vec![Box::new(AndroidAudioDevice::new())])
+        Ok(vec![
+            Box::new(AndroidAudioDevice::new()),
+            Box::new(AndroidPlaybackDevice::new()),
+        ])
     }
 
-    /// The rsac *default device* is not available on Android yet — errors
-    /// with guidance.
+    /// Returns the playback-capture device — rsac's *default device* on
+    /// Android.
     ///
-    /// On desktop backends `default_device()` returns the default **output**
-    /// endpoint because rsac's headline capability there is system-audio
-    /// loopback. On Android, system audio (`CaptureTarget::SystemDefault`)
-    /// means `AudioPlaybackCapture` behind the MediaProjection consent flow
-    /// (ADR-0013), which is **not wired yet** (rsac-77f1). Pretending the
-    /// microphone is "the default device" would silently deliver different
-    /// audio than the desktop contract promises (the dishonest-fallback
-    /// option ADR-0013 explicitly rejected) — and `api.rs` routes
-    /// `SystemDefault` / `Application*` / `ProcessTree` through this method,
-    /// so this is the honest refusal point. It returns
-    /// [`AudioError::PlatformNotSupported`] with the honest state:
-    ///
-    /// - **Supported now:** microphone capture via
-    ///   `CaptureTarget::Device(DeviceId("default".into()))`.
-    /// - **Pending:** playback capture (`SystemDefault` and the per-app /
-    ///   process-tree targets) via `AudioPlaybackCapture` + MediaProjection
-    ///   consent (rsac-77f1).
+    /// On every desktop backend `default_device()` returns the default
+    /// **output** endpoint because rsac's headline capability is
+    /// system-audio loopback; the Android equivalent of that endpoint is
+    /// `AudioPlaybackCapture` (ADR-0013, rsac-77f1), so
+    /// `CaptureTarget::SystemDefault` (and the per-app tiers) resolve here.
+    /// The real preconditions — API 29+, `RECORD_AUDIO`, a MediaProjection
+    /// consent token, the mediaProjection foreground service on API 34+ —
+    /// surface as actionable errors at `create_stream` time (see
+    /// [`AndroidPlaybackDevice`]). For the microphone, target
+    /// `CaptureTarget::Device(DeviceId("default".into()))` explicitly.
     fn default_device(&self) -> AudioResult<Box<dyn AudioDevice>> {
-        Err(AudioError::PlatformNotSupported {
-            feature: "default-device (system audio) capture on Android: \
-                      SystemDefault maps to AudioPlaybackCapture — all \
-                      capturable playback, NOT the microphone (ADR-0013) — \
-                      which is not wired yet (rsac-77f1, MediaProjection \
-                      consent flow; per-app and process-tree capture arrive \
-                      with the same seed). Use \
-                      CaptureTarget::Device(DeviceId(\"default\".into())) to \
-                      capture the microphone (the default AAudio input)"
-                .to_string(),
-            platform: "android".to_string(),
-        })
+        Ok(Box::new(AndroidPlaybackDevice::new()))
     }
 
     // watch(): inherits the trait default (PlatformNotSupported) —
     // consistent with `supports_device_change_notifications: false` in
     // PlatformCapabilities::android(). Input-route change notifications are
     // AudioManager/AudioDeviceCallback territory, which belongs to the Java
-    // side (AAR, rsac-c4b8).
+    // side (rsac-ad8a).
 }
 
 // ── AndroidAudioDevice ───────────────────────────────────────────────────
@@ -247,10 +247,10 @@ impl AudioDevice for AndroidAudioDevice {
     /// # Errors
     ///
     /// - [`AudioError::PlatformNotSupported`] for `SystemDefault` and
-    ///   `Application*` / `ProcessTree` (playback-capture tiers, pending
-    ///   rsac-77f1 — see the module docs).
+    ///   `Application*` / `ProcessTree` (playback-capture tiers, served by
+    ///   [`AndroidPlaybackDevice`], not this mic device).
     /// - [`AudioError::DeviceNotFound`] for a `Device` id other than
-    ///   `"default"` (real ids arrive with the AAR, rsac-c4b8).
+    ///   `"default"` (real ids arrive with rsac-ad8a).
     /// - [`AudioError::StreamCreationFailed`] /
     ///   [`AudioError::StreamStartFailed`] from the AAudio open/start path
     ///   (typically: the `RECORD_AUDIO` runtime permission is missing — a
@@ -305,49 +305,45 @@ impl AudioDevice for AndroidAudioDevice {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::error::ErrorKind;
 
     #[test]
-    fn enumerate_devices_returns_single_default_input() {
+    fn enumerate_devices_lists_mic_and_playback() {
         let enumerator = AndroidDeviceEnumerator::new();
         let devices = enumerator
             .enumerate_devices()
             .expect("enumeration is infallible metadata");
-        assert_eq!(devices.len(), 1, "exactly one logical Android input device");
+        assert_eq!(devices.len(), 2, "mic + playback-capture endpoint");
 
-        let device = &devices[0];
-        assert_eq!(device.id(), DeviceId(DEFAULT_INPUT_DEVICE_ID.to_string()));
-        assert_eq!(device.name(), "Default audio input (AAudio)");
-        assert!(device.is_default());
-        assert_eq!(device.kind().unwrap(), DeviceKind::Input);
+        let mic = &devices[0];
+        assert_eq!(mic.id(), DeviceId(DEFAULT_INPUT_DEVICE_ID.to_string()));
+        assert_eq!(mic.name(), "Default audio input (AAudio)");
+        assert!(mic.is_default(), "mic stays the default Input device");
+        assert_eq!(mic.kind().unwrap(), DeviceKind::Input);
+
+        let playback = &devices[1];
+        assert_eq!(
+            playback.id(),
+            DeviceId(playback::PLAYBACK_DEVICE_ID.to_string())
+        );
+        assert_eq!(playback.kind().unwrap(), DeviceKind::Output);
+        assert!(playback.is_default(), "default of its (Output) kind");
     }
 
     #[test]
-    fn default_device_is_honest_platform_not_supported() {
+    fn default_device_is_the_playback_capture_endpoint() {
+        // rsac's default device is the system-audio endpoint on every
+        // platform; on Android that is the AudioPlaybackCapture device
+        // (ADR-0013), NOT the microphone — the dishonest-fallback option
+        // ADR-0013 explicitly rejected.
         let enumerator = AndroidDeviceEnumerator::new();
-        let err = match enumerator.default_device() {
-            Ok(_) => panic!("default_device must error until rsac-77f1"),
-            Err(err) => err,
-        };
-        assert_eq!(err.kind(), ErrorKind::Platform);
-        match err {
-            AudioError::PlatformNotSupported { feature, platform } => {
-                assert_eq!(platform, "android");
-                // The honesty pillars: what SystemDefault really means on
-                // Android, which seed delivers it, and what works today.
-                assert!(
-                    feature.contains("AudioPlaybackCapture"),
-                    "real meaning: {feature}"
-                );
-                assert!(feature.contains("NOT the"), "not-the-mic: {feature}");
-                assert!(feature.contains("rsac-77f1"), "pending seed: {feature}");
-                assert!(
-                    feature.contains("Device(DeviceId(\"default\""),
-                    "mic guidance: {feature}"
-                );
-            }
-            other => panic!("expected PlatformNotSupported, got {other:?}"),
-        }
+        let device = enumerator
+            .default_device()
+            .expect("the playback endpoint is metadata-only until create_stream");
+        assert_eq!(
+            device.id(),
+            DeviceId(playback::PLAYBACK_DEVICE_ID.to_string())
+        );
+        assert_eq!(device.kind().unwrap(), DeviceKind::Output);
     }
 
     #[test]

--- a/src/audio/android/playback.rs
+++ b/src/audio/android/playback.rs
@@ -1,0 +1,617 @@
+//! Android **playback capture** — the `AudioPlaybackCapture` tiers
+//! (rsac-77f1, ADR-0013).
+//!
+//! Serves `CaptureTarget::SystemDefault`, `Application`,
+//! `ApplicationByName`, and `ProcessTree` by orchestrating the rsac AAR's
+//! Kotlin capture loop through JNI (see [`super::jni`] for the boundary and
+//! `mobile/android/` for the Java side):
+//!
+//! ```text
+//! create_stream()                     Kotlin (AAR)
+//! ───────────────                     ────────────
+//! resolve target → matchUid
+//! register ingest session   ────────► CaptureBridge(projection, session,
+//! create_and_start_bridge()             rate, ch, matchUid, framesPerRead)
+//!                                      RsacCaptureService.registerBridge
+//!                                      bridge.start() → read thread:
+//!                                        AudioRecord.read → nativePush ──► ring
+//! stop_capture()/Drop       ────────► bridge.stop() (join, release)
+//!   unregister session first            └ thread exit → nativeSessionEnded
+//!   projection.stop() + DeleteGlobalRef        (no-op: already unregistered)
+//! ```
+//!
+//! # Target → UID mapping (normative, ADR-0013)
+//!
+//! | `CaptureTarget` | `matchUid` |
+//! |---|---|
+//! | `SystemDefault` | none (`-1`) — usage filters only ("all capturable playback") |
+//! | `Application(ApplicationId)` | the id parsed as a numeric **app UID** |
+//! | `ApplicationByName(String)` | package name → UID via the AAR's `PackageResolver` (`PackageManager`) |
+//! | `ProcessTree(ProcessId)` | PID → UID from `/proc/<pid>/status` (pure Rust). **Tree ≡ app**: all of an Android app's processes share one UID — a documented equivalence, not a limitation |
+//!
+//! The usage-filter set (`MEDIA`/`GAME`/`UNKNOWN`) is fixed on the Kotlin
+//! side (the transport mapping from ADR-0013); the UID is the only policy
+//! input crossing the boundary.
+//!
+//! # Consent-token lifecycle
+//!
+//! The [`AndroidProjectionToken`](crate::core::config::AndroidProjectionToken)
+//! (a `GlobalRef` to the user-consented `MediaProjection`, minted by
+//! `RsacProjection.request` → `nativeRetainProjection`) is consumed from
+//! [`StreamConfig::android_projection`] and **owned by the stream**: the
+//! teardown choke point stops the projection (`MediaProjection.stop()`) and
+//! deletes the ref — one token = one projection session, released on
+//! capture drop exactly as `RsacProjection`'s contract documents.
+//!
+//! # Terminal semantics (ADR-0010 / ADR-0003)
+//!
+//! - **Graceful stop** (`stop_capture` / `Drop`): the session is
+//!   unregistered *first* (so trailing `nativePush`/`nativeSessionEnded`
+//!   calls are provably-safe no-ops), Kotlin `stop()` joins the read
+//!   thread, and the bridge is driven `Running → Stopping` (drainable
+//!   tail).
+//! - **Spontaneous death** (projection revoked, foreground service
+//!   destroyed, `AudioRecord` death): the Kotlin read loop exits and calls
+//!   `nativeSessionEnded`, which finds the session still registered and
+//!   forces the sticky terminal `Error` — a parked reader observes the
+//!   Fatal `StreamEnded` instead of hanging.
+//!
+//! [`StreamConfig::android_projection`]: crate::core::config::StreamConfig::android_projection
+
+#![cfg(all(target_os = "android", feature = "feat_android"))]
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use jni_sys::jobject;
+
+use crate::bridge::ring_buffer::{BridgeProducer, BridgeShared};
+use crate::bridge::state::StreamState;
+use crate::bridge::stream::PlatformStream;
+use crate::bridge::{calculate_capacity, create_bridge, BridgeStream};
+use crate::core::config::{AudioFormat, CaptureTarget, DeviceId, SampleFormat, StreamConfig};
+use crate::core::error::{AudioError, AudioResult};
+use crate::core::interface::{AudioDevice, CapturingStream, DeviceKind};
+
+use super::jni;
+use super::thread::scratch_capacity_samples;
+
+/// The [`DeviceId`] string of the logical Android playback-capture
+/// endpoint.
+pub(crate) const PLAYBACK_DEVICE_ID: &str = "playback-capture";
+
+/// Frames per Java-side read/push period — lockstep with the Kotlin
+/// `CaptureBridge.DEFAULT_FRAMES_PER_READ` (480 frames = 10 ms at 48 kHz);
+/// passed explicitly so the two sides cannot drift silently.
+const FRAMES_PER_READ: i32 = 480;
+
+/// `matchUid` sentinel for "no UID filter" — lockstep with the Kotlin
+/// `CaptureBridge.NO_UID_FILTER`.
+const NO_UID_FILTER: i32 = -1;
+
+// ── UID resolution ───────────────────────────────────────────────────────
+
+/// Extracts the real UID from the text of `/proc/<pid>/status` (the first
+/// field of the `Uid:` line). Pure parsing — unit-tested on every host.
+fn parse_uid_from_status(status_text: &str) -> Option<u32> {
+    status_text
+        .lines()
+        .find_map(|line| line.strip_prefix("Uid:"))?
+        .split_whitespace()
+        .next()?
+        .parse()
+        .ok()
+}
+
+/// Resolves a PID to its UID via `/proc/<pid>/status` — the ADR-0013
+/// `ProcessTree` mapping, done in pure Rust (no JNI needed).
+///
+/// Honest limitation (documented in the AAR's `PackageResolver` too):
+/// Android mounts `/proc` with `hidepid=2`, so other apps' processes are
+/// generally not readable — this works for the caller's own UID's processes
+/// (which covers the tree ≡ app equivalence) and PIDs the platform exposes.
+fn uid_for_pid(pid: u32) -> AudioResult<u32> {
+    let path = format!("/proc/{}/status", pid);
+    let text = std::fs::read_to_string(&path).map_err(|e| AudioError::ApplicationNotFound {
+        identifier: format!(
+            "PID {} (cannot read {}: {}; the process does not exist or is \
+             not visible to this app — Android hides other apps' /proc \
+             entries)",
+            pid, path, e
+        ),
+    })?;
+    parse_uid_from_status(&text).ok_or_else(|| AudioError::ApplicationNotFound {
+        identifier: format!("PID {} ({} has no parseable Uid: line)", pid, path),
+    })
+}
+
+/// Resolves a playback [`CaptureTarget`] to its `matchUid` argument
+/// (ADR-0013 mapping — see the module docs table).
+fn resolve_match_uid(target: &CaptureTarget) -> AudioResult<i32> {
+    match target {
+        CaptureTarget::SystemDefault => Ok(NO_UID_FILTER),
+        CaptureTarget::Application(app_id) => {
+            app_id.0.parse::<u32>().map(|uid| uid as i32).map_err(|_| {
+                AudioError::InvalidParameter {
+                    param: "application id".to_string(),
+                    reason: format!(
+                        "on Android, CaptureTarget::Application carries the \
+                         numeric app UID (ADR-0013); {:?} is not a number. \
+                         Use CaptureTarget::ApplicationByName(package) for a \
+                         package name",
+                        app_id.0
+                    ),
+                }
+            })
+        }
+        CaptureTarget::ApplicationByName(package) => jni::resolve_uid_for_package(package),
+        CaptureTarget::ProcessTree(pid) => uid_for_pid(pid.0).map(|uid| uid as i32),
+        CaptureTarget::Device(_) => Err(AudioError::PlatformNotSupported {
+            feature: "device capture through the Android playback-capture \
+                      endpoint: this endpoint serves the playback tiers \
+                      (SystemDefault / Application / ApplicationByName / \
+                      ProcessTree). Use \
+                      CaptureTarget::Device(DeviceId(\"default\".into())) for \
+                      the microphone"
+                .to_string(),
+            platform: "android".to_string(),
+        }),
+    }
+}
+
+// ── AndroidPlaybackDevice ────────────────────────────────────────────────
+
+/// The logical Android playback-capture endpoint (`AudioPlaybackCapture`
+/// behind MediaProjection consent).
+///
+/// A metadata-only handle: constructing it touches no OS or JVM resources.
+/// The Kotlin capture pipeline is created lazily in
+/// [`create_stream`](AudioDevice::create_stream). This is rsac's *default
+/// device* on Android — `CaptureTarget::SystemDefault` resolves here, the
+/// same way every desktop backend's default device is the system-audio
+/// loopback endpoint (and the same shape as iOS's `BroadcastAudioDevice`).
+#[derive(Debug, Clone, Copy)]
+pub struct AndroidPlaybackDevice;
+
+impl AndroidPlaybackDevice {
+    /// Creates the logical playback-capture device handle.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for AndroidPlaybackDevice {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AudioDevice for AndroidPlaybackDevice {
+    fn id(&self) -> DeviceId {
+        DeviceId(PLAYBACK_DEVICE_ID.to_string())
+    }
+
+    fn name(&self) -> String {
+        "Playback capture (AudioPlaybackCapture)".to_string()
+    }
+
+    /// `true` — the default of its ([`DeviceKind::Output`]) kind; the mic
+    /// device stays the default [`DeviceKind::Input`].
+    fn is_default(&self) -> bool {
+        true
+    }
+
+    /// The shapes the Kotlin `CaptureBridge` constructs `AudioRecord` with:
+    /// `PCM_FLOAT` mono/stereo at the common Android rates. Unlike AAudio,
+    /// there is no renegotiation — the record either honors the requested
+    /// shape or construction fails — so the delivered format equals the
+    /// (negotiated) requested one.
+    fn supported_formats(&self) -> Vec<AudioFormat> {
+        const RATES: [u32; 2] = [48_000, 44_100];
+        let mut formats = Vec::with_capacity(RATES.len() * 2);
+        for rate in RATES {
+            for channels in [2u16, 1] {
+                formats.push(AudioFormat {
+                    sample_rate: rate,
+                    channels,
+                    sample_format: SampleFormat::F32,
+                });
+            }
+        }
+        formats
+    }
+
+    /// [`DeviceKind::Output`]: playback capture is a loopback of the
+    /// system's (possibly UID-filtered) output mix — same convention as the
+    /// desktop loopback endpoints and iOS's broadcast device.
+    fn kind(&self) -> AudioResult<DeviceKind> {
+        Ok(DeviceKind::Output)
+    }
+
+    /// Creates a live playback-capture stream through the ring-buffer
+    /// bridge.
+    ///
+    /// Wiring (identical shape to every other rsac backend): create the
+    /// bridge (ring depth honours `config.buffer_size`, ADR-0007 pattern),
+    /// transition it to `Running`, start the Kotlin capture pipeline
+    /// ([`create_playback_capture`]), and wrap everything in a
+    /// [`BridgeStream`].
+    ///
+    /// # Errors
+    ///
+    /// - [`AudioError::UserConsentRequired`] when no projection token is in
+    ///   the config (normally caught earlier by the `build()` preflight).
+    /// - [`AudioError::ApplicationNotFound`] /
+    ///   [`AudioError::InvalidParameter`] from target → UID resolution.
+    /// - [`AudioError::StreamCreationFailed`] /
+    ///   [`AudioError::StreamStartFailed`] from the JNI/Kotlin pipeline
+    ///   (missing AAR classes, RECORD_AUDIO not granted, consumed/revoked
+    ///   projection, no mediaProjection foreground service on API 34+).
+    fn create_stream(&self, config: &StreamConfig) -> AudioResult<Box<dyn CapturingStream>> {
+        let requested = config.to_audio_format();
+
+        let capacity = calculate_capacity(config.buffer_size, 4);
+        let (producer, consumer) = create_bridge(capacity, requested.clone());
+
+        consumer
+            .shared()
+            .state
+            .transition(StreamState::Created, StreamState::Running)
+            .map_err(|actual| AudioError::InternalError {
+                message: format!(
+                    "Failed to transition bridge state to Running (was {:?})",
+                    actual
+                ),
+                source: None,
+            })?;
+
+        let terminal = Arc::clone(consumer.shared());
+
+        let (platform_stream, delivered) =
+            create_playback_capture(config, &requested, producer, terminal)?;
+
+        let bridge_stream =
+            BridgeStream::new(consumer, platform_stream, delivered, Duration::from_secs(1));
+
+        Ok(Box::new(bridge_stream))
+    }
+}
+
+// ── AndroidPlaybackStream ────────────────────────────────────────────────
+
+/// JNI handles for one playback capture, serialized by the `Mutex` in
+/// [`AndroidPlaybackStream`]. Both are nulled/zeroed as they are released —
+/// the idempotency guard for teardown.
+struct PlaybackHandles {
+    /// GlobalRef to the Kotlin `CaptureBridge`; null once released.
+    bridge: jobject,
+    /// The owned projection token (GlobalRef to the `MediaProjection`);
+    /// `0` once released.
+    projection_token: i64,
+}
+
+/// Platform-specific stream handle for Android playback capture.
+///
+/// Implements [`PlatformStream`] so it can be wrapped by
+/// [`BridgeStream`](crate::bridge::stream::BridgeStream) like every other
+/// rsac backend.
+pub(crate) struct AndroidPlaybackStream {
+    /// JNI handles, serialized by the `Mutex` for `&self` access.
+    handles: Mutex<PlaybackHandles>,
+    /// The ingest-session registry id (see [`super::jni`]'s module docs).
+    session_id: i64,
+    /// `true` while the Kotlin pipeline is delivering. Cleared by the
+    /// teardown choke point and by `nativeSessionEnded` (spontaneous
+    /// death), so [`is_active`](PlatformStream::is_active) reflects both.
+    is_active: Arc<AtomicBool>,
+    /// Producer-terminal-signal handle (ADR-0010).
+    terminal: Arc<BridgeShared>,
+}
+
+// SAFETY: the raw `jobject`s inside the Mutex are JNI **GlobalRefs**, which
+// the JNI spec defines as valid on any thread; every use goes through the
+// Mutex (only the teardown choke point touches them), so no unsynchronized
+// concurrent use can occur. The remaining fields are Send + Sync already.
+// Mirrors the discipline on `AndroidPlatformStream` / `IosPlatformStream`.
+unsafe impl Send for AndroidPlaybackStream {}
+// SAFETY: see the `Send` justification — all interior pointer access is
+// serialized by the `Mutex`.
+unsafe impl Sync for AndroidPlaybackStream {}
+
+impl AndroidPlaybackStream {
+    /// Stops the Kotlin pipeline (once), releases the projection, and
+    /// signals the bridge terminal.
+    ///
+    /// Ordering matters (see the module docs' terminal-semantics section):
+    ///
+    /// 1. **Unregister the ingest session** — before Kotlin `stop()`, so a
+    ///    `nativePush` still in flight after the bounded join is a provable
+    ///    no-op (the registry design exists for exactly this hazard) and
+    ///    the read thread's final `nativeSessionEnded` finds nothing.
+    /// 2. Kotlin `bridge.stop()` + `unregisterBridge` + drop the GlobalRef.
+    /// 3. `MediaProjection.stop()` + drop its GlobalRef (one token = one
+    ///    projection session).
+    /// 4. Drive the bridge `Running → Stopping` (graceful producer
+    ///    terminal, ADR-0010) and wake parked readers.
+    ///
+    /// Idempotent: the nulled handles (under the `Mutex`) make later calls
+    /// no-ops. JNI failures are logged, never propagated — teardown always
+    /// runs to completion.
+    fn stop_and_close(&self) -> AudioResult<()> {
+        let mut handles = self.handles.lock().map_err(|_| AudioError::InternalError {
+            message: "Android playback stream handles mutex poisoned".to_string(),
+            source: None,
+        })?;
+
+        if handles.bridge.is_null() && handles.projection_token == 0 {
+            return Ok(());
+        }
+
+        // 1. Make trailing Java-entered calls no-ops.
+        jni::unregister_session(self.session_id);
+
+        // 2. Stop + detach + release the Kotlin bridge.
+        let bridge = std::mem::replace(&mut handles.bridge, std::ptr::null_mut());
+        jni::stop_and_release_bridge(bridge);
+
+        // 3. Release the projection (consent-token lifecycle contract).
+        let token = std::mem::replace(&mut handles.projection_token, 0);
+        jni::stop_and_release_projection(token);
+
+        self.is_active.store(false, Ordering::SeqCst);
+
+        // 4. Graceful producer terminal (ADR-0010): `Running → Stopping`
+        // keeps a buffered tail drainable; the CAS no-ops if the state
+        // already advanced (e.g. nativeSessionEnded's sticky Error).
+        let _ = self
+            .terminal
+            .state
+            .transition(StreamState::Running, StreamState::Stopping);
+        self.terminal.notify_wake();
+        #[cfg(feature = "async-stream")]
+        self.terminal.waker.wake();
+
+        Ok(())
+    }
+}
+
+impl PlatformStream for AndroidPlaybackStream {
+    fn stop_capture(&self) -> AudioResult<()> {
+        self.stop_and_close()
+    }
+
+    fn is_active(&self) -> bool {
+        self.is_active.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for AndroidPlaybackStream {
+    /// Deterministic shutdown: dropping the handle never leaves the Kotlin
+    /// read thread pushing into a bridge nobody reads, a parked reader
+    /// hanging (ADR-0010), or the projection GlobalRef leaked.
+    fn drop(&mut self) {
+        if let Err(e) = self.stop_and_close() {
+            log::warn!("AndroidPlaybackStream::drop: teardown failed: {:?}", e);
+        }
+    }
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────
+
+/// Resolves the target, registers the ingest session, and starts the
+/// Kotlin capture pipeline, returning the [`AndroidPlaybackStream`] handle
+/// plus the delivered [`AudioFormat`].
+///
+/// The delivered format **is** the requested one: the Kotlin
+/// `CaptureBridge` constructs its `AudioRecord` with exactly the requested
+/// rate/channels in `PCM_FLOAT` (no renegotiation — construction fails
+/// instead), and the format is published on the bridge before the read
+/// loop starts so `CapturingStream::format()` is authoritative from the
+/// first buffer.
+fn create_playback_capture(
+    config: &StreamConfig,
+    requested: &AudioFormat,
+    producer: BridgeProducer,
+    terminal: Arc<BridgeShared>,
+) -> AudioResult<(AndroidPlaybackStream, AudioFormat)> {
+    // ── Consent token (normally enforced by the build() preflight) ──
+    let token = config
+        .android_projection
+        .ok_or_else(|| AudioError::UserConsentRequired {
+            feature: "Android playback capture".to_string(),
+            missing: "MediaProjection token — obtain one via \
+                      RsacProjection.request() and pass it to \
+                      AudioCaptureBuilder::with_android_projection()"
+                .to_string(),
+        })?;
+    if token.as_raw() == 0 {
+        return Err(AudioError::StreamCreationFailed {
+            reason: "the Android projection token is 0 — the consent flow \
+                     failed to retain the MediaProjection (see \
+                     RsacProjection.nativeRetainProjection). Request consent \
+                     again and pass the fresh token"
+                .to_string(),
+            context: None,
+        });
+    }
+
+    // ── Kotlin-side constraints, checked before any JNI work ────────
+    if requested.channels != 1 && requested.channels != 2 {
+        return Err(AudioError::UnsupportedFormat {
+            format: format!(
+                "{} channels (Android playback capture supports mono or \
+                 stereo)",
+                requested.channels
+            ),
+            context: None,
+        });
+    }
+
+    // ── Target → UID (ADR-0013) ──────────────────────────────────────
+    let match_uid = resolve_match_uid(&config.capture_target)?;
+
+    let delivered = AudioFormat {
+        sample_rate: requested.sample_rate,
+        channels: requested.channels,
+        sample_format: SampleFormat::F32,
+    };
+    // Publish before any push so readers never see the requested-format
+    // fallback once data flows (M1 pattern, same as the mic slice).
+    producer.set_negotiated_format(&delivered);
+
+    // ── Ingest session (see jni.rs for the registry design) ─────────
+    let is_active = Arc::new(AtomicBool::new(true));
+    let session_id = jni::register_session(
+        producer,
+        Arc::clone(&terminal),
+        Arc::clone(&is_active),
+        scratch_capacity_samples(delivered.sample_rate, delivered.channels),
+    );
+
+    // ── Kotlin pipeline: construct → register → start ────────────────
+    let bridge = match jni::create_and_start_bridge(
+        token.as_raw() as jobject,
+        session_id,
+        delivered.sample_rate,
+        delivered.channels,
+        match_uid,
+        FRAMES_PER_READ,
+    ) {
+        Ok(bridge) => bridge,
+        Err(e) => {
+            // Nothing Java-side is running; reclaim the session so the
+            // producer (and its ring) is dropped rather than leaked. The
+            // projection token stays with the caller (they may retry).
+            jni::unregister_session(session_id);
+            return Err(e);
+        }
+    };
+
+    log::debug!(
+        "Android playback capture started (target={:?}, matchUid={}, {} Hz, \
+         {} ch, {} frames/read)",
+        config.capture_target,
+        match_uid,
+        delivered.sample_rate,
+        delivered.channels,
+        FRAMES_PER_READ
+    );
+
+    Ok((
+        AndroidPlaybackStream {
+            handles: Mutex::new(PlaybackHandles {
+                bridge,
+                projection_token: token.as_raw(),
+            }),
+            session_id,
+            is_active,
+            terminal,
+        },
+        delivered,
+    ))
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// Tests — pure logic only (no JNI): UID parsing and target mapping edges.
+// They compile for the Android target under `--tests` and will run on the
+// emulator leg (rsac-e6d3).
+// ══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::ApplicationId;
+
+    // ── /proc status parsing ─────────────────────────────────────────
+
+    #[test]
+    fn parse_uid_takes_the_first_field_of_the_uid_line() {
+        let status =
+            "Name:\tcom.example.app\nPid:\t4242\nUid:\t10123\t10123\t10123\t10123\nGid:\t10123\n";
+        assert_eq!(parse_uid_from_status(status), Some(10_123));
+    }
+
+    #[test]
+    fn parse_uid_handles_missing_or_malformed_lines() {
+        assert_eq!(parse_uid_from_status(""), None);
+        assert_eq!(parse_uid_from_status("Name:\tfoo\nGid:\t1000\n"), None);
+        assert_eq!(parse_uid_from_status("Uid:\tnot-a-number\n"), None);
+        assert_eq!(parse_uid_from_status("Uid:\n"), None);
+    }
+
+    #[test]
+    fn parse_uid_ignores_lines_that_merely_contain_uid() {
+        // Only a line *starting* with "Uid:" is the real field.
+        let status = "SigCgt:\t0000000000000000\nNoUid: 99\nUid:\t10007\t10007\n";
+        assert_eq!(parse_uid_from_status(status), Some(10_007));
+    }
+
+    // ── Target mapping (ADR-0013) ────────────────────────────────────
+
+    #[test]
+    fn system_default_maps_to_no_uid_filter() {
+        assert_eq!(
+            resolve_match_uid(&CaptureTarget::SystemDefault).unwrap(),
+            NO_UID_FILTER
+        );
+    }
+
+    #[test]
+    fn application_id_carries_the_numeric_uid() {
+        let target = CaptureTarget::Application(ApplicationId("10123".to_string()));
+        assert_eq!(resolve_match_uid(&target).unwrap(), 10_123);
+    }
+
+    #[test]
+    fn non_numeric_application_id_is_actionable() {
+        let target = CaptureTarget::Application(ApplicationId("com.example.app".to_string()));
+        match resolve_match_uid(&target).unwrap_err() {
+            AudioError::InvalidParameter { reason, .. } => {
+                assert!(reason.contains("numeric app UID"), "{reason}");
+                assert!(reason.contains("ApplicationByName"), "{reason}");
+            }
+            other => panic!("expected InvalidParameter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn device_target_is_refused_with_mic_guidance() {
+        let target = CaptureTarget::Device(DeviceId(PLAYBACK_DEVICE_ID.to_string()));
+        match resolve_match_uid(&target).unwrap_err() {
+            AudioError::PlatformNotSupported { feature, platform } => {
+                assert_eq!(platform, "android");
+                assert!(feature.contains("Device(DeviceId(\"default\""), "{feature}");
+            }
+            other => panic!("expected PlatformNotSupported, got {other:?}"),
+        }
+    }
+
+    // ── Device metadata ──────────────────────────────────────────────
+
+    #[test]
+    fn playback_device_metadata_is_consistent() {
+        let device = AndroidPlaybackDevice::new();
+        assert_eq!(device.id(), DeviceId(PLAYBACK_DEVICE_ID.to_string()));
+        assert!(device.is_default());
+        assert_eq!(device.kind().unwrap(), DeviceKind::Output);
+        let formats = device.supported_formats();
+        assert!(!formats.is_empty());
+        for fmt in &formats {
+            assert_eq!(fmt.sample_format, SampleFormat::F32);
+            assert!(fmt.channels == 1 || fmt.channels == 2);
+        }
+        // First entry (the DeviceInfo::default_format seed) is 48 kHz
+        // stereo F32.
+        assert_eq!(formats[0].sample_rate, 48_000);
+        assert_eq!(formats[0].channels, 2);
+    }
+
+    #[test]
+    fn frames_per_read_matches_the_kotlin_default() {
+        // Lockstep with CaptureBridge.DEFAULT_FRAMES_PER_READ (480 = 10 ms
+        // at 48 kHz). The jni_lockstep tests guard the symbol names; this
+        // guards the period constant.
+        assert_eq!(FRAMES_PER_READ, 480);
+    }
+}

--- a/src/audio/android/thread.rs
+++ b/src/audio/android/thread.rs
@@ -1,0 +1,1152 @@
+//! `AndroidPlatformStream` — the Android backend's [`PlatformStream`]
+//! implementation, plus the AAudio open/start factory and the `extern "C"`
+//! callbacks that feed the bridge.
+//!
+//! # Threading model
+//!
+//! Like macOS/iOS (and unlike the rsac-owned Windows capture loop), AAudio
+//! manages its own threads: the data callback fires on an AAudio-owned
+//! callback thread — **potentially a real-time thread**, because the stream
+//! is opened with `AAUDIO_PERFORMANCE_MODE_LOW_LATENCY` — and the error
+//! callback fires on a separate, non-real-time thread AAudio creates for it.
+//! There is **no rsac-owned capture thread**; the module name follows the
+//! per-backend convention, not an actual `std::thread`.
+//!
+//! # Real-time discipline (ADR-0001, full rules)
+//!
+//! The data callback must be treated as hard-RT:
+//!
+//! - **No allocation:** the i16→f32 conversion scratch is pre-allocated once
+//!   at stream creation and never grown in the callback; a period that would
+//!   exceed its capacity is dropped and counted (`overrun_count`), never
+//!   allocated for. The f32 fast path pushes the incoming slice directly.
+//! - **No locks:** the callback context is reached through a raw pointer
+//!   (see the ownership dance below) — no `Mutex`, no `Condvar` (the
+//!   consumer relies on the bounded backstop poll, exactly like the
+//!   Linux/macOS RT push paths).
+//! - **No panics escape:** the push is [`BridgeProducer::push_samples_guarded_stamped`]
+//!   (foreign C-callback boundary — an unwind into AAudio would be UB), and
+//!   the surrounding code is panic-free by construction.
+//!
+//! # Callback-context ownership dance
+//!
+//! AAudio callbacks receive an opaque `void* user_data`. rsac leaks one
+//! `Box` per callback (a [`DataCallbackContext`] for the data callback and a
+//! separate [`ErrorCallbackContext`] for the error callback — separate
+//! allocations so the two callbacks never alias each other's state) and
+//! hands the raw pointers to the stream builder. Lifetime:
+//!
+//! 1. **Leaked** (`Box::into_raw`) before `AAudioStreamBuilder_openStream`,
+//!    because the builder needs the pointers up front.
+//! 2. **Completed** between open and `AAudioStream_requestStart`: the
+//!    delivered format/rate/channels are read back and written into the data
+//!    context (no data callback can run before start, so this access is
+//!    exclusive).
+//! 3. **Reclaimed exactly once** (`Box::from_raw`) in the teardown choke
+//!    point, strictly **after** `AAudioStream_requestStop` + a bounded
+//!    state-quiesce wait + `AAudioStream_close` have returned — the point at
+//!    which no callback can reference the contexts anymore. The teardown is
+//!    serialized by a `Mutex` and made idempotent by nulling the pointers,
+//!    so double-free is impossible.
+//!
+//! # Terminal signaling (ADR-0010 / ADR-0003)
+//!
+//! - Graceful stop (`stop_capture` / `Drop`): after the stream is closed the
+//!   bridge is driven `Running → Stopping` (drainable tail) and a parked
+//!   reader is woken — the [`BridgeProducer::signal_done`] semantics applied
+//!   via the shared handle, because the producer itself lives inside the
+//!   leaked data-callback context.
+//! - Spontaneous death (`AAUDIO_ERROR_DISCONNECTED` et al. via the error
+//!   callback): the bridge is forced to the terminal `Error` state (the
+//!   [`BridgeProducer::signal_error`] semantics), so a blocked reader
+//!   observes the Fatal `StreamEnded` instead of hanging — mirroring the
+//!   macOS `kAudioDevicePropertyDeviceIsAlive` listener pattern.
+
+#![cfg(all(target_os = "android", feature = "feat_android"))]
+
+use std::ffi::c_void;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::bridge::ring_buffer::{BridgeProducer, BridgeShared};
+use crate::bridge::state::StreamState;
+use crate::bridge::stream::PlatformStream;
+use crate::core::config::{AudioFormat, CaptureTarget, SampleFormat};
+use crate::core::error::{AudioError, AudioResult, BackendContext};
+
+use super::aaudio::{
+    aaudio_data_callback_result_t, aaudio_format_t, aaudio_result_t, result_name, result_to_error,
+    AAudioStream, AAudioStreamBuilder, AAudioStreamBuilder_delete, AAudioStreamBuilder_openStream,
+    AAudioStreamBuilder_setChannelCount, AAudioStreamBuilder_setDataCallback,
+    AAudioStreamBuilder_setDirection, AAudioStreamBuilder_setErrorCallback,
+    AAudioStreamBuilder_setFormat, AAudioStreamBuilder_setPerformanceMode,
+    AAudioStreamBuilder_setSampleRate, AAudioStream_close, AAudioStream_getChannelCount,
+    AAudioStream_getFormat, AAudioStream_getSampleRate, AAudioStream_getState,
+    AAudioStream_requestStart, AAudioStream_requestStop, AAudioStream_waitForStateChange,
+    AAudio_createStreamBuilder, AAUDIO_CALLBACK_RESULT_CONTINUE, AAUDIO_CALLBACK_RESULT_STOP,
+    AAUDIO_DIRECTION_INPUT, AAUDIO_FORMAT_PCM_FLOAT, AAUDIO_FORMAT_PCM_I16,
+    AAUDIO_FORMAT_UNSPECIFIED, AAUDIO_OK, AAUDIO_PERFORMANCE_MODE_LOW_LATENCY,
+    AAUDIO_STREAM_STATE_STARTED, AAUDIO_STREAM_STATE_STARTING, AAUDIO_STREAM_STATE_STOPPING,
+    AAUDIO_UNSPECIFIED,
+};
+use super::DEFAULT_INPUT_DEVICE_ID;
+
+// ── Tuning constants ─────────────────────────────────────────────────────
+
+/// Floor for the i16→f32 conversion scratch, in **frames**. AAudio callback
+/// periods are typically one burst (≈ 96–1024 frames); this floor plus the
+/// half-second sizing below leaves generous headroom so a legitimate period
+/// can never force a callback-time allocation (ADR-0001: oversized periods
+/// are dropped + counted, never allocated for).
+const SCRATCH_MIN_FRAMES: usize = 4096;
+
+/// Sizes the i16→f32 conversion scratch, in `f32` samples: half a second of
+/// audio at the delivered rate (with [`SCRATCH_MIN_FRAMES`] as the floor),
+/// times the channel count. One-time cost at 48 kHz stereo: 48 000 × 4 B ≈
+/// 192 KiB — allocated on the setup thread, never in the callback.
+fn scratch_capacity_samples(sample_rate: u32, channels: u16) -> usize {
+    ((sample_rate as usize) / 2).max(SCRATCH_MIN_FRAMES) * usize::from(channels.max(1))
+}
+
+// ── Sample conversion (pure logic, unit-tested) ──────────────────────────
+
+/// Converts one signed 16-bit PCM sample to rsac's canonical `f32` range.
+///
+/// Divides by 32768 (`-i16::MIN`), so `i16::MIN` maps to exactly `-1.0` and
+/// `i16::MAX` to `32767/32768` — the conventional asymmetric mapping used
+/// across audio stacks. Pure integer→float math: no allocation, no panic.
+#[inline]
+fn i16_sample_to_f32(sample: i16) -> f32 {
+    f32::from(sample) / 32768.0
+}
+
+/// Converts an interleaved i16 slice into `dst` as f32, **without ever
+/// growing `dst`'s capacity** (ADR-0001: refusing beats reallocating on the
+/// callback thread).
+///
+/// Returns `false` — leaving `dst` untouched and performing no allocation —
+/// when `src.len()` exceeds `dst.capacity()`; the caller drops + counts the
+/// period instead. Returns `true` after clearing and filling `dst` with
+/// exactly `src.len()` converted samples.
+fn convert_i16_to_f32_into(src: &[i16], dst: &mut Vec<f32>) -> bool {
+    if src.len() > dst.capacity() {
+        return false;
+    }
+    dst.clear();
+    // Capacity was checked above, so this extend never reallocates.
+    dst.extend(src.iter().map(|&s| i16_sample_to_f32(s)));
+    true
+}
+
+// ── Callback contexts ────────────────────────────────────────────────────
+
+/// State owned by the **data** callback (leaked `Box`; see the module docs'
+/// ownership dance).
+///
+/// Accessed as `&mut` from the AAudio data-callback thread only: AAudio
+/// serializes data callbacks per stream, nothing else touches this between
+/// `requestStart` and the post-`close` reclamation, so the exclusive access
+/// is sound without a lock (which the RT context forbids anyway, ADR-0001).
+struct DataCallbackContext {
+    /// Producer half of the lock-free bridge; pushes are alloc-free in
+    /// steady state (free-list return ring, ADR-0001) and panic-guarded
+    /// (foreign C-callback boundary).
+    producer: BridgeProducer,
+    /// Delivered channel count (read back from the open stream).
+    channels: u16,
+    /// Delivered sample rate in Hz (read back from the open stream).
+    sample_rate: u32,
+    /// Delivered sample format code (`AAUDIO_FORMAT_PCM_FLOAT` or
+    /// `AAUDIO_FORMAT_PCM_I16`, validated at open).
+    format: aaudio_format_t,
+    /// Pre-allocated i16→f32 conversion buffer — never grown in the
+    /// callback. Left empty (capacity 0) for f32-delivery streams, which
+    /// push the incoming slice directly.
+    scratch: Vec<f32>,
+}
+
+/// State owned by the **error** callback (separate leaked `Box`, so the
+/// error thread never aliases the data callback's `&mut` context).
+///
+/// Holds only thread-safe handles: everything the disconnect path needs to
+/// drive the bridge terminal (ADR-0010) and flip the liveness flag.
+struct ErrorCallbackContext {
+    /// Bridge shared state — used to force the terminal `Error` state and
+    /// wake parked readers (the `signal_error` semantics; the producer
+    /// itself lives in the data context).
+    shared: Arc<BridgeShared>,
+    /// Liveness flag shared with [`AndroidPlatformStream`]; cleared so
+    /// `is_active()` reflects the disconnect.
+    is_active: Arc<AtomicBool>,
+}
+
+/// Counts one producer-side dropped buffer **without pushing** (the period
+/// never reached the ring — e.g. an oversized i16 period or an unexpected
+/// format code).
+///
+/// Mirrors the accounting of `push_or_drop`'s drop arm on the shared bridge
+/// counters, so the loss is visible through `overrun_count()` /
+/// `buffers_dropped()` exactly like an ordinary ring-overflow drop.
+/// Lock-free `Relaxed` adds — safe on the RT callback thread (same helper
+/// shape as the iOS backend's `count_external_drop`).
+fn count_external_drop(producer: &BridgeProducer) {
+    let shared = producer.shared();
+    shared.buffers_dropped.fetch_add(1, Ordering::Relaxed);
+    shared.consecutive_drops.fetch_add(1, Ordering::Relaxed);
+}
+
+// ── extern "C" callbacks ─────────────────────────────────────────────────
+
+/// AAudio data callback: pushes each captured period into the bridge.
+///
+/// Runs on AAudio's callback thread — **potentially real-time** (the stream
+/// requests `LOW_LATENCY`), so the full ADR-0001 rules apply: no allocation
+/// (pre-sized scratch, free-list-backed push), no locks, no logging, and no
+/// panic may escape (the push is `push_samples_guarded_stamped`; everything
+/// around it is panic-free by construction — checked arithmetic, no
+/// indexing, no growth).
+///
+/// # Safety
+///
+/// Invoked only by AAudio with the contract registered at build time:
+/// `user_data` is the leaked [`DataCallbackContext`] (valid until the
+/// post-close reclamation, and never aliased — AAudio serializes data
+/// callbacks and the setup/teardown paths only touch the context while no
+/// callback can run); `audio_data` points at `num_frames` frames of
+/// interleaved samples in the stream's delivered format, valid for the
+/// duration of the call.
+unsafe extern "C" fn data_callback(
+    _stream: *mut AAudioStream,
+    user_data: *mut c_void,
+    audio_data: *mut c_void,
+    num_frames: i32,
+) -> aaudio_data_callback_result_t {
+    if user_data.is_null() {
+        // No context — nothing can be delivered; stop the callback stream.
+        return AAUDIO_CALLBACK_RESULT_STOP;
+    }
+    // SAFETY: `user_data` is the leaked `Box<DataCallbackContext>` registered
+    // at build time; it stays valid until reclaimed after `AAudioStream_close`
+    // (which cannot race this call — close returns only once callbacks have
+    // ceased). Exclusive `&mut` access is sound because AAudio serializes
+    // data callbacks and no other code touches the context while the stream
+    // is started (see the module-docs ownership dance).
+    let ctx = unsafe { &mut *user_data.cast::<DataCallbackContext>() };
+
+    // Once the bridge is terminal (explicit stop raced us, or the error
+    // callback already poisoned the stream), tell AAudio to stop invoking
+    // us. A single Relaxed-class atomic load — RT-safe.
+    if ctx.producer.shared().state.is_terminal() {
+        return AAUDIO_CALLBACK_RESULT_STOP;
+    }
+
+    if audio_data.is_null() || num_frames <= 0 {
+        // Degenerate delivery; nothing to push this period.
+        return AAUDIO_CALLBACK_RESULT_CONTINUE;
+    }
+
+    // `num_frames > 0` was checked, so the cast is lossless; the multiply is
+    // checked so a pathological frame count can never produce a wrong slice
+    // length (which would be UB), even on 32-bit targets.
+    let frames = num_frames as usize;
+    let samples = match frames.checked_mul(usize::from(ctx.channels)) {
+        Some(n) => n,
+        None => {
+            count_external_drop(&ctx.producer);
+            return AAUDIO_CALLBACK_RESULT_CONTINUE;
+        }
+    };
+
+    match ctx.format {
+        AAUDIO_FORMAT_PCM_FLOAT => {
+            // SAFETY: for a PCM_FLOAT stream, `audio_data` points at
+            // `num_frames * channels` valid, suitably-aligned f32 samples for
+            // the duration of this call (AAudio delivery contract); every bit
+            // pattern is a valid f32. The slice is read-only and not retained
+            // past the call.
+            let data = unsafe { std::slice::from_raw_parts(audio_data.cast::<f32>(), samples) };
+            // Guarded (foreign C frame — unwind would be UB) + stream-position
+            // stamped push. Ring-full ⇒ drop + count inside the producer;
+            // never blocks, never allocates in steady state (ADR-0001).
+            ctx.producer
+                .push_samples_guarded_stamped(data, ctx.channels, ctx.sample_rate);
+        }
+        AAUDIO_FORMAT_PCM_I16 => {
+            // SAFETY: for a PCM_I16 stream, `audio_data` points at
+            // `num_frames * channels` valid, suitably-aligned i16 samples for
+            // the duration of this call (AAudio delivery contract).
+            let data = unsafe { std::slice::from_raw_parts(audio_data.cast::<i16>(), samples) };
+            if convert_i16_to_f32_into(data, &mut ctx.scratch) {
+                ctx.producer.push_samples_guarded_stamped(
+                    &ctx.scratch,
+                    ctx.channels,
+                    ctx.sample_rate,
+                );
+            } else {
+                // Period larger than the pre-sized scratch: drop + count
+                // instead of allocating (ADR-0001). No logging here — this
+                // may be an RT thread.
+                count_external_drop(&ctx.producer);
+            }
+        }
+        _ => {
+            // Unreachable in practice: the format was validated right after
+            // open and AAudio never changes it mid-stream. Count the loss
+            // (visible via overrun_count) rather than silently spinning; no
+            // logging on the RT thread.
+            count_external_drop(&ctx.producer);
+        }
+    }
+
+    AAUDIO_CALLBACK_RESULT_CONTINUE
+}
+
+/// AAudio error callback: the stream can no longer deliver audio (device
+/// disconnect — `AAUDIO_ERROR_DISCONNECTED` = -899 — service death, …).
+///
+/// Runs on a dedicated **non-real-time** thread AAudio creates for error
+/// delivery. Drives the bridge to the terminal `Error` state (the
+/// `signal_error` semantics — ADR-0010's "producer died" contract) so a
+/// parked reader observes the Fatal `StreamEnded` instead of hanging, and
+/// clears the liveness flag so `is_active()` reflects the death. The stream
+/// handle itself is still closed later by `stop_capture`/`Drop` (AAudio
+/// forbids closing from inside the callback).
+///
+/// # Safety
+///
+/// Invoked only by AAudio with `user_data` = the leaked
+/// [`ErrorCallbackContext`] registered at build time, valid until reclaimed
+/// after `AAudioStream_close`. Only `Send + Sync` handles are touched
+/// (atomics + `Arc`), so the cross-thread shared access is sound.
+unsafe extern "C" fn error_callback(
+    _stream: *mut AAudioStream,
+    user_data: *mut c_void,
+    error: aaudio_result_t,
+) {
+    if user_data.is_null() {
+        return;
+    }
+    // SAFETY: see the function-level Safety section — leaked, live context;
+    // shared (&) access to Sync fields only.
+    let ctx = unsafe { &*user_data.cast::<ErrorCallbackContext>() };
+
+    ctx.is_active.store(false, Ordering::SeqCst);
+
+    // Terminal poison (ADR-0010, fatal sibling of signal_done): force the
+    // sticky terminal Error and wake both reader kinds. Lock-free-to-signal
+    // and alloc-free — the same tail signal_error() produces; replicated via
+    // the shared handle because the BridgeProducer lives in the data
+    // context (mirrors the macOS DeviceIsAlive listener).
+    ctx.shared.state.force_set(StreamState::Error);
+    ctx.shared.notify_wake();
+    #[cfg(feature = "async-stream")]
+    ctx.shared.waker.wake();
+
+    // Diagnostics last, and unwind-contained: this is a foreign C frame, so
+    // even a pathological panicking logger must not unwind into AAudio (UB).
+    let _ = std::panic::catch_unwind(|| {
+        log::warn!(
+            "AAudio error callback: stream can no longer deliver audio \
+             ({} / {}); bridge driven to terminal Error (ADR-0010)",
+            result_name(error),
+            error
+        );
+    });
+}
+
+// Compile-time guarantee that the leaked data context may be handed to
+// AAudio's callback thread (it is constructed on the setup thread and used
+// on the callback thread — a cross-thread move).
+fn _assert_data_callback_context_send() {
+    fn _assert<T: Send>() {}
+    _assert::<DataCallbackContext>();
+}
+
+// The error context is *shared* with (not moved to) the error thread.
+fn _assert_error_callback_context_send_sync() {
+    fn _assert<T: Send + Sync>() {}
+    _assert::<ErrorCallbackContext>();
+}
+
+// ── Target resolution (mic-only slice) ───────────────────────────────────
+
+/// Returns `true` if a [`CaptureTarget::Device`] id selects the single
+/// logical Android input device.
+///
+/// Accepts [`DEFAULT_INPUT_DEVICE_ID`] case-insensitively, plus the empty
+/// string (the "default endpoint" convention shared with the Windows and
+/// iOS backends).
+fn is_default_input_id(id: &str) -> bool {
+    id.is_empty() || id.eq_ignore_ascii_case(DEFAULT_INPUT_DEVICE_ID)
+}
+
+/// Validates a [`CaptureTarget`] against the Android **mic slice**
+/// (ADR-0013).
+///
+/// | Target | Outcome |
+/// |---|---|
+/// | `Device("default")` (or `""`) | `Ok(())` — the default AAudio input |
+/// | `Device(other)` | [`AudioError::DeviceNotFound`] — real input-device ids need the Java `AudioManager` list (rsac-c4b8) |
+/// | `SystemDefault` | [`AudioError::PlatformNotSupported`] — **pending** rsac-77f1: on Android this means playback capture (`AudioPlaybackCapture`), **not** the microphone |
+/// | `Application` / `ApplicationByName` / `ProcessTree` | [`AudioError::PlatformNotSupported`] — **pending** rsac-77f1 (UID-filtered playback capture + MediaProjection consent; tree ≡ app on Android) |
+///
+/// The match is intentionally exhaustive (no wildcard): a new
+/// `CaptureTarget` variant must be classified here before the crate
+/// compiles for Android.
+fn ensure_mic_target(target: &CaptureTarget) -> AudioResult<()> {
+    match target {
+        CaptureTarget::Device(id) if is_default_input_id(&id.0) => Ok(()),
+        CaptureTarget::Device(id) => Err(AudioError::DeviceNotFound {
+            device_id: id.0.clone(),
+        }),
+        CaptureTarget::SystemDefault => Err(AudioError::PlatformNotSupported {
+            feature: "system-audio capture on Android: SystemDefault maps to \
+                      AudioPlaybackCapture — all capturable playback, NOT the \
+                      microphone (ADR-0013) — and is not wired yet (rsac-77f1, \
+                      MediaProjection consent flow). Supported today: the \
+                      default AAudio input (microphone) via \
+                      CaptureTarget::Device(DeviceId(\"default\".into()))"
+                .to_string(),
+            platform: "android".to_string(),
+        }),
+        CaptureTarget::Application(_)
+        | CaptureTarget::ApplicationByName(_)
+        | CaptureTarget::ProcessTree(_) => Err(AudioError::PlatformNotSupported {
+            feature: "per-application / process-tree capture on Android: these \
+                      map to AudioPlaybackCapture UID filters (ADR-0013; all of \
+                      an Android app's processes share one UID, so tree ≡ app) \
+                      and arrive with the MediaProjection consent flow \
+                      (rsac-77f1). Supported today: the default AAudio input \
+                      (microphone) via \
+                      CaptureTarget::Device(DeviceId(\"default\".into()))"
+                .to_string(),
+            platform: "android".to_string(),
+        }),
+    }
+}
+
+// ── AndroidPlatformStream ────────────────────────────────────────────────
+
+/// Raw AAudio handles for one capture stream, serialized by the `Mutex` in
+/// [`AndroidPlatformStream`].
+///
+/// All three pointers are nulled as they are released, which is both the
+/// idempotency guard for teardown and the double-free guard for the leaked
+/// callback contexts.
+struct StreamHandles {
+    /// The open AAudio stream; null once closed.
+    stream: *mut AAudioStream,
+    /// Leaked data-callback context; reclaimed exactly once after close.
+    data_ctx: *mut DataCallbackContext,
+    /// Leaked error-callback context; reclaimed exactly once after close.
+    error_ctx: *mut ErrorCallbackContext,
+}
+
+/// Platform-specific stream handle for Android (AAudio backend).
+///
+/// Wraps the live AAudio stream + the leaked callback contexts and
+/// implements [`PlatformStream`] so it can be used with
+/// [`BridgeStream`](crate::bridge::stream::BridgeStream).
+///
+/// # Shutdown
+///
+/// [`stop_capture`](PlatformStream::stop_capture) (and `Drop`, via the same
+/// choke point) requests stop, waits (bounded) for the callback to quiesce,
+/// closes the stream, reclaims the callback contexts, and then drives the
+/// bridge `Running → Stopping` — the graceful producer terminal signal
+/// (ADR-0010). The ordering matters: the contexts are reclaimed only after
+/// `AAudioStream_close` returns (no callback can reference them anymore),
+/// and the terminal transition happens only after the close (no callback
+/// can push past the declared end).
+pub(crate) struct AndroidPlatformStream {
+    /// Raw AAudio handles, serialized by the `Mutex` for `&self` access.
+    handles: Mutex<StreamHandles>,
+    /// `true` while the stream is delivering audio. Cleared by the teardown
+    /// choke point and by the error callback (device disconnect), so
+    /// [`is_active`](PlatformStream::is_active) reflects both.
+    is_active: Arc<AtomicBool>,
+    /// Producer-terminal-signal handle (ADR-0010): a clone of the bridge's
+    /// shared state, used to drive `Running → Stopping` (+ reader wake)
+    /// once the stream is closed.
+    terminal: Arc<BridgeShared>,
+}
+
+// SAFETY: `AndroidPlatformStream` carries raw pointers (`*mut AAudioStream`
+// and the two leaked callback-context pointers), which are not `Send`/`Sync`
+// by default — but `PlatformStream: Send` and `BridgeStream<S>: Sync`
+// require both. This is sound because:
+//
+// - every dereference/FFI use of the pointers after construction goes
+//   through the `Mutex<StreamHandles>` (only the teardown choke point
+//   touches them), so no unsynchronized concurrent use can occur;
+// - AAudio's lifecycle functions (`requestStop`/`waitForStateChange`/
+//   `close`) may be called from any thread except the stream's own
+//   callbacks — AAudio streams are not thread-safe *concurrently*, and the
+//   Mutex provides exactly the required serialization;
+// - the callback contexts are only reclaimed under that same Mutex, after
+//   `AAudioStream_close` has returned (callbacks quiesced), so a
+//   cross-thread teardown can never race a callback's access;
+// - the remaining fields (`Arc<AtomicBool>`, `Arc<BridgeShared>`) are
+//   `Send + Sync` already.
+//
+// Mirrors the `unsafe impl Send/Sync` discipline on `IosPlatformStream` /
+// `MacosPlatformStream`.
+unsafe impl Send for AndroidPlatformStream {}
+// SAFETY: see the `Send` justification above — all interior pointer access
+// is serialized by the `Mutex`.
+unsafe impl Sync for AndroidPlatformStream {}
+
+impl AndroidPlatformStream {
+    /// Stops + closes the AAudio stream (once), reclaims the callback
+    /// contexts, and signals the bridge terminal.
+    ///
+    /// Idempotent: the nulled `stream` pointer (under the `Mutex`) ensures
+    /// the FFI teardown, the context reclamation, and the terminal
+    /// transition run at most once; later calls are no-ops. Shared by
+    /// [`stop_capture`](PlatformStream::stop_capture) and `Drop` so dropping
+    /// the handle (without an explicit stop) also lands the stream terminal
+    /// (ADR-0010).
+    ///
+    /// OS-call failures on this path are logged and *not* propagated: the
+    /// teardown always runs to completion (close → reclaim → terminal), so
+    /// a failed `requestStop` can never strand a parked reader or leak the
+    /// contexts.
+    fn stop_and_close(&self) -> AudioResult<()> {
+        let mut handles = self.handles.lock().map_err(|_| AudioError::InternalError {
+            message: "AAudio stream handles mutex poisoned".to_string(),
+            source: None,
+        })?;
+
+        if handles.stream.is_null() {
+            // Already torn down — idempotent no-op.
+            return Ok(());
+        }
+        let stream = handles.stream;
+
+        // 1. Ask AAudio to stop delivering data callbacks.
+        // SAFETY: `stream` is the live stream opened by
+        // `create_android_capture`; requestStop may be called from any
+        // thread except the stream's own callbacks (we are on a consumer /
+        // drop thread), and the Mutex serializes against other teardowns.
+        let res = unsafe { AAudioStream_requestStop(stream) };
+        if res != AAUDIO_OK {
+            log::warn!(
+                "AAudioStream_requestStop failed: {} ({}); continuing teardown",
+                result_name(res),
+                res
+            );
+        }
+
+        // 2. Bounded quiesce: wait for the stream to leave the transitional
+        // states so no data callback is in flight when we close + reclaim.
+        // This matters on pre-API-30 devices, where close() alone had a
+        // documented race with in-flight callbacks (API 30 split release/
+        // close to fix it). Best-effort and bounded — never hangs teardown.
+        wait_until_quiescent(stream);
+
+        // 3. Close: releases the stream; AAudio delivers no callbacks after
+        // this returns.
+        // SAFETY: same liveness/serialization argument as requestStop; the
+        // pointer is nulled immediately after so it is never used again.
+        let res = unsafe { AAudioStream_close(stream) };
+        if res != AAUDIO_OK {
+            log::warn!(
+                "AAudioStream_close failed: {} ({}); continuing teardown",
+                result_name(res),
+                res
+            );
+        }
+        handles.stream = std::ptr::null_mut();
+
+        // 4. Reclaim the leaked callback contexts — exactly once (pointers
+        // are nulled), and only now that close has returned so no callback
+        // can reference them (the module-docs ownership dance, step 3).
+        if !handles.data_ctx.is_null() {
+            // SAFETY: `data_ctx` came from `Box::into_raw` in
+            // `create_android_capture`, has not been freed (non-null ⇒ this
+            // is the first reclamation, guarded by the Mutex), and no
+            // callback can still hold a reference (stream closed above).
+            drop(unsafe { Box::from_raw(handles.data_ctx) });
+            handles.data_ctx = std::ptr::null_mut();
+        }
+        if !handles.error_ctx.is_null() {
+            // SAFETY: same argument as `data_ctx`.
+            drop(unsafe { Box::from_raw(handles.error_ctx) });
+            handles.error_ctx = std::ptr::null_mut();
+        }
+
+        self.is_active.store(false, Ordering::SeqCst);
+
+        // 5. Producer-terminal-signal (ADR-0010): the stream is closed, so
+        // no more pushes can occur — drive the bridge to the graceful
+        // ending state (`signal_done` semantics via the shared handle;
+        // the producer itself was just reclaimed with the data context).
+        // `Running → Stopping` keeps a buffered tail drainable; the CAS
+        // no-ops if the state already advanced (e.g. `BridgeStream::stop`
+        // or the error callback got there first — terminal Error is sticky).
+        let _ = self
+            .terminal
+            .state
+            .transition(StreamState::Running, StreamState::Stopping);
+        // Wake a parked blocking reader so it observes the ending state
+        // promptly (PU-5). Non-RT stop path — the notify is allowed here
+        // (ADR-0001 forbids it only on the RT callback push path).
+        self.terminal.notify_wake();
+        #[cfg(feature = "async-stream")]
+        self.terminal.waker.wake();
+
+        Ok(())
+    }
+}
+
+impl PlatformStream for AndroidPlatformStream {
+    fn stop_capture(&self) -> AudioResult<()> {
+        self.stop_and_close()
+    }
+
+    fn is_active(&self) -> bool {
+        self.is_active.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for AndroidPlatformStream {
+    /// Deterministic shutdown: stop + close the stream (and signal the
+    /// bridge terminal) if not already done, so dropping the handle never
+    /// leaves a running callback pushing into a bridge nobody reads, a
+    /// parked reader hanging (ADR-0010), or the leaked contexts unreclaimed.
+    fn drop(&mut self) {
+        if let Err(e) = self.stop_and_close() {
+            log::warn!("AndroidPlatformStream::drop: teardown failed: {:?}", e);
+        }
+    }
+}
+
+/// Bounded wait for the stream to leave the transitional
+/// STARTING/STARTED/STOPPING states after a stop request, so the data
+/// callback is quiescent before close + context reclamation.
+///
+/// Up to 5 × 100 ms slices of [`AAudioStream_waitForStateChange`]; any
+/// error or a non-transitional state ends the wait early. Purely
+/// best-effort: teardown proceeds regardless (a warning is logged if the
+/// stream never settled).
+fn wait_until_quiescent(stream: *mut AAudioStream) {
+    /// One wait slice, in nanoseconds (100 ms).
+    const SLICE_NANOS: i64 = 100_000_000;
+    /// Maximum slices (≤ 500 ms total).
+    const MAX_SLICES: usize = 5;
+
+    // SAFETY: `stream` is live and open (caller holds the handles Mutex and
+    // has not closed it yet); getState is a trivial read.
+    let mut current = unsafe { AAudioStream_getState(stream) };
+    for _ in 0..MAX_SLICES {
+        if current != AAUDIO_STREAM_STATE_STARTING
+            && current != AAUDIO_STREAM_STATE_STARTED
+            && current != AAUDIO_STREAM_STATE_STOPPING
+        {
+            return;
+        }
+        let mut next = current;
+        // SAFETY: live stream; `next` is a valid out-pointer to a local for
+        // the duration of the call.
+        let res =
+            unsafe { AAudioStream_waitForStateChange(stream, current, &mut next, SLICE_NANOS) };
+        if res != AAUDIO_OK {
+            return;
+        }
+        current = next;
+    }
+    log::warn!(
+        "AAudio stream did not leave its transitional state within \
+         {} ms of requestStop; closing anyway",
+        (SLICE_NANOS / 1_000_000) * MAX_SLICES as i64
+    );
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────
+
+/// Reclaims the two leaked callback contexts.
+///
+/// # Safety
+///
+/// Both pointers must have come from `Box::into_raw`, must not have been
+/// freed, and **no AAudio callback may still be able to run** — i.e. the
+/// stream was never opened, or `AAudioStream_close` has returned.
+unsafe fn reclaim_contexts(
+    data_ctx: *mut DataCallbackContext,
+    error_ctx: *mut ErrorCallbackContext,
+) {
+    // SAFETY: per the function contract — unique, live Box allocations with
+    // no remaining referents.
+    drop(unsafe { Box::from_raw(data_ctx) });
+    // SAFETY: as above.
+    drop(unsafe { Box::from_raw(error_ctx) });
+}
+
+/// Best-effort close of a just-opened stream on a factory failure path,
+/// followed by context reclamation.
+///
+/// # Safety
+///
+/// `stream` must be the live stream returned by a successful
+/// `AAudioStreamBuilder_openStream` and must not be closed already; the
+/// context pointers follow the [`reclaim_contexts`] contract (which is
+/// satisfied once the close here returns).
+unsafe fn close_and_reclaim(
+    stream: *mut AAudioStream,
+    data_ctx: *mut DataCallbackContext,
+    error_ctx: *mut ErrorCallbackContext,
+) {
+    // SAFETY: live stream per the function contract; the factory abandons
+    // the pointer right after this call.
+    let res = unsafe { AAudioStream_close(stream) };
+    if res != AAUDIO_OK {
+        log::warn!(
+            "AAudioStream_close failed during error cleanup: {} ({})",
+            result_name(res),
+            res
+        );
+    }
+    // SAFETY: close returned above, so no callback can reference the
+    // contexts anymore; pointers are unique live Box allocations.
+    unsafe { reclaim_contexts(data_ctx, error_ctx) };
+}
+
+/// Opens and starts an AAudio input stream for the default audio input,
+/// returning the [`AndroidPlatformStream`] handle plus the **delivered**
+/// [`AudioFormat`].
+///
+/// Steps:
+///
+/// 1. Validate `target` against the mic slice ([`ensure_mic_target`]).
+/// 2. Leak the two callback contexts and register them on a stream builder
+///    (input direction, low-latency mode, `PCM_FLOAT` at the requested
+///    rate/channels).
+/// 3. Open the stream — if the requested shape is rejected, retry once with
+///    `AAUDIO_UNSPECIFIED` format/rate/channels so the device-native
+///    configuration is used instead of failing outright.
+/// 4. Read back the **actual** format/rate/channels via the stream getters,
+///    publish the delivered [`AudioFormat`] on the bridge
+///    (`set_negotiated_format` — before any push, so
+///    `CapturingStream::format()` is authoritative from the first buffer),
+///    and size the i16→f32 scratch from the delivered values (the only
+///    buffer allocation, done here on the setup thread — ADR-0001).
+/// 5. `AAudioStream_requestStart` — data callbacks begin.
+///
+/// The delivered rate/channels may differ from the requested ones; this
+/// backend does not resample (the honest contract shared with the iOS mic
+/// slice). `sample_format` is always reported as `F32`: the bridge payload
+/// is interleaved f32 regardless of AAudio's wire format (i16 delivery is
+/// converted in the callback).
+///
+/// # Errors
+///
+/// - Target errors per [`ensure_mic_target`].
+/// - [`AudioError::BackendError`] if the builder cannot be created.
+/// - [`AudioError::StreamCreationFailed`] if both open attempts fail
+///   (commonly: the `RECORD_AUDIO` runtime permission has not been granted
+///   — a host-app responsibility; rsac's `mobile/android` helpers wrap the
+///   request flow) or the delivered configuration is unusable.
+/// - [`AudioError::StreamStartFailed`] if `requestStart` fails.
+///
+/// All failure paths close the stream (when open) and reclaim the leaked
+/// contexts — nothing leaks on error.
+pub(crate) fn create_android_capture(
+    target: &CaptureTarget,
+    requested: &AudioFormat,
+    producer: BridgeProducer,
+    terminal: Arc<BridgeShared>,
+) -> AudioResult<(AndroidPlatformStream, AudioFormat)> {
+    ensure_mic_target(target)?;
+
+    let is_active = Arc::new(AtomicBool::new(true));
+
+    // Leak the callback contexts (ownership-dance step 1). The data
+    // context's delivered-format fields and scratch are placeholders until
+    // step 4 below — no callback can run before requestStart.
+    let data_ctx: *mut DataCallbackContext = Box::into_raw(Box::new(DataCallbackContext {
+        producer,
+        channels: requested.channels.max(1),
+        sample_rate: requested.sample_rate.max(1),
+        format: AAUDIO_FORMAT_PCM_FLOAT,
+        scratch: Vec::new(),
+    }));
+    let error_ctx: *mut ErrorCallbackContext = Box::into_raw(Box::new(ErrorCallbackContext {
+        shared: Arc::clone(&terminal),
+        is_active: Arc::clone(&is_active),
+    }));
+
+    // ── Builder ──────────────────────────────────────────────────────
+    let mut builder: *mut AAudioStreamBuilder = std::ptr::null_mut();
+    // SAFETY: `builder` is a valid out-pointer to a local.
+    let res = unsafe { AAudio_createStreamBuilder(&mut builder) };
+    if res != AAUDIO_OK || builder.is_null() {
+        // SAFETY: no stream was opened, so no callback ever ran — the
+        // contexts have no referents.
+        unsafe { reclaim_contexts(data_ctx, error_ctx) };
+        return Err(result_to_error("AAudio_createStreamBuilder", res));
+    }
+
+    // ── Configure: input, low-latency, FLOAT at the requested shape ──
+    // SAFETY: `builder` is the live builder created above; the setters are
+    // simple field writes. The callback function pointers match the
+    // registered typedefs, and the user_data pointers are the leaked
+    // contexts, valid for the stream's whole lifetime (ownership dance).
+    unsafe {
+        AAudioStreamBuilder_setDirection(builder, AAUDIO_DIRECTION_INPUT);
+        AAudioStreamBuilder_setPerformanceMode(builder, AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
+        AAudioStreamBuilder_setFormat(builder, AAUDIO_FORMAT_PCM_FLOAT);
+        AAudioStreamBuilder_setSampleRate(
+            builder,
+            requested.sample_rate.min(i32::MAX as u32) as i32,
+        );
+        AAudioStreamBuilder_setChannelCount(builder, i32::from(requested.channels));
+        AAudioStreamBuilder_setDataCallback(
+            builder,
+            Some(data_callback),
+            data_ctx.cast::<c_void>(),
+        );
+        AAudioStreamBuilder_setErrorCallback(
+            builder,
+            Some(error_callback),
+            error_ctx.cast::<c_void>(),
+        );
+    }
+
+    // ── Open (attempt 1: requested shape; attempt 2: device-native) ──
+    let mut stream: *mut AAudioStream = std::ptr::null_mut();
+    // SAFETY: live builder; `stream` is a valid out-pointer to a local.
+    let mut res = unsafe { AAudioStreamBuilder_openStream(builder, &mut stream) };
+    if res != AAUDIO_OK || stream.is_null() {
+        log::debug!(
+            "AAudio open with requested shape ({} Hz, {} ch, PCM_FLOAT) failed: \
+             {} ({}); retrying with device-native settings",
+            requested.sample_rate,
+            requested.channels,
+            result_name(res),
+            res
+        );
+        stream = std::ptr::null_mut();
+        // SAFETY: live builder; overwriting the previous requests with the
+        // UNSPECIFIED sentinels ("let AAudio choose").
+        unsafe {
+            AAudioStreamBuilder_setFormat(builder, AAUDIO_FORMAT_UNSPECIFIED);
+            AAudioStreamBuilder_setSampleRate(builder, AAUDIO_UNSPECIFIED);
+            AAudioStreamBuilder_setChannelCount(builder, AAUDIO_UNSPECIFIED);
+        }
+        // SAFETY: as the first attempt.
+        res = unsafe { AAudioStreamBuilder_openStream(builder, &mut stream) };
+    }
+
+    // The builder is no longer needed once the stream is open (or has
+    // definitively failed to open).
+    // SAFETY: live builder created above; not used after this call.
+    let del_res = unsafe { AAudioStreamBuilder_delete(builder) };
+    if del_res != AAUDIO_OK {
+        log::warn!(
+            "AAudioStreamBuilder_delete failed: {} ({})",
+            result_name(del_res),
+            del_res
+        );
+    }
+
+    if res != AAUDIO_OK || stream.is_null() {
+        // SAFETY: no stream is open (both attempts failed), so no callback
+        // ever ran — the contexts have no referents.
+        unsafe { reclaim_contexts(data_ctx, error_ctx) };
+        return Err(AudioError::StreamCreationFailed {
+            reason: format!(
+                "AAudioStreamBuilder_openStream failed for the default audio \
+                 input: {} ({}). Common causes: the RECORD_AUDIO runtime \
+                 permission has not been granted (a HOST-APP responsibility — \
+                 rsac's mobile/android helpers wrap the request flow), or no \
+                 audio input device is available on this device/emulator",
+                result_name(res),
+                res
+            ),
+            context: Some(BackendContext {
+                backend_name: "AAudio".to_string(),
+                os_error_code: Some(i64::from(res)),
+                os_error_message: Some(result_name(res).to_string()),
+            }),
+        });
+    }
+
+    // ── Read back the REAL delivered configuration ───────────────────
+    // SAFETY: `stream` is the live stream opened above; the getters are
+    // trivial reads valid on an open stream.
+    let delivered_format = unsafe { AAudioStream_getFormat(stream) };
+    // SAFETY: as above.
+    let delivered_rate = unsafe { AAudioStream_getSampleRate(stream) };
+    // SAFETY: as above.
+    let delivered_channels = unsafe { AAudioStream_getChannelCount(stream) };
+
+    let format_ok =
+        delivered_format == AAUDIO_FORMAT_PCM_FLOAT || delivered_format == AAUDIO_FORMAT_PCM_I16;
+    if !format_ok || delivered_rate <= 0 || !(1..=i32::from(u16::MAX)).contains(&delivered_channels)
+    {
+        // SAFETY: stream is live and unclosed; contexts follow the
+        // ownership dance (close inside quiesces the callbacks first).
+        unsafe { close_and_reclaim(stream, data_ctx, error_ctx) };
+        return Err(AudioError::StreamCreationFailed {
+            reason: format!(
+                "AAudio delivered an unusable stream configuration \
+                 (format code {}, {} Hz, {} ch); expected PCM_FLOAT or \
+                 PCM_I16 with positive rate/channels",
+                delivered_format, delivered_rate, delivered_channels
+            ),
+            context: None,
+        });
+    }
+
+    let delivered = AudioFormat {
+        sample_rate: delivered_rate as u32,
+        // Range-checked above.
+        channels: delivered_channels as u16,
+        // The bridge payload is ALWAYS interleaved f32 (i16 delivery is
+        // converted in the callback), so F32 is the honest report.
+        sample_format: SampleFormat::F32,
+    };
+
+    // ── Complete the data context (ownership-dance step 2) ───────────
+    // SAFETY: between openStream and requestStart AAudio delivers no data
+    // callbacks, so this thread has exclusive access to the leaked context;
+    // the error callback uses its own separate context and never touches
+    // this one.
+    unsafe {
+        let ctx = &mut *data_ctx;
+        ctx.channels = delivered.channels;
+        ctx.sample_rate = delivered.sample_rate;
+        ctx.format = delivered_format;
+        // Pre-allocate the i16→f32 scratch from the DELIVERED shape
+        // (ADR-0001: the only buffer allocation, on the setup thread). The
+        // f32 path pushes the incoming slice directly and needs no scratch.
+        ctx.scratch = if delivered_format == AAUDIO_FORMAT_PCM_I16 {
+            Vec::with_capacity(scratch_capacity_samples(
+                delivered.sample_rate,
+                delivered.channels,
+            ))
+        } else {
+            Vec::new()
+        };
+        // Publish the delivery format BEFORE any push so readers never see
+        // the requested-format fallback once data flows (M1 pattern).
+        ctx.producer.set_negotiated_format(&delivered);
+    }
+
+    // ── Start ────────────────────────────────────────────────────────
+    // SAFETY: live, open stream; requestStart may be called from this
+    // (setup) thread.
+    let res = unsafe { AAudioStream_requestStart(stream) };
+    if res != AAUDIO_OK {
+        // SAFETY: stream is live and unclosed; close_and_reclaim quiesces
+        // and frees everything.
+        unsafe { close_and_reclaim(stream, data_ctx, error_ctx) };
+        return Err(AudioError::StreamStartFailed {
+            reason: format!(
+                "AAudioStream_requestStart failed: {} ({})",
+                result_name(res),
+                res
+            ),
+        });
+    }
+
+    log::debug!(
+        "AAudio: capture started (target={:?}, delivered {} Hz, {} ch, \
+         wire format code {})",
+        target,
+        delivered.sample_rate,
+        delivered.channels,
+        delivered_format
+    );
+
+    Ok((
+        AndroidPlatformStream {
+            handles: Mutex::new(StreamHandles {
+                stream,
+                data_ctx,
+                error_ctx,
+            }),
+            is_active,
+            terminal,
+        },
+        delivered,
+    ))
+}
+
+// ── Compile-time assertions ──────────────────────────────────────────────
+
+/// Assert that `AndroidPlatformStream` is `Send + Sync` (required by
+/// `PlatformStream` and `BridgeStream<S>`).
+fn _assert_android_platform_stream_send_sync() {
+    fn _assert<T: Send + Sync>() {}
+    _assert::<AndroidPlatformStream>();
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// Tests — pure logic only (no FFI): sample conversion, scratch sizing, and
+// target classification. They compile for the Android target under `--tests`
+// and will run on a future emulator job.
+// ══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::{ApplicationId, DeviceId, ProcessId};
+    use crate::core::error::ErrorKind;
+
+    // ── i16 → f32 conversion ─────────────────────────────────────────
+
+    #[test]
+    fn i16_conversion_maps_the_canonical_anchor_points() {
+        assert_eq!(i16_sample_to_f32(0), 0.0);
+        assert_eq!(i16_sample_to_f32(i16::MIN), -1.0);
+        assert_eq!(i16_sample_to_f32(i16::MAX), 32_767.0 / 32_768.0);
+        assert_eq!(i16_sample_to_f32(16_384), 0.5);
+        assert_eq!(i16_sample_to_f32(-16_384), -0.5);
+    }
+
+    #[test]
+    fn i16_conversion_output_is_always_in_unit_range() {
+        for s in [i16::MIN, -1, 0, 1, i16::MAX, 12_345, -12_345] {
+            let f = i16_sample_to_f32(s);
+            assert!((-1.0..=1.0).contains(&f), "{s} mapped out of range: {f}");
+        }
+    }
+
+    #[test]
+    fn convert_into_fills_dst_in_order() {
+        let src = [0i16, i16::MIN, i16::MAX, 16_384];
+        let mut dst = Vec::with_capacity(4);
+        assert!(convert_i16_to_f32_into(&src, &mut dst));
+        assert_eq!(dst, vec![0.0, -1.0, 32_767.0 / 32_768.0, 0.5]);
+    }
+
+    #[test]
+    fn convert_into_refuses_to_grow_dst() {
+        // Capacity 2 but 4 samples offered → must return false and must NOT
+        // reallocate (ADR-0001: drop, don't allocate).
+        let src = [1i16, 2, 3, 4];
+        let mut dst: Vec<f32> = Vec::with_capacity(2);
+        let cap_before = dst.capacity();
+        assert!(!convert_i16_to_f32_into(&src, &mut dst));
+        assert_eq!(dst.capacity(), cap_before, "capacity must be untouched");
+    }
+
+    #[test]
+    fn convert_into_clears_previous_contents() {
+        let mut dst = Vec::with_capacity(8);
+        assert!(convert_i16_to_f32_into(&[i16::MAX; 8], &mut dst));
+        assert_eq!(dst.len(), 8);
+        // A smaller follow-up period must fully replace, not append.
+        assert!(convert_i16_to_f32_into(&[0i16, 0], &mut dst));
+        assert_eq!(dst, vec![0.0, 0.0]);
+    }
+
+    #[test]
+    fn convert_into_handles_empty_input() {
+        let mut dst: Vec<f32> = Vec::new(); // capacity 0 is still >= 0 needed
+        assert!(convert_i16_to_f32_into(&[], &mut dst));
+        assert!(dst.is_empty());
+    }
+
+    // ── Scratch sizing ───────────────────────────────────────────────
+
+    #[test]
+    fn scratch_capacity_covers_generous_periods_at_common_rates() {
+        for (rate, ch) in [(48_000u32, 2u16), (44_100, 1), (96_000, 2), (8_000, 1)] {
+            let cap = scratch_capacity_samples(rate, ch);
+            // At least the frame floor…
+            assert!(cap >= SCRATCH_MIN_FRAMES * usize::from(ch));
+            // …and at least 400 ms of audio at the delivered rate (we size
+            // to 500 ms), far above any realistic AAudio burst.
+            let worst_case_400ms = (rate as usize * 2 / 5) * usize::from(ch);
+            assert!(
+                cap >= worst_case_400ms,
+                "scratch for {rate} Hz x {ch} ch ({cap}) must cover a 400 ms \
+                 period ({worst_case_400ms})"
+            );
+        }
+    }
+
+    #[test]
+    fn scratch_capacity_guards_degenerate_channel_count() {
+        // channels == 0 is clamped to 1, never a zero-sized scratch.
+        assert!(scratch_capacity_samples(48_000, 0) >= SCRATCH_MIN_FRAMES);
+    }
+
+    // ── Target classification (mic slice, ADR-0013) ──────────────────
+
+    #[test]
+    fn default_device_ids_are_accepted() {
+        for id in ["default", "DEFAULT", "Default", ""] {
+            let target = CaptureTarget::Device(DeviceId(id.to_string()));
+            assert!(
+                ensure_mic_target(&target).is_ok(),
+                "id {id:?} must select the mic"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_device_id_is_device_not_found() {
+        let target = CaptureTarget::Device(DeviceId("17".to_string()));
+        match ensure_mic_target(&target).unwrap_err() {
+            AudioError::DeviceNotFound { device_id } => assert_eq!(device_id, "17"),
+            other => panic!("expected DeviceNotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn system_default_is_pending_playback_capture_not_the_mic() {
+        let err = ensure_mic_target(&CaptureTarget::SystemDefault).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Platform);
+        match err {
+            AudioError::PlatformNotSupported { feature, platform } => {
+                assert_eq!(platform, "android");
+                // The honesty pillars: what SystemDefault really means, which
+                // seed delivers it, and what works today.
+                assert!(
+                    feature.contains("AudioPlaybackCapture"),
+                    "real meaning: {feature}"
+                );
+                assert!(feature.contains("NOT the"), "not-the-mic: {feature}");
+                assert!(feature.contains("rsac-77f1"), "pending seed: {feature}");
+                assert!(
+                    feature.contains("Device(DeviceId(\"default\""),
+                    "mic guidance: {feature}"
+                );
+            }
+            other => panic!("expected PlatformNotSupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn per_app_targets_are_pending_not_permanent() {
+        let targets = [
+            CaptureTarget::Application(ApplicationId("1234".to_string())),
+            CaptureTarget::ApplicationByName("com.example.app".to_string()),
+            CaptureTarget::ProcessTree(ProcessId(1234)),
+        ];
+        for target in targets {
+            match ensure_mic_target(&target).unwrap_err() {
+                AudioError::PlatformNotSupported { feature, platform } => {
+                    assert_eq!(platform, "android");
+                    assert!(
+                        feature.contains("rsac-77f1"),
+                        "must name the delivering seed for {target:?}: {feature}"
+                    );
+                    assert!(
+                        feature.contains("tree ≡ app"),
+                        "must document the UID equivalence for {target:?}: {feature}"
+                    );
+                    assert!(
+                        !feature.contains("permanent"),
+                        "Android playback capture is PENDING, never permanent \
+                         ({target:?}): {feature}"
+                    );
+                }
+                other => panic!("expected PlatformNotSupported for {target:?}, got {other:?}"),
+            }
+        }
+    }
+}

--- a/src/audio/android/thread.rs
+++ b/src/audio/android/thread.rs
@@ -104,7 +104,7 @@ const SCRATCH_MIN_FRAMES: usize = 4096;
 /// audio at the delivered rate (with [`SCRATCH_MIN_FRAMES`] as the floor),
 /// times the channel count. One-time cost at 48 kHz stereo: 48 000 × 4 B ≈
 /// 192 KiB — allocated on the setup thread, never in the callback.
-fn scratch_capacity_samples(sample_rate: u32, channels: u16) -> usize {
+pub(super) fn scratch_capacity_samples(sample_rate: u32, channels: u16) -> usize {
     ((sample_rate as usize) / 2).max(SCRATCH_MIN_FRAMES) * usize::from(channels.max(1))
 }
 
@@ -188,8 +188,10 @@ struct ErrorCallbackContext {
 /// counters, so the loss is visible through `overrun_count()` /
 /// `buffers_dropped()` exactly like an ordinary ring-overflow drop.
 /// Lock-free `Relaxed` adds — safe on the RT callback thread (same helper
-/// shape as the iOS backend's `count_external_drop`).
-fn count_external_drop(producer: &BridgeProducer) {
+/// shape as the iOS backend's `count_external_drop`). Shared with the JNI
+/// playback-ingest path (`jni.rs`), which applies the same accounting to
+/// periods that never reach the ring.
+pub(super) fn count_external_drop(producer: &BridgeProducer) {
     let shared = producer.shared();
     shared.buffers_dropped.fetch_add(1, Ordering::Relaxed);
     shared.consecutive_drops.fetch_add(1, Ordering::Relaxed);
@@ -386,9 +388,9 @@ fn is_default_input_id(id: &str) -> bool {
 /// | Target | Outcome |
 /// |---|---|
 /// | `Device("default")` (or `""`) | `Ok(())` — the default AAudio input |
-/// | `Device(other)` | [`AudioError::DeviceNotFound`] — real input-device ids need the Java `AudioManager` list (rsac-c4b8) |
-/// | `SystemDefault` | [`AudioError::PlatformNotSupported`] — **pending** rsac-77f1: on Android this means playback capture (`AudioPlaybackCapture`), **not** the microphone |
-/// | `Application` / `ApplicationByName` / `ProcessTree` | [`AudioError::PlatformNotSupported`] — **pending** rsac-77f1 (UID-filtered playback capture + MediaProjection consent; tree ≡ app on Android) |
+/// | `Device(other)` | [`AudioError::DeviceNotFound`] — real input-device ids need the Java `AudioManager` list (rsac-ad8a) |
+/// | `SystemDefault` | [`AudioError::PlatformNotSupported`] — served by the **playback-capture device** (`super::playback`, rsac-77f1), not the mic |
+/// | `Application` / `ApplicationByName` / `ProcessTree` | [`AudioError::PlatformNotSupported`] — served by the playback-capture device (UID-filtered `AudioPlaybackCapture`; tree ≡ app on Android) |
 ///
 /// The match is intentionally exhaustive (no wildcard): a new
 /// `CaptureTarget` variant must be classified here before the crate
@@ -400,24 +402,25 @@ fn ensure_mic_target(target: &CaptureTarget) -> AudioResult<()> {
             device_id: id.0.clone(),
         }),
         CaptureTarget::SystemDefault => Err(AudioError::PlatformNotSupported {
-            feature: "system-audio capture on Android: SystemDefault maps to \
-                      AudioPlaybackCapture — all capturable playback, NOT the \
-                      microphone (ADR-0013) — and is not wired yet (rsac-77f1, \
-                      MediaProjection consent flow). Supported today: the \
-                      default AAudio input (microphone) via \
-                      CaptureTarget::Device(DeviceId(\"default\".into()))"
+            feature: "system-audio capture through the Android microphone \
+                      device: SystemDefault maps to AudioPlaybackCapture — all \
+                      capturable playback, NOT the microphone (ADR-0013) — and \
+                      is served by the playback-capture device \
+                      (CaptureTarget::SystemDefault resolves there via \
+                      default_device(); this mic device only serves \
+                      CaptureTarget::Device(DeviceId(\"default\".into())))"
                 .to_string(),
             platform: "android".to_string(),
         }),
         CaptureTarget::Application(_)
         | CaptureTarget::ApplicationByName(_)
         | CaptureTarget::ProcessTree(_) => Err(AudioError::PlatformNotSupported {
-            feature: "per-application / process-tree capture on Android: these \
-                      map to AudioPlaybackCapture UID filters (ADR-0013; all of \
-                      an Android app's processes share one UID, so tree ≡ app) \
-                      and arrive with the MediaProjection consent flow \
-                      (rsac-77f1). Supported today: the default AAudio input \
-                      (microphone) via \
+            feature: "per-application / process-tree capture through the \
+                      Android microphone device: these map to \
+                      AudioPlaybackCapture UID filters (ADR-0013; all of an \
+                      Android app's processes share one UID, so tree ≡ app) \
+                      and are served by the playback-capture device, not this \
+                      mic device. This mic device only serves \
                       CaptureTarget::Device(DeviceId(\"default\".into()))"
                 .to_string(),
             platform: "android".to_string(),
@@ -1097,20 +1100,23 @@ mod tests {
     }
 
     #[test]
-    fn system_default_is_pending_playback_capture_not_the_mic() {
+    fn system_default_is_routed_to_playback_capture_not_the_mic() {
         let err = ensure_mic_target(&CaptureTarget::SystemDefault).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::Platform);
         match err {
             AudioError::PlatformNotSupported { feature, platform } => {
                 assert_eq!(platform, "android");
-                // The honesty pillars: what SystemDefault really means, which
-                // seed delivers it, and what works today.
+                // The honesty pillars: what SystemDefault really means, where
+                // it is served, and what this device does serve.
                 assert!(
                     feature.contains("AudioPlaybackCapture"),
                     "real meaning: {feature}"
                 );
                 assert!(feature.contains("NOT the"), "not-the-mic: {feature}");
-                assert!(feature.contains("rsac-77f1"), "pending seed: {feature}");
+                assert!(
+                    feature.contains("playback-capture device"),
+                    "serving device: {feature}"
+                );
                 assert!(
                     feature.contains("Device(DeviceId(\"default\""),
                     "mic guidance: {feature}"
@@ -1121,7 +1127,7 @@ mod tests {
     }
 
     #[test]
-    fn per_app_targets_are_pending_not_permanent() {
+    fn per_app_targets_are_served_by_the_playback_device() {
         let targets = [
             CaptureTarget::Application(ApplicationId("1234".to_string())),
             CaptureTarget::ApplicationByName("com.example.app".to_string()),
@@ -1132,8 +1138,8 @@ mod tests {
                 AudioError::PlatformNotSupported { feature, platform } => {
                     assert_eq!(platform, "android");
                     assert!(
-                        feature.contains("rsac-77f1"),
-                        "must name the delivering seed for {target:?}: {feature}"
+                        feature.contains("playback-capture device"),
+                        "must name the serving device for {target:?}: {feature}"
                     );
                     assert!(
                         feature.contains("tree ≡ app"),
@@ -1141,7 +1147,7 @@ mod tests {
                     );
                     assert!(
                         !feature.contains("permanent"),
-                        "Android playback capture is PENDING, never permanent \
+                        "Android playback capture is SUPPORTED, never permanent \
                          ({target:?}): {feature}"
                     );
                 }

--- a/src/audio/ios/avaudio.rs
+++ b/src/audio/ios/avaudio.rs
@@ -1,0 +1,601 @@
+//! AVAudioEngine interop: input-node tap → `BridgeProducer` (rsac-9e02).
+//!
+//! This is the ObjC boundary of the iOS microphone backend. It uses the
+//! **typed** `objc2-avf-audio` bindings (same objc2 0.6 generation as the
+//! macOS backend's `objc2-app-kit` usage) rather than raw `msg_send!` — every
+//! class the mic slice needs is covered by the framework crate, so the
+//! tap.rs-style raw-selector fallback is unnecessary here.
+//!
+//! # Capture shape
+//!
+//! ```text
+//! AVAudioEngine → inputNode → installTapOnBus:0 bufferSize:N format:nil
+//!                               │ (AVFAudio's tap thread, non-RT)
+//!                               ▼
+//!             tap block: interleave into pre-allocated scratch
+//!                               ▼
+//!             BridgeProducer::push_samples_guarded_stamped()
+//! ```
+//!
+//! Passing `format: nil` to the tap means AVFAudio delivers the bus's native
+//! format — typically **deinterleaved** float32 at the `AVAudioSession`'s
+//! input rate. The tap block interleaves the planes into rsac's canonical
+//! interleaved-f32 layout before pushing.
+//!
+//! # Real-time / allocation discipline (ADR-0001, adapted)
+//!
+//! The tap block runs on AVFAudio's internal tap-delivery thread — a
+//! background (non-realtime) thread, *not* the hard-RT audio IO thread
+//! (AVFAudio copies each period into an `AVAudioPCMBuffer` and dispatches it
+//! off the IO thread). The adapted ADR-0001 rules still apply:
+//!
+//! - the interleave scratch `Vec<f32>` is **allocated once** at install time
+//!   and never grown in the callback — a buffer that would exceed its
+//!   capacity is dropped and counted (`overrun_count`), never allocated for;
+//! - the push is `push_samples_guarded_stamped` — lock-free, alloc-free in
+//!   steady state (free-list return ring), and panic-guarded because the
+//!   block is invoked from a **foreign ObjC callback frame** where an unwind
+//!   would be undefined behavior (same rule as the CoreAudio IOProc);
+//! - the single `Mutex` around the tap state is uncontended by design (only
+//!   the tap thread locks it after install) and is acceptable precisely
+//!   because this thread is not the RT IO thread.
+
+#![cfg(all(target_os = "ios", feature = "feat_ios"))]
+
+use std::ptr::NonNull;
+use std::sync::atomic::Ordering;
+use std::sync::Mutex;
+
+use block2::RcBlock;
+use objc2::rc::{autoreleasepool, Retained};
+use objc2_avf_audio::{AVAudioEngine, AVAudioInputNode, AVAudioPCMBuffer, AVAudioTime};
+
+use crate::bridge::ring_buffer::BridgeProducer;
+use crate::core::config::{AudioFormat, SampleFormat};
+use crate::core::error::{AudioError, AudioResult};
+
+// ── Tuning constants ─────────────────────────────────────────────────────
+
+/// Requested tap period, in sample frames, passed to
+/// `installTapOnBus:bufferSize:format:block:`.
+///
+/// AVFAudio documents the honoured range as roughly \[100 ms, 400 ms\] and
+/// clamps requests into it, so the *delivered* period is OS-chosen (commonly
+/// ~4800 frames at 48 kHz). This value is only the request; the scratch
+/// buffer is sized independently from the session's native rate (see
+/// [`scratch_capacity_samples`]) so an upward clamp never forces a
+/// callback-time allocation.
+const TAP_BUFFER_FRAMES: u32 = 4096;
+
+/// Sizes the interleave scratch buffer, in `f32` samples.
+///
+/// Half a second of audio at the native rate (with [`TAP_BUFFER_FRAMES`] as
+/// the floor), times the channel count. That comfortably covers AVFAudio's
+/// documented 400 ms maximum tap period plus clamp slack; a hypothetical
+/// larger delivery is dropped + counted rather than allocated for
+/// (ADR-0001 adapted). One-time cost at 48 kHz stereo: 48 000 × 4 B ≈ 192 KiB.
+fn scratch_capacity_samples(sample_rate: u32, channels: u16) -> usize {
+    ((sample_rate as usize) / 2).max(TAP_BUFFER_FRAMES as usize) * usize::from(channels.max(1))
+}
+
+// ── AvAudioEngineCapture ─────────────────────────────────────────────────
+
+/// Owns the live AVAudioEngine objects for one microphone capture.
+///
+/// Keeps the engine and its input node retained (`Retained<_>` = ObjC strong
+/// references) for the stream's whole lifetime — the tap block itself is
+/// retained *by AVFAudio* (blocks passed to `installTapOnBus:` are copied),
+/// so it is deliberately **not** stored here.
+///
+/// Not `Send`/`Sync` by itself; `IosPlatformStream` (thread.rs) wraps it in a
+/// `Mutex` and documents the cross-thread safety argument there.
+pub(crate) struct AvAudioEngineCapture {
+    /// The engine driving the input hardware. Strong reference held for the
+    /// stream's lifetime; released (ObjC refcount) on drop.
+    engine: Retained<AVAudioEngine>,
+    /// The engine's input node — kept so [`stop`](Self::stop) can remove the
+    /// tap from the exact node it was installed on.
+    input_node: Retained<AVAudioInputNode>,
+}
+
+impl AvAudioEngineCapture {
+    /// Removes the tap and stops the engine (idempotent at the AVFAudio
+    /// level).
+    ///
+    /// Order matters: the tap is removed **before** the engine stops so no
+    /// further tap invocations are queued once stop returns. Removing a tap
+    /// is documented safe while the engine is running, and `stop` on an
+    /// already-stopped engine is a no-op.
+    pub(crate) fn stop(&self) {
+        autoreleasepool(|_| {
+            // SAFETY: `installTapOnBus:` was called with bus 0 on this exact
+            // node at creation; removing a tap (even one already removed) is
+            // a documented-safe void call.
+            unsafe { self.input_node.removeTapOnBus(0) };
+            // SAFETY: stopping an AVAudioEngine has no preconditions and is
+            // idempotent; it halts the audio hardware and releases prepared
+            // resources.
+            unsafe { self.engine.stop() };
+        });
+    }
+}
+
+// ── Tap-state (captured by the tap block) ────────────────────────────────
+
+/// Mutable state owned by the tap block (behind a `Mutex` so the block can be
+/// an ObjC-callable `Fn`).
+struct TapState {
+    /// Producer half of the lock-free bridge; pushes are alloc-free in steady
+    /// state (free-list return ring, ADR-0001).
+    producer: BridgeProducer,
+    /// Pre-allocated interleave buffer — never grown in the callback.
+    scratch: Vec<f32>,
+    /// One-shot log guard: non-float32 delivery (should be impossible with
+    /// `format: nil` on an input-node tap, but never silently spin-drop).
+    warned_non_float: bool,
+    /// One-shot log guard: delivered period exceeded the scratch capacity.
+    warned_overflow: bool,
+}
+
+/// Counts one producer-side dropped buffer **without pushing** (the buffer
+/// never reached the ring — e.g. non-float delivery or a period larger than
+/// the scratch capacity).
+///
+/// Mirrors the accounting of `push_or_drop`'s drop arm on the shared bridge
+/// counters, so the loss is visible through `overrun_count()` /
+/// `buffers_dropped()` exactly like an ordinary ring-overflow drop. Lock-free
+/// `Relaxed` adds — safe from the tap thread.
+fn count_external_drop(producer: &BridgeProducer) {
+    let shared = producer.shared();
+    shared.buffers_dropped.fetch_add(1, Ordering::Relaxed);
+    shared.consecutive_drops.fetch_add(1, Ordering::Relaxed);
+}
+
+// ── Interleave gather (pure logic, unit-tested) ──────────────────────────
+
+/// Gathers one tap period into `dst` as interleaved f32, without allocating.
+///
+/// `channel_ptrs` follows the `AVAudioPCMBuffer.floatChannelData` contract:
+/// one pointer per channel, each pointing at `frames` valid samples spaced
+/// `stride` apart —
+///
+/// - **deinterleaved** (the common input-tap case): separate planes,
+///   `stride == 1`;
+/// - **interleaved**: pointers into one chunk, each offset by one frame,
+///   `stride == channel count`.
+///
+/// The generic gather loop handles both via the stride contract; a memcpy
+/// fast path covers the canonical interleaved layout.
+///
+/// Returns `false` — leaving `dst`'s capacity untouched and performing **no
+/// allocation** — when `frames × channels` exceeds `dst`'s capacity
+/// (ADR-0001 adapted: the caller drops + counts instead). Returns `true`
+/// after clearing and filling `dst` with exactly `frames × channels`
+/// interleaved samples.
+///
+/// # Safety
+///
+/// Every pointer in `channel_ptrs` must be valid for reads of
+/// `(frames - 1) * stride + 1` `f32` values (the floatChannelData layout
+/// guarantees this for `frames = frameLength` and `stride = stride()`), and
+/// the pointed-to memory must not be mutated for the duration of the call.
+unsafe fn gather_into_scratch(
+    dst: &mut Vec<f32>,
+    channel_ptrs: &[NonNull<f32>],
+    frames: usize,
+    stride: usize,
+    interleaved: bool,
+) -> bool {
+    let channels = channel_ptrs.len();
+    let needed = match frames.checked_mul(channels) {
+        Some(n) => n,
+        None => return false,
+    };
+    if needed > dst.capacity() {
+        // Would force a reallocation on the callback thread — refuse.
+        return false;
+    }
+    dst.clear();
+
+    if interleaved && stride == channels && channels > 0 {
+        // Canonical interleaved layout: channel 0's pointer is the base of
+        // one contiguous chunk of `frames * channels` samples.
+        // SAFETY: per the function contract, the base pointer is valid for
+        // `(frames - 1) * stride + 1` reads per channel pointer; with the
+        // channel pointers each offset by one sample, the union is exactly
+        // `frames * channels` contiguous samples from the base.
+        let samples = unsafe { std::slice::from_raw_parts(channel_ptrs[0].as_ptr(), needed) };
+        dst.extend_from_slice(samples);
+    } else {
+        // Generic gather (deinterleaved planes, or any exotic stride):
+        // frame-major, channel-minor — rsac's canonical interleaved order.
+        // Capacity was checked above, so `push` never reallocates.
+        for frame in 0..frames {
+            for ch in channel_ptrs {
+                // SAFETY: `frame * stride` indexes one of the `frames` valid
+                // samples of this channel per the floatChannelData contract.
+                dst.push(unsafe { *ch.as_ptr().add(frame * stride) });
+            }
+        }
+    }
+    true
+}
+
+// ── Engine construction + tap install ────────────────────────────────────
+
+/// Creates an `AVAudioEngine`, installs an input-node tap that pushes
+/// interleaved f32 into `producer`, and starts the engine.
+///
+/// Returns the live [`AvAudioEngineCapture`] (keep it alive for the stream's
+/// lifetime; see thread.rs) plus the **delivered** [`AudioFormat`] — built
+/// from the input node's actual sample rate / channel count, never from
+/// assumptions. The same format is published on the bridge via
+/// `set_negotiated_format` *before* the tap starts pushing, so
+/// `CapturingStream::format()` is authoritative from the first buffer.
+///
+/// # Errors
+///
+/// [`AudioError::StreamCreationFailed`] when:
+///
+/// - the input node reports a 0 Hz / 0-channel format (no active input
+///   route — the host app has not configured/activated a record-capable
+///   `AVAudioSession`, or microphone permission is missing; both are
+///   host-app responsibilities, see the module docs of `super`), or
+/// - `startAndReturnError:` fails (the `NSError`'s localized description is
+///   included verbatim).
+pub(crate) fn start_input_capture(
+    producer: BridgeProducer,
+) -> AudioResult<(AvAudioEngineCapture, AudioFormat)> {
+    autoreleasepool(|_| {
+        // SAFETY: plain `[[AVAudioEngine alloc] init]`; no preconditions. The
+        // engine is created in its default realtime-device-rendering mode.
+        let engine = unsafe { AVAudioEngine::new() };
+
+        // SAFETY: accessing `inputNode` lazily creates and attaches the
+        // engine's singleton input node; no preconditions beyond a live
+        // engine (held above).
+        let input_node: Retained<AVAudioInputNode> = unsafe { engine.inputNode() };
+
+        // The REAL format: what the hardware/session feeds bus 0. With
+        // `format: nil` below, the tap delivers the bus's native format, so
+        // this is the honest rate/channel source (the per-buffer format in
+        // the tap block remains authoritative per invocation).
+        //
+        // SAFETY: bus 0 always exists on an input node.
+        let native = unsafe { input_node.inputFormatForBus(0) };
+        // SAFETY: trivial property reads on a retained, immutable
+        // AVAudioFormat.
+        let native_rate = unsafe { native.sampleRate() };
+        let native_channels = unsafe { native.channelCount() };
+
+        if native_rate <= 0.0 || native_channels == 0 || native_channels > u32::from(u16::MAX) {
+            return Err(AudioError::StreamCreationFailed {
+                reason: format!(
+                    "AVAudioEngine input node reports an unusable native format \
+                     ({native_rate} Hz, {native_channels} ch): no active audio \
+                     input route. The HOST APP must declare \
+                     NSMicrophoneUsageDescription, obtain microphone permission, \
+                     and configure + activate an AVAudioSession with a \
+                     record-capable category (.record / .playAndRecord) before \
+                     building the capture — rsac's mobile/ios Swift helpers wrap \
+                     this flow; the library deliberately does not touch the \
+                     shared session"
+                ),
+                context: None,
+            });
+        }
+
+        let delivered = AudioFormat {
+            sample_rate: native_rate.round() as u32,
+            channels: native_channels as u16,
+            sample_format: SampleFormat::F32,
+        };
+
+        // Publish the delivery format BEFORE any push so readers never see
+        // the requested-format fallback once data flows (M1 pattern; the
+        // bridge normalizes sample_format to F32, which is also what the tap
+        // delivers).
+        producer.set_negotiated_format(&delivered);
+
+        // Pre-allocate the interleave scratch (ADR-0001 adapted: the ONLY
+        // buffer allocation, done here on the setup thread, never in the tap).
+        let scratch = Vec::with_capacity(scratch_capacity_samples(
+            delivered.sample_rate,
+            delivered.channels,
+        ));
+
+        let state = Mutex::new(TapState {
+            producer,
+            scratch,
+            warned_non_float: false,
+            warned_overflow: false,
+        });
+
+        // The tap block. `'static`: it owns everything it touches (the Mutex
+        // is moved in). Send-safety of the captured state: `TapState` is
+        // `Send` (`BridgeProducer` is Send by design — it is *made* to be
+        // moved to a callback thread — and `Vec<f32>`/`bool` are Send), so
+        // `Mutex<TapState>` is Send + Sync; the closure only accesses the
+        // state through that Mutex.
+        //
+        // SOUNDNESS (cross-thread invocation): AVFAudio invokes the block on
+        // its internal tap thread and serializes invocations per tap; the
+        // Mutex makes the state safe even against a hypothetical overlap.
+        let tap_block = RcBlock::new(
+            move |buffer: NonNull<AVAudioPCMBuffer>, _when: NonNull<AVAudioTime>| {
+                // Autorelease pool: `pcm.format()` returns an (auto)released
+                // ObjC object each invocation; pooling here keeps the foreign
+                // thread from accumulating autoreleased references. Push/pop
+                // of a pool is cheap and allocation-free on the Rust side.
+                autoreleasepool(|_| {
+                    let mut guard = match state.lock() {
+                        Ok(g) => g,
+                        // Poisoned == a previous invocation panicked. The push
+                        // is panic-guarded so this is theoretical; skipping the
+                        // period beats unwinding into the ObjC frame (UB).
+                        Err(_) => return,
+                    };
+                    let st = &mut *guard;
+
+                    // SAFETY: AVFAudio passes a valid AVAudioPCMBuffer that
+                    // outlives this block invocation.
+                    let pcm: &AVAudioPCMBuffer = unsafe { buffer.as_ref() };
+
+                    // SAFETY: trivial property reads on the live buffer.
+                    let frames = unsafe { pcm.frameLength() } as usize;
+                    if frames == 0 {
+                        return;
+                    }
+
+                    // Per-buffer format is authoritative (a session route
+                    // change can alter rate/channels mid-stream).
+                    // SAFETY: property reads on the live buffer / its format.
+                    let fmt = unsafe { pcm.format() };
+                    let channels = unsafe { fmt.channelCount() } as usize;
+                    let rate = unsafe { fmt.sampleRate() };
+                    let interleaved = unsafe { fmt.isInterleaved() };
+                    let stride = unsafe { pcm.stride() };
+
+                    // SAFETY: property read; null iff the buffer is not
+                    // 32-bit float.
+                    let data = unsafe { pcm.floatChannelData() };
+
+                    if data.is_null()
+                        || channels == 0
+                        || channels > usize::from(u16::MAX)
+                        || !rate.is_finite()
+                        || rate <= 0.0
+                    {
+                        // Not float32 (or degenerate format): count the loss
+                        // and log once — never silently spin.
+                        if !st.warned_non_float {
+                            st.warned_non_float = true;
+                            log::warn!(
+                                "AVAudioEngine tap delivered a non-float32/degenerate \
+                                 buffer (channels={channels}, rate={rate}); dropping \
+                                 and counting (further drops logged silently)"
+                            );
+                        }
+                        count_external_drop(&st.producer);
+                        return;
+                    }
+
+                    // SAFETY: floatChannelData is non-null (checked) and per
+                    // its contract points at `channels` channel pointers,
+                    // valid for this invocation.
+                    let channel_ptrs: &[NonNull<f32>] =
+                        unsafe { std::slice::from_raw_parts(data.cast_const(), channels) };
+
+                    // SAFETY: `frames`/`stride` come from the same buffer the
+                    // pointers describe, satisfying gather_into_scratch's
+                    // validity contract.
+                    let gathered = unsafe {
+                        gather_into_scratch(
+                            &mut st.scratch,
+                            channel_ptrs,
+                            frames,
+                            stride,
+                            interleaved,
+                        )
+                    };
+                    if !gathered {
+                        // Period larger than the pre-sized scratch: drop +
+                        // count instead of allocating (ADR-0001 adapted).
+                        if !st.warned_overflow {
+                            st.warned_overflow = true;
+                            log::warn!(
+                                "AVAudioEngine tap period ({frames} frames x {channels} ch) \
+                                 exceeds the pre-allocated scratch capacity \
+                                 ({}); dropping and counting",
+                                st.scratch.capacity()
+                            );
+                        }
+                        count_external_drop(&st.producer);
+                        return;
+                    }
+
+                    // Guarded push (foreign ObjC callback frame — an unwind
+                    // out of here would be UB, same rule as the CoreAudio
+                    // IOProc) with stream-position timestamps. Ring-full ⇒
+                    // drop + count inside the producer; never blocks.
+                    st.producer.push_samples_guarded_stamped(
+                        &st.scratch,
+                        channels as u16,
+                        rate.round() as u32,
+                    );
+                });
+            },
+        );
+
+        // SAFETY: bus 0 is valid; `format: nil` applies the bus's native
+        // format; the block pointer is valid for the duration of the call and
+        // AVFAudio *copies* (retains) the block on install, so dropping our
+        // `tap_block` handle when this scope ends leaves AVFAudio's copy — and
+        // the captured TapState — alive until `removeTapOnBus:` releases it.
+        unsafe {
+            input_node.installTapOnBus_bufferSize_format_block(
+                0,
+                TAP_BUFFER_FRAMES,
+                None,
+                RcBlock::as_ptr(&tap_block),
+            );
+        }
+
+        // SAFETY: preallocates render resources; documented to have no
+        // preconditions (may implicitly activate the audio session — which
+        // the host app should already have done; see module docs).
+        unsafe { engine.prepare() };
+
+        // SAFETY: standard engine start; the Result maps the ObjC
+        // `startAndReturnError:` out-error.
+        if let Err(err) = unsafe { engine.startAndReturnError() } {
+            // Roll back the tap so AVFAudio releases its copy of the block
+            // (and with it the BridgeProducer) promptly.
+            // SAFETY: removing the tap we just installed on bus 0.
+            unsafe { input_node.removeTapOnBus(0) };
+            return Err(AudioError::StreamCreationFailed {
+                reason: format!(
+                    "AVAudioEngine failed to start: {}. Common causes on iOS: \
+                     the AVAudioSession is not configured/active with a \
+                     record-capable category, or microphone permission \
+                     (NSMicrophoneUsageDescription) was denied — both are host-app \
+                     responsibilities (see rsac's mobile/ios helpers)",
+                    err.localizedDescription()
+                ),
+                context: None,
+            });
+        }
+
+        log::debug!(
+            "AVAudioEngine: input capture started ({} Hz, {} ch, tap request {} frames)",
+            delivered.sample_rate,
+            delivered.channels,
+            TAP_BUFFER_FRAMES
+        );
+
+        Ok((AvAudioEngineCapture { engine, input_node }, delivered))
+    })
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// Tests — pure logic only (no ObjC). They compile for the iOS target under
+// `--tests` and run on-device; they never touch AVAudioEngine.
+// ══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds `NonNull<f32>` channel pointers over borrowed slices.
+    fn ptrs_of(planes: &[&[f32]]) -> Vec<NonNull<f32>> {
+        planes
+            .iter()
+            .map(|p| NonNull::new(p.as_ptr() as *mut f32).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn gather_deinterleaved_stereo_interleaves_frame_major() {
+        // L/R planes, stride 1 (the canonical input-tap layout).
+        let left = [1.0f32, 2.0, 3.0];
+        let right = [10.0f32, 20.0, 30.0];
+        let ptrs = ptrs_of(&[&left, &right]);
+        let mut dst = Vec::with_capacity(6);
+
+        // SAFETY: each plane holds `frames` samples at stride 1.
+        let ok = unsafe { gather_into_scratch(&mut dst, &ptrs, 3, 1, false) };
+        assert!(ok);
+        assert_eq!(dst, vec![1.0, 10.0, 2.0, 20.0, 3.0, 30.0]);
+    }
+
+    #[test]
+    fn gather_interleaved_fast_path_is_a_straight_copy() {
+        // One interleaved chunk; channel pointers offset by one sample,
+        // stride == channels == 2.
+        let interleaved = [1.0f32, 10.0, 2.0, 20.0, 3.0, 30.0];
+        let base = NonNull::new(interleaved.as_ptr() as *mut f32).unwrap();
+        // SAFETY: one-past offsets within the same allocation.
+        let ch1 = unsafe { NonNull::new_unchecked(interleaved.as_ptr().add(1) as *mut f32) };
+        let ptrs = [base, ch1];
+        let mut dst = Vec::with_capacity(6);
+
+        // SAFETY: 3 frames * stride 2 spans exactly the 6-sample chunk.
+        let ok = unsafe { gather_into_scratch(&mut dst, &ptrs, 3, 2, true) };
+        assert!(ok);
+        assert_eq!(dst, interleaved.to_vec());
+    }
+
+    #[test]
+    fn gather_interleaved_generic_path_matches_fast_path() {
+        // Force the generic loop (interleaved=false) over the same interleaved
+        // layout: with stride == channels and offset pointers it must produce
+        // the identical frame-major output.
+        let interleaved = [1.0f32, 10.0, 2.0, 20.0, 3.0, 30.0];
+        let base = NonNull::new(interleaved.as_ptr() as *mut f32).unwrap();
+        // SAFETY: in-bounds offset.
+        let ch1 = unsafe { NonNull::new_unchecked(interleaved.as_ptr().add(1) as *mut f32) };
+        let ptrs = [base, ch1];
+        let mut dst = Vec::with_capacity(6);
+
+        // SAFETY: same layout contract as the fast-path test.
+        let ok = unsafe { gather_into_scratch(&mut dst, &ptrs, 3, 2, false) };
+        assert!(ok);
+        assert_eq!(dst, interleaved.to_vec());
+    }
+
+    #[test]
+    fn gather_mono_passthrough() {
+        let mono = [0.5f32, -0.5, 0.25, -0.25];
+        let ptrs = ptrs_of(&[&mono]);
+        let mut dst = Vec::with_capacity(4);
+
+        // SAFETY: one plane of 4 samples at stride 1.
+        let ok = unsafe { gather_into_scratch(&mut dst, &ptrs, 4, 1, false) };
+        assert!(ok);
+        assert_eq!(dst, mono.to_vec());
+    }
+
+    #[test]
+    fn gather_refuses_to_grow_scratch() {
+        // Capacity 4 but 3 frames * 2 ch = 6 needed → must return false and
+        // must NOT reallocate (ADR-0001 adapted: drop, don't allocate).
+        let left = [1.0f32, 2.0, 3.0];
+        let right = [10.0f32, 20.0, 30.0];
+        let ptrs = ptrs_of(&[&left, &right]);
+        let mut dst: Vec<f32> = Vec::with_capacity(4);
+        let cap_before = dst.capacity();
+
+        // SAFETY: valid planes; the function must bail before reading.
+        let ok = unsafe { gather_into_scratch(&mut dst, &ptrs, 3, 1, false) };
+        assert!(!ok);
+        assert_eq!(dst.capacity(), cap_before, "capacity must be untouched");
+    }
+
+    #[test]
+    fn gather_zero_channels_yields_empty_ok() {
+        // Degenerate but must not panic or read: 0 channels → needed == 0.
+        let ptrs: [NonNull<f32>; 0] = [];
+        let mut dst: Vec<f32> = Vec::with_capacity(8);
+        // SAFETY: no pointers are dereferenced when the channel list is empty.
+        let ok = unsafe { gather_into_scratch(&mut dst, &ptrs, 128, 1, false) };
+        assert!(ok);
+        assert!(dst.is_empty());
+    }
+
+    #[test]
+    fn scratch_capacity_covers_the_documented_tap_clamp() {
+        // AVFAudio can clamp the tap period up to ~400 ms; the scratch must
+        // cover at least that at the native rate (we size to 500 ms).
+        for (rate, ch) in [(48_000u32, 2u16), (44_100, 1), (96_000, 2), (8_000, 1)] {
+            let cap = scratch_capacity_samples(rate, ch);
+            let worst_case_400ms = (rate as usize * 2 / 5) * usize::from(ch);
+            assert!(
+                cap >= worst_case_400ms,
+                "scratch for {rate} Hz x {ch} ch ({cap}) must cover a 400 ms period \
+                 ({worst_case_400ms})"
+            );
+            // And never below the requested tap size either.
+            assert!(cap >= TAP_BUFFER_FRAMES as usize * usize::from(ch));
+        }
+    }
+}

--- a/src/audio/ios/broadcast.rs
+++ b/src/audio/ios/broadcast.rs
@@ -1,0 +1,1401 @@
+//! ReplayKit broadcast → host: the App-Group mmap-ring **consumer** (rsac-b3aa).
+//!
+//! This module wires [`CaptureTarget::SystemDefault`] on iOS to the ReplayKit
+//! Broadcast Upload Extension transport decided in ADR-0013: the extension
+//! (producer, `mobile/ios/Sources/RsacBroadcastKit/RingProducer.swift`) writes
+//! interleaved f32 frames into a memory-mapped SPSC ring in the shared App
+//! Group container; this module is the host-side consumer that drains the ring
+//! into a normal [`BridgeProducer`], so everything downstream is the standard
+//! `BridgeStream` pipeline (terminal semantics per ADR-0010/ADR-0003, overrun
+//! accounting per ADR-0007).
+//!
+//! # THE contract
+//!
+//! `mobile/ios/Sources/RsacBroadcastKit/RingLayout.swift` is the **canonical**
+//! cross-process ring contract (layout v1). The constants and cursor/ordering
+//! semantics below mirror it byte-for-byte. Any layout change is a breaking
+//! cross-process ABI change: bump the version **on both sides in lockstep**
+//! and make both sides reject a mismatch (this side does, see
+//! [`classify_publish_word`]).
+//!
+//! # Consumer shape
+//!
+//! ```text
+//! Broadcast extension process              Host app process
+//! ──────────────────────────               ─────────────────────────────
+//! RPBroadcastSampleHandler                 create_stream():
+//!   → RsacRingProducer::write                bounded poll for header publish
+//!        │  (mmap ring, App Group)           → read geometry → set_negotiated_format
+//!        ▼                                   → spawn NON-RT drain thread
+//!   release-store writeCursor                     │ acquire-load writeCursor
+//!                                                 │ copy frames → BridgeProducer
+//!                                                 │ release-store readCursor
+//!                                                 ▼
+//!                                           BridgeStream<BroadcastPlatformStream>
+//! ```
+//!
+//! # Consumer obligations (documented loudly, per ADR-0013)
+//!
+//! - The **host app** must be entitled to the App Group
+//!   (`com.apple.security.application-groups`) and pass its identifier via
+//!   [`AudioCaptureBuilder::with_ios_app_group`](crate::api::AudioCaptureBuilder::with_ios_app_group).
+//! - The **consumer app** must embed a Broadcast Upload Extension built on
+//!   `RsacBroadcastKit` (see `mobile/ios/README.md`), entitled to the same
+//!   App Group.
+//! - Capture is **user-initiated only** (control-center picker /
+//!   `RPSystemBroadcastPickerView`); there is no programmatic start. Stream
+//!   creation polls a bounded window ([`PUBLISH_POLL_TIMEOUT`]) for the ring
+//!   header to be published, then fails with actionable guidance.
+//! - The broadcast captures **everything** (no per-app filter) — per-app
+//!   capture remains permanently unsupported on iOS (ADR-0013).
+//!
+//! # Terminal semantics (ADR-0010 / ADR-0003)
+//!
+//! A heartbeat stamp older than [`HEARTBEAT_TIMEOUT_MILLIS`] means the
+//! extension was killed or the broadcast ended ⇒ the drain thread empties the
+//! ring, then `signal_error()` — the fatal producer terminal, observed by
+//! readers as [`AudioError::StreamEnded`] *after* any bridge-buffered tail is
+//! drained (`pop_blocking` pops data before the terminal check). Host-initiated
+//! `stop()` is the graceful path: `signal_done()` (`Running → Stopping`, tail
+//! stays drainable).
+//!
+//! # Unit tests
+//!
+//! The pure ring math below (publish-word classification, header/geometry
+//! validation, slot & wrap math, heartbeat staleness) has unit tests that
+//! **compile under `--tests` for the iOS target** and run on-device later
+//! under rsac-97c8 — they are contract-pinning tests, not host-run tests.
+//!
+//! [`CaptureTarget::SystemDefault`]: crate::core::config::CaptureTarget::SystemDefault
+//! [`AudioError::StreamEnded`]: crate::core::error::AudioError::StreamEnded
+
+#![cfg(all(target_os = "ios", feature = "feat_ios"))]
+
+use std::ffi::CString;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use objc2::rc::autoreleasepool;
+use objc2_foundation::{NSFileManager, NSString};
+
+use crate::bridge::ring_buffer::{BridgeProducer, BridgeShared};
+use crate::bridge::state::StreamState;
+use crate::bridge::stream::PlatformStream;
+use crate::bridge::{calculate_capacity, create_bridge, BridgeStream};
+use crate::core::config::{AudioFormat, CaptureTarget, DeviceId, SampleFormat, StreamConfig};
+use crate::core::error::{AudioError, AudioResult};
+use crate::core::interface::{AudioDevice, CapturingStream, DeviceKind};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Ring contract v1 — mirrors RingLayout.swift EXACTLY. Do not change without
+// a version bump on both sides.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// ASCII `"RSAC"` read as a little-endian u32 (bytes `52 53 41 43`).
+pub(crate) const RING_MAGIC: u32 = 0x4341_5352;
+
+/// Ring layout version this consumer speaks. Bump in lockstep with
+/// `RsacRingLayout.layoutVersion`.
+pub(crate) const RING_LAYOUT_VERSION: u32 = 1;
+
+/// The u64 the producer release-stores at offset 0 as the header publish
+/// point: little-endian `(layoutVersion << 32) | magic`.
+pub(crate) const PUBLISHED_MAGIC_VERSION: u64 =
+    ((RING_LAYOUT_VERSION as u64) << 32) | RING_MAGIC as u64;
+
+/// File name of the ring inside the App Group container (contract constant).
+pub(crate) const RING_FILE_NAME: &str = "rsac_broadcast_ring_v1";
+
+/// Header field offsets, in bytes (see the RingLayout.swift table).
+pub(crate) const OFFSET_SAMPLE_RATE: usize = 8;
+/// Offset of the interleaved channel count (u32).
+pub(crate) const OFFSET_CHANNELS: usize = 12;
+/// Offset of the ring capacity in frames (u32).
+pub(crate) const OFFSET_CAPACITY_FRAMES: usize = 16;
+/// Offset of the producer-owned monotonic write cursor (atomic u64).
+pub(crate) const OFFSET_WRITE_CURSOR: usize = 24;
+/// Offset of the consumer-owned monotonic read cursor (atomic u64).
+pub(crate) const OFFSET_READ_CURSOR: usize = 32;
+/// Offset of the producer liveness stamp (atomic u64, CLOCK_MONOTONIC ms).
+pub(crate) const OFFSET_HEARTBEAT_MILLIS: usize = 40;
+/// Offset of the producer's ring-full drop counter (atomic u64).
+pub(crate) const OFFSET_PRODUCER_DROP_COUNT: usize = 48;
+/// Byte offset where the interleaved f32 frame data begins (64-byte aligned).
+pub(crate) const DATA_OFFSET: usize = 64;
+
+/// A heartbeat stamp older than this ⇒ the producer is dead (terminal,
+/// ADR-0010/ADR-0003). Contract constant (`heartbeatTimeoutMillis`).
+pub(crate) const HEARTBEAT_TIMEOUT_MILLIS: u64 = 2_000;
+
+// ── Consumer tuning (host-side policy, not part of the cross-process ABI) ──
+
+/// How long `create_stream` waits for the broadcast ring header to be
+/// published before failing.
+///
+/// The broadcast is **user-initiated** (picker UI) and the extension creates
+/// the ring lazily on the first delivered audio buffer, so this window covers
+/// "the user is tapping the picker right now". No existing [`StreamConfig`]
+/// knob fits a wall-clock creation timeout (`buffer_size` is a ring *slot*
+/// count), so this is a documented constant rather than a config field.
+const PUBLISH_POLL_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Cadence of the header-publish poll during [`PUBLISH_POLL_TIMEOUT`].
+const PUBLISH_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Sleep between drain passes when the cross-process ring is empty. Small
+/// enough to keep worst-case added latency well under one tap period; large
+/// enough not to burn CPU on a non-RT thread.
+const DRAIN_IDLE_SLEEP: Duration = Duration::from_millis(3);
+
+/// Frames copied out of the cross-process ring per bridge push: ~20 ms at the
+/// delivered rate (floored at 256 frames). Keeps individual `AudioBuffer`s at
+/// a desktop-like cadence instead of pushing multi-second slabs.
+fn drain_chunk_frames(sample_rate: u32) -> usize {
+    ((sample_rate as usize) / 50).max(256)
+}
+
+/// The [`DeviceId`] string of the logical broadcast-capture device.
+///
+/// Honest naming: this is not a hardware endpoint — it is the ReplayKit
+/// broadcast transport surfaced as rsac's system-capture device.
+pub(crate) const BROADCAST_DEVICE_ID: &str = "replaykit-broadcast";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Pure ring math (unit-tested; no OS access)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Classification of the u64 at ring offset 0 (the publish word).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PublishState {
+    /// Header not (yet) published — keep polling.
+    Unpublished,
+    /// Published with layout v1 — the header is trustworthy.
+    PublishedV1,
+    /// Published by a producer speaking a **different** layout version. Both
+    /// sides must reject a mismatch (contract rule) — hard error, not a poll.
+    VersionMismatch(u32),
+}
+
+/// Classifies a publish word per the RingLayout torn-read-defense protocol:
+/// the header is trustworthy only once offset 0 equals
+/// `(layoutVersion << 32) | magic`; a matching magic with a different version
+/// is a producer/consumer version skew.
+pub(crate) fn classify_publish_word(word: u64) -> PublishState {
+    if word == PUBLISHED_MAGIC_VERSION {
+        return PublishState::PublishedV1;
+    }
+    if (word & 0xFFFF_FFFF) == u64::from(RING_MAGIC) {
+        return PublishState::VersionMismatch((word >> 32) as u32);
+    }
+    PublishState::Unpublished
+}
+
+/// Validated, immutable geometry of a published ring header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RingGeometry {
+    /// Frames per second (Hz), from the header.
+    pub sample_rate: u32,
+    /// Interleaved channel count, from the header.
+    pub channels: u32,
+    /// Ring capacity in **frames**, from the header.
+    pub capacity_frames: u64,
+}
+
+/// Validates published header fields against sanity bounds and the mapped
+/// file length. `reserved` is deliberately **not** checked: v1 says the
+/// consumer must ignore it.
+///
+/// Rejects zero geometry, channel counts above rsac's 32-channel builder
+/// ceiling (a published header claiming more is corrupt in practice), and a
+/// file too small to hold `DATA_OFFSET + capacity × channels × 4` bytes
+/// (all size math is overflow-checked).
+pub(crate) fn validate_geometry(
+    sample_rate: u32,
+    channels: u32,
+    capacity_frames: u32,
+    file_len: usize,
+) -> Result<RingGeometry, String> {
+    if sample_rate == 0 {
+        return Err("header sampleRate is 0".to_string());
+    }
+    if channels == 0 || channels > 32 {
+        return Err(format!("header channels {} outside 1..=32", channels));
+    }
+    if capacity_frames == 0 {
+        return Err("header capacityFrames is 0".to_string());
+    }
+    let needed = ring_file_size(capacity_frames, channels)
+        .ok_or_else(|| "header geometry overflows the file-size computation".to_string())?;
+    if file_len < needed {
+        return Err(format!(
+            "ring file is {} bytes but the published geometry needs {}",
+            file_len, needed
+        ));
+    }
+    Ok(RingGeometry {
+        sample_rate,
+        channels,
+        capacity_frames: u64::from(capacity_frames),
+    })
+}
+
+/// Total ring file size for a geometry (`dataOffset + frames × channels × 4`),
+/// or `None` on overflow.
+pub(crate) fn ring_file_size(capacity_frames: u32, channels: u32) -> Option<usize> {
+    (capacity_frames as usize)
+        .checked_mul(channels as usize)?
+        .checked_mul(4)?
+        .checked_add(DATA_OFFSET)
+}
+
+/// Frames readable in `[read, write)`, or `None` when the cursors are
+/// inconsistent (fill level above capacity — e.g. a new broadcast generation
+/// re-initialized the file under a live consumer, or header corruption).
+///
+/// Cursors are monotonic frame counts (never wrapped); `wrapping_sub` keeps
+/// the inconsistency detectable instead of panicking in a release build.
+pub(crate) fn available_frames(write: u64, read: u64, capacity_frames: u64) -> Option<u64> {
+    let avail = write.wrapping_sub(read);
+    if avail > capacity_frames {
+        return None;
+    }
+    Some(avail)
+}
+
+/// Splits a read of `frames` frames starting at monotonic cursor `read` into
+/// the two physically contiguous segments of the ring: `(first, second)`
+/// frame counts, where `first` runs from `read % capacity` to the physical
+/// end and `second` wraps to the physical start (`0` when no wrap occurs).
+pub(crate) fn contiguous_segments(read: u64, frames: u64, capacity_frames: u64) -> (u64, u64) {
+    debug_assert!(frames <= capacity_frames);
+    let slot = read % capacity_frames;
+    let first = frames.min(capacity_frames - slot);
+    (first, frames - first)
+}
+
+/// `true` when a heartbeat stamp is **strictly older** than
+/// [`HEARTBEAT_TIMEOUT_MILLIS`] relative to `now` (both CLOCK_MONOTONIC ms).
+/// A stamp "from the future" (should not happen — same clock domain) reads as
+/// fresh via the saturating subtraction.
+pub(crate) fn heartbeat_is_stale(heartbeat_millis: u64, now_millis: u64) -> bool {
+    now_millis.saturating_sub(heartbeat_millis) > HEARTBEAT_TIMEOUT_MILLIS
+}
+
+/// Current CLOCK_MONOTONIC time in milliseconds — the heartbeat clock domain.
+///
+/// The Swift producer stamps `clock_gettime_nsec_np(CLOCK_MONOTONIC) / 1e6`;
+/// `clock_gettime(CLOCK_MONOTONIC)` reads the **same** boot-scoped clock, so
+/// the comparison is process-independent. Deliberately not `SystemTime`
+/// (wall-clock jumps would fake producer death).
+fn monotonic_now_millis() -> u64 {
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: `ts` is a valid, writable timespec and CLOCK_MONOTONIC is
+    // always supported on iOS; on the (impossible) failure path we fall
+    // through with the zeroed timespec, which reads as "very stale" and
+    // errs on the terminal side rather than hanging.
+    unsafe {
+        libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
+    }
+    (ts.tv_sec as u64) * 1_000 + (ts.tv_nsec as u64) / 1_000_000
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BroadcastRing — the mapped consumer view of one published ring generation
+// ═══════════════════════════════════════════════════════════════════════════
+
+// UNSAFE-AUDIT (ADR-0013 consequence: the cross-process ring is a hand-rolled
+// second ring implementation and carries its own soundness argument):
+//
+// 1. **Mapping lifetime/aliasing.** `base` points at a `MAP_SHARED` mapping of
+//    the ring file, created in `try_open_ring` and unmapped exactly once in
+//    `Drop`. The struct is the mapping's single in-process owner; it is moved
+//    into the drain thread and never aliased by another Rust reference. The
+//    backing fd is closed immediately after `mmap` succeeds (the mapping
+//    remains valid per POSIX).
+// 2. **SIGBUS avoidance.** Pages beyond EOF fault on access, so the file
+//    length is `fstat`ed and validated against the published geometry
+//    (`validate_geometry`) BEFORE any access past the header, and the whole
+//    mapping length equals the fstat'ed length. The producer never shrinks
+//    the file (RingProducer deliberately avoids `O_TRUNC` and re-initializes
+//    through the mapping), so the length cannot go stale under us.
+// 3. **Cross-language atomics (C11 interop).** The header's atomic fields are
+//    accessed via `AtomicU64::from_ptr` on 8-aligned offsets (0, 24, 32, 40,
+//    48 — the mmap base is page-aligned). The Swift producer accesses the
+//    same addresses through a C shim over C11 `atomic_*` builtins
+//    (`CRsacRingAtomics`). Rust's `AtomicU64` is documented to have the same
+//    representation and lock-free operations as the platform's 8-byte C11
+//    atomics on arm64, so release/acquire pairs synchronize across the
+//    process boundary. Both sides only ever touch these words atomically.
+// 4. **Torn-read defense for non-atomic data.** The u32 header fields are
+//    written before the producer's release-store of the publish word and are
+//    immutable afterwards; this consumer only reads them after an
+//    acquire-load observes `PUBLISHED_MAGIC_VERSION` (happens-before). Frame
+//    bytes in `[read, write)` are written before the release-store of
+//    `writeCursor` and are never rewritten until the consumer release-stores
+//    `readCursor` past them (the producer acquire-loads `readCursor` before
+//    reusing slots), so the plain `copy_nonoverlapping` reads in
+//    `drain_once` are data-race-free.
+// 5. **Generation churn.** A new broadcast re-initializes the file through a
+//    fresh mapping in the producer. If that happens while this consumer is
+//    attached, the cursors reset and `available_frames` detects the
+//    inconsistent fill level (> capacity) ⇒ fatal terminal — never an
+//    out-of-bounds access (slot math is `% capacity` over the validated
+//    geometry of *this* mapping).
+/// One mapped, validated, published generation of the broadcast ring
+/// (consumer side).
+pub(crate) struct BroadcastRing {
+    /// Base of the `MAP_SHARED` mapping (page-aligned).
+    base: *mut u8,
+    /// Length of the mapping (== the fstat'ed file length at open).
+    map_len: usize,
+    /// Validated header geometry (immutable once published).
+    geometry: RingGeometry,
+}
+
+// SAFETY: `BroadcastRing` is moved into exactly one drain thread and never
+// shared between Rust threads; the raw pointer targets process-shared memory
+// whose concurrent (cross-process) accesses are synchronized by the atomic
+// cursor protocol audited above. Sending the owning handle to another thread
+// is therefore sound. (No `Sync` impl — it is never shared by reference.)
+unsafe impl Send for BroadcastRing {}
+
+impl BroadcastRing {
+    /// Borrow an atomic header field at `offset` (must be one of the 8-aligned
+    /// atomic offsets of the v1 layout).
+    fn atomic_u64_at(&self, offset: usize) -> &AtomicU64 {
+        debug_assert!(offset.is_multiple_of(8) && offset + 8 <= DATA_OFFSET);
+        // SAFETY: `base + offset` is 8-aligned (page-aligned base, offset a
+        // multiple of 8), in-bounds of the mapping (validated ≥ DATA_OFFSET),
+        // valid for the lifetime of `&self`, and only ever accessed
+        // atomically by both processes (UNSAFE-AUDIT items 1 and 3).
+        unsafe { AtomicU64::from_ptr(self.base.add(offset).cast::<u64>()) }
+    }
+
+    /// Acquire-load of the producer-owned write cursor: frames in
+    /// `[readCursor, writeCursor)` are fully written after this load.
+    fn write_cursor(&self) -> u64 {
+        self.atomic_u64_at(OFFSET_WRITE_CURSOR)
+            .load(Ordering::Acquire)
+    }
+
+    /// Relaxed load of the consumer-owned read cursor (this thread is its
+    /// only writer).
+    fn read_cursor(&self) -> u64 {
+        self.atomic_u64_at(OFFSET_READ_CURSOR)
+            .load(Ordering::Relaxed)
+    }
+
+    /// Release-store of the read cursor **after** the frames were copied out,
+    /// so the producer's acquire-load never reuses slots we are still reading.
+    fn store_read_cursor(&self, value: u64) {
+        self.atomic_u64_at(OFFSET_READ_CURSOR)
+            .store(value, Ordering::Release)
+    }
+
+    /// Relaxed load of the heartbeat stamp (a standalone liveness value; it
+    /// guards no other data, matching the producer's relaxed store).
+    fn heartbeat_millis(&self) -> u64 {
+        self.atomic_u64_at(OFFSET_HEARTBEAT_MILLIS)
+            .load(Ordering::Relaxed)
+    }
+
+    /// Relaxed load of the producer's ring-full drop counter.
+    fn producer_drop_count(&self) -> u64 {
+        self.atomic_u64_at(OFFSET_PRODUCER_DROP_COUNT)
+            .load(Ordering::Relaxed)
+    }
+
+    /// Start of the interleaved f32 data region (64-byte aligned).
+    fn data_ptr(&self) -> *const f32 {
+        // SAFETY: DATA_OFFSET is in-bounds (map_len ≥ DATA_OFFSET + data).
+        unsafe { self.base.add(DATA_OFFSET).cast::<f32>() }
+    }
+}
+
+impl Drop for BroadcastRing {
+    fn drop(&mut self) {
+        // SAFETY: `base`/`map_len` are exactly the pointer/length returned by
+        // the successful mmap in `try_open_ring`, unmapped exactly once (this
+        // struct is the mapping's single owner — UNSAFE-AUDIT item 1).
+        unsafe {
+            libc::munmap(self.base.cast::<libc::c_void>(), self.map_len);
+        }
+    }
+}
+
+// ── Opening / polling ─────────────────────────────────────────────────────
+
+/// Why a probe of the ring file did not yield a live, published ring yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingReason {
+    /// The ring file does not exist yet (broadcast not started, or no audio
+    /// buffer delivered yet — the extension creates the ring lazily).
+    NoFile,
+    /// The file exists but the header publish word is not committed yet.
+    Unpublished,
+    /// The file is published but its heartbeat is stale — a dead previous
+    /// broadcast generation, not a live one.
+    StaleHeartbeat,
+    /// A transient OS error (open/fstat/mmap) — retried until the deadline.
+    OsError,
+}
+
+impl PendingReason {
+    /// Actionable one-liner for the timeout error message.
+    fn describe(self) -> &'static str {
+        match self {
+            PendingReason::NoFile => {
+                "the ring file was never created (broadcast not started, or the \
+                 broadcast extension is not built on RsacBroadcastKit / not \
+                 entitled to this App Group)"
+            }
+            PendingReason::Unpublished => {
+                "the ring file exists but its header was never published \
+                 (the extension may have received no audio buffers yet)"
+            }
+            PendingReason::StaleHeartbeat => {
+                "only a stale ring from a previous, ended broadcast was found \
+                 (start a new broadcast)"
+            }
+            PendingReason::OsError => "the ring file could not be opened/mapped",
+        }
+    }
+}
+
+/// Resolves the App Group container directory for `group` via
+/// `-[NSFileManager containerURLForSecurityApplicationGroupIdentifier:]`.
+///
+/// `None` means the identifier is wrong or the **host app** lacks the App
+/// Group entitlement (the same failure the Swift producer surfaces as
+/// `appGroupUnavailable`).
+fn app_group_container_path(group: &str) -> Option<PathBuf> {
+    autoreleasepool(|_| {
+        let ns_group = NSString::from_str(group);
+        let url = NSFileManager::defaultManager()
+            .containerURLForSecurityApplicationGroupIdentifier(&ns_group)?;
+        let path = url.path()?;
+        Some(PathBuf::from(path.to_string()))
+    })
+}
+
+/// One probe of the ring file: open → size-check → map → publish-word check →
+/// geometry validation → heartbeat-freshness check.
+///
+/// - `Ok(Ok(ring))` — a live, published, validated ring (mapping owned).
+/// - `Ok(Err(reason))` — not ready yet; keep polling.
+/// - `Err(_)` — a **hard** contract failure (version mismatch / corrupt
+///   published geometry) that polling cannot fix.
+fn try_open_ring(path: &Path) -> AudioResult<Result<BroadcastRing, PendingReason>> {
+    let c_path = match CString::new(path.as_os_str().as_encoded_bytes()) {
+        Ok(p) => p,
+        Err(_) => {
+            // A NUL inside an App-Group path cannot happen in practice; treat
+            // as a hard configuration error rather than polling forever.
+            return Err(AudioError::StreamCreationFailed {
+                reason: format!("ring path {:?} contains an interior NUL byte", path),
+                context: None,
+            });
+        }
+    };
+
+    // SAFETY: `c_path` is a valid NUL-terminated C string; O_RDWR because the
+    // consumer owns (and release-stores) `readCursor` in the shared mapping.
+    let fd = unsafe { libc::open(c_path.as_ptr(), libc::O_RDWR) };
+    if fd < 0 {
+        let errno = std::io::Error::last_os_error();
+        return Ok(Err(match errno.raw_os_error() {
+            Some(code) if code == libc::ENOENT => PendingReason::NoFile,
+            _ => {
+                log::debug!("broadcast ring open({:?}) failed: {}", path, errno);
+                PendingReason::OsError
+            }
+        }));
+    }
+    // Ensure the fd is closed on every exit path below; a successful mmap
+    // stays valid after close(2) per POSIX.
+    struct FdGuard(libc::c_int);
+    impl Drop for FdGuard {
+        fn drop(&mut self) {
+            // SAFETY: `self.0` is an fd this guard exclusively owns.
+            unsafe {
+                libc::close(self.0);
+            }
+        }
+    }
+    let _fd_guard = FdGuard(fd);
+
+    // SAFETY: zero-initialized stat buffer; fstat on an owned, open fd.
+    let mut st: libc::stat = unsafe { std::mem::zeroed() };
+    // SAFETY: `fd` is open and `st` is a valid, writable stat buffer.
+    if unsafe { libc::fstat(fd, &mut st) } != 0 {
+        log::debug!(
+            "broadcast ring fstat failed: {}",
+            std::io::Error::last_os_error()
+        );
+        return Ok(Err(PendingReason::OsError));
+    }
+    let file_len = st.st_size.max(0) as usize;
+    if file_len < DATA_OFFSET {
+        // Producer created the file but has not sized/published it yet.
+        return Ok(Err(PendingReason::Unpublished));
+    }
+
+    // SAFETY: mapping `file_len` bytes of an open O_RDWR fd, MAP_SHARED so the
+    // cursor stores are visible cross-process; length matches the fstat'ed
+    // size, so no access below can fault past EOF (UNSAFE-AUDIT item 2).
+    let mapped = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            file_len,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_SHARED,
+            fd,
+            0,
+        )
+    };
+    if mapped == libc::MAP_FAILED {
+        log::debug!(
+            "broadcast ring mmap failed: {}",
+            std::io::Error::last_os_error()
+        );
+        return Ok(Err(PendingReason::OsError));
+    }
+    let base = mapped.cast::<u8>();
+
+    /// Unmaps on early exits; disarmed once ownership moves into BroadcastRing.
+    struct MapGuard {
+        base: *mut u8,
+        len: usize,
+        armed: bool,
+    }
+    impl Drop for MapGuard {
+        fn drop(&mut self) {
+            if self.armed {
+                // SAFETY: exactly the pointer/length of the mmap above; the
+                // guard is disarmed before BroadcastRing takes ownership, so
+                // there is a single munmap per mapping.
+                unsafe {
+                    libc::munmap(self.base.cast::<libc::c_void>(), self.len);
+                }
+            }
+        }
+    }
+    let mut map_guard = MapGuard {
+        base,
+        len: file_len,
+        armed: true,
+    };
+
+    // Publish-word acquire-load: only a committed v1 header is trusted
+    // (torn-read defense — UNSAFE-AUDIT item 4).
+    //
+    // SAFETY: offset 0 is 8-aligned and in-bounds; accessed atomically by
+    // both processes (UNSAFE-AUDIT item 3).
+    let publish = unsafe { AtomicU64::from_ptr(base.cast::<u64>()) }.load(Ordering::Acquire);
+    match classify_publish_word(publish) {
+        PublishState::Unpublished => return Ok(Err(PendingReason::Unpublished)),
+        PublishState::VersionMismatch(version) => {
+            return Err(AudioError::StreamCreationFailed {
+                reason: format!(
+                    "broadcast ring layout version mismatch: the extension wrote \
+                     v{version}, this rsac speaks v{RING_LAYOUT_VERSION}. Update rsac and the \
+                     RsacBroadcastKit SwiftPM package in lockstep (the ring \
+                     layout is a versioned cross-process ABI)"
+                ),
+                context: None,
+            });
+        }
+        PublishState::PublishedV1 => {}
+    }
+
+    // Non-atomic header fields: written before the publish release-store and
+    // immutable afterwards, so plain reads are race-free after the acquire
+    // above. Stored little-endian; `from_le` keeps the intent explicit (a
+    // no-op on arm64).
+    //
+    // SAFETY: 4-aligned, in-bounds header reads (file_len ≥ DATA_OFFSET).
+    let read_u32 =
+        |offset: usize| -> u32 { u32::from_le(unsafe { base.add(offset).cast::<u32>().read() }) };
+    let sample_rate = read_u32(OFFSET_SAMPLE_RATE);
+    let channels = read_u32(OFFSET_CHANNELS);
+    let capacity_frames = read_u32(OFFSET_CAPACITY_FRAMES);
+
+    let geometry = match validate_geometry(sample_rate, channels, capacity_frames, file_len) {
+        Ok(g) => g,
+        Err(why) => {
+            // Published geometry is immutable — polling cannot fix this.
+            return Err(AudioError::StreamCreationFailed {
+                reason: format!(
+                    "broadcast ring header is published but invalid ({why}) — \
+                     the ring file is corrupt or produced by an incompatible \
+                     RsacBroadcastKit build"
+                ),
+                context: None,
+            });
+        }
+    };
+
+    map_guard.armed = false;
+    let ring = BroadcastRing {
+        base,
+        map_len: file_len,
+        geometry,
+    };
+
+    // A published ring with a stale heartbeat is the remnant of a previous,
+    // ended broadcast — not a live producer. Keep polling for a fresh
+    // generation (the producer re-publishes through the same file).
+    if heartbeat_is_stale(ring.heartbeat_millis(), monotonic_now_millis()) {
+        return Ok(Err(PendingReason::StaleHeartbeat));
+    }
+
+    Ok(Ok(ring))
+}
+
+/// Bounded poll for a live, published ring, per the create_stream contract.
+fn poll_for_published_ring(path: &Path, timeout: Duration) -> AudioResult<BroadcastRing> {
+    let deadline = Instant::now() + timeout;
+    // Assigned on every iteration before the deadline check reads it.
+    let mut last_pending;
+    loop {
+        match try_open_ring(path)? {
+            Ok(ring) => return Ok(ring),
+            Err(reason) => last_pending = reason,
+        }
+        if Instant::now() >= deadline {
+            return Err(AudioError::StreamCreationFailed {
+                reason: format!(
+                    "broadcast not started: no live rsac broadcast ring appeared \
+                     within {}s ({}). System-audio capture on iOS is \
+                     user-initiated: the user must start the broadcast via the \
+                     control-center screen-recording picker or an \
+                     RPSystemBroadcastPickerView, and the app must embed a \
+                     Broadcast Upload Extension built on RsacBroadcastKit \
+                     sharing this App Group — see mobile/ios/README.md",
+                    timeout.as_secs(),
+                    last_pending.describe()
+                ),
+                context: None,
+            });
+        }
+        std::thread::sleep(PUBLISH_POLL_INTERVAL);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Drain thread — cross-process ring → BridgeProducer
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Outcome of one drain pass over the cross-process ring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DrainOutcome {
+    /// Frames were copied into the bridge; try again immediately.
+    Drained,
+    /// The ring is currently empty.
+    Empty,
+    /// The cursors are inconsistent (fill level above capacity) — the file
+    /// was re-initialized under us or is corrupt. Terminal.
+    Corrupt,
+}
+
+/// Copies up to `chunk_frames` frames out of the ring into `scratch` and
+/// pushes them into the bridge (drop-not-block), then advances `readCursor`.
+///
+/// The read cursor advances **whether or not** the bridge push succeeded: the
+/// frames were consumed from the cross-process ring either way, and a bridge
+/// ring-full drop is already counted by `push_samples_or_drop_stamped`
+/// (ADR-0007 drop-don't-block accounting).
+fn drain_once(
+    ring: &BroadcastRing,
+    producer: &mut BridgeProducer,
+    scratch: &mut [f32],
+    chunk_frames: usize,
+) -> DrainOutcome {
+    let capacity = ring.geometry.capacity_frames;
+    let channels = ring.geometry.channels as usize;
+
+    let write = ring.write_cursor(); // acquire: frames below are fully written
+    let read = ring.read_cursor();
+    let avail = match available_frames(write, read, capacity) {
+        Some(a) => a,
+        None => return DrainOutcome::Corrupt,
+    };
+    if avail == 0 {
+        return DrainOutcome::Empty;
+    }
+
+    let take = avail.min(chunk_frames as u64);
+    let (first, second) = contiguous_segments(read, take, capacity);
+    let slot = (read % capacity) as usize;
+    let data = ring.data_ptr();
+
+    // SAFETY: `validate_geometry` proved the mapping holds the whole data
+    // region; `slot + first ≤ capacity` and `second ≤ capacity` by the
+    // segment math, so both source ranges are in-bounds. `scratch` is sized
+    // to `chunk_frames × channels ≥ take × channels` by the caller. The
+    // frames in `[read, write)` are stable until we release-store the
+    // advanced read cursor below (UNSAFE-AUDIT item 4).
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            data.add(slot * channels),
+            scratch.as_mut_ptr(),
+            (first as usize) * channels,
+        );
+        if second > 0 {
+            std::ptr::copy_nonoverlapping(
+                data,
+                scratch.as_mut_ptr().add((first as usize) * channels),
+                (second as usize) * channels,
+            );
+        }
+    }
+
+    let samples = (take as usize) * channels;
+    // Non-RT rsac-owned thread → the stamped (stream-position) push variant,
+    // like the Windows capture loop. Ring-full ⇒ drop + count, never block.
+    producer.push_samples_or_drop_stamped(
+        &scratch[..samples],
+        ring.geometry.channels as u16,
+        ring.geometry.sample_rate,
+    );
+
+    // Release: the producer may reuse these slots only after this store.
+    ring.store_read_cursor(read + take);
+
+    DrainOutcome::Drained
+}
+
+/// Forwards the producer's cross-process `producerDropCount` into the
+/// bridge's overrun accounting so `overrun_count()` reflects **all** loss.
+///
+/// Only `buffers_dropped` is advanced: `consecutive_drops` means "consecutive
+/// bridge pushes that dropped, with no success in between" (it feeds
+/// `is_under_backpressure`), and producer-side drops interleave arbitrarily
+/// with successful bridge pushes — folding them in would corrupt that signal.
+fn forward_producer_drops(ring: &BroadcastRing, shared: &BridgeShared, last_seen: &mut u64) {
+    let now = ring.producer_drop_count();
+    if now > *last_seen {
+        let delta = now - *last_seen;
+        *last_seen = now;
+        shared.buffers_dropped.fetch_add(delta, Ordering::Relaxed);
+        log::debug!("broadcast extension dropped {delta} buffer(s) ring-full (total {now})");
+    }
+}
+
+/// Body of the drain thread. Runs until the host stops the stream (graceful
+/// terminal) or the producer dies / the ring corrupts (fatal terminal).
+fn run_drain_loop(
+    ring: BroadcastRing,
+    mut producer: BridgeProducer,
+    stop: Arc<AtomicBool>,
+    active: Arc<AtomicBool>,
+) {
+    let channels = ring.geometry.channels as usize;
+    let chunk_frames = drain_chunk_frames(ring.geometry.sample_rate);
+    // The ONLY buffer allocation, made once on this non-RT thread before the
+    // loop; `drain_once` never grows it.
+    let mut scratch = vec![0.0f32; chunk_frames * channels];
+    let mut forwarded_drops = ring.producer_drop_count();
+
+    loop {
+        if stop.load(Ordering::SeqCst) {
+            // Host-initiated stop: graceful producer terminal (ADR-0010) —
+            // `Running → Stopping` keeps the bridge-buffered tail drainable.
+            producer.signal_done();
+            break;
+        }
+
+        forward_producer_drops(&ring, producer.shared(), &mut forwarded_drops);
+
+        match drain_once(&ring, &mut producer, &mut scratch, chunk_frames) {
+            DrainOutcome::Drained => {
+                // Non-RT thread: wake a parked blocking reader promptly (the
+                // Windows-capture-loop precedent; ADR-0001 forbids this only
+                // on RT callback paths).
+                producer.notify_consumers();
+            }
+            DrainOutcome::Empty => {
+                if heartbeat_is_stale(ring.heartbeat_millis(), monotonic_now_millis()) {
+                    // Extension killed or broadcast ended: the ring is drained
+                    // (we only reach here on Empty) ⇒ fatal producer terminal
+                    // (ADR-0010) ⇒ readers observe StreamEnded after draining
+                    // any bridge-buffered tail (ADR-0003).
+                    log::info!(
+                        "broadcast ring heartbeat older than {HEARTBEAT_TIMEOUT_MILLIS} ms \
+                         — broadcast ended or extension killed; ending stream"
+                    );
+                    producer.signal_error();
+                    break;
+                }
+                std::thread::sleep(DRAIN_IDLE_SLEEP);
+            }
+            DrainOutcome::Corrupt => {
+                log::error!(
+                    "broadcast ring cursors inconsistent (fill level above \
+                     capacity) — file re-initialized under a live consumer or \
+                     corrupt; ending stream"
+                );
+                producer.signal_error();
+                break;
+            }
+        }
+    }
+
+    active.store(false, Ordering::SeqCst);
+    // `ring` drops here: the mapping is unmapped only after the loop can no
+    // longer touch it.
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BroadcastPlatformStream — PlatformStream over the drain thread
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Platform-specific stream handle for the iOS broadcast path.
+///
+/// Owns the drain thread's lifecycle; all fields are `Send + Sync` types, so
+/// no `unsafe impl` is needed (unlike the ObjC-holding mic stream).
+///
+/// # Shutdown
+///
+/// [`stop_capture`](PlatformStream::stop_capture) (and `Drop`, via the same
+/// choke point) sets the stop flag, joins the drain thread (which unmaps the
+/// ring on exit), and then makes sure the bridge reached an ending state and
+/// parked readers are woken (ADR-0010) — the CAS no-ops when the thread
+/// already signalled a terminal itself (heartbeat death / corruption).
+pub(crate) struct BroadcastPlatformStream {
+    /// Tells the drain thread to exit (host-initiated, graceful).
+    stop: Arc<AtomicBool>,
+    /// The drain thread's handle; taken exactly once by the stop choke point.
+    join: Mutex<Option<std::thread::JoinHandle<()>>>,
+    /// Cleared by the drain thread on exit (any cause), so `is_active()` is
+    /// honest even when the producer died without a host-side stop.
+    active: Arc<AtomicBool>,
+    /// Producer-terminal-signal handle (ADR-0010): drives `Running → Stopping`
+    /// + reader wake from the stop path.
+    terminal: Arc<BridgeShared>,
+}
+
+impl BroadcastPlatformStream {
+    /// Stops the drain thread (once) and lands the bridge in an ending state.
+    /// Idempotent: the JoinHandle is taken exactly once; later calls no-op.
+    fn stop_thread(&self) -> AudioResult<()> {
+        self.stop.store(true, Ordering::SeqCst);
+        let handle = {
+            let mut guard = self.join.lock().map_err(|_| AudioError::InternalError {
+                message: "broadcast drain-thread handle mutex poisoned".to_string(),
+                source: None,
+            })?;
+            guard.take()
+        };
+        if let Some(handle) = handle {
+            // The thread exits within one DRAIN_IDLE_SLEEP/drain pass of the
+            // stop flag; a panicked drain thread must not panic the stopper.
+            let _ = handle.join();
+        }
+        self.active.store(false, Ordering::SeqCst);
+
+        // Belt-and-suspenders graceful terminal: no-ops when the drain thread
+        // already drove the state (signal_done / signal_error).
+        let _ = self
+            .terminal
+            .state
+            .transition(StreamState::Running, StreamState::Stopping);
+        self.terminal.notify_wake();
+        #[cfg(feature = "async-stream")]
+        self.terminal.waker.wake();
+        Ok(())
+    }
+}
+
+impl PlatformStream for BroadcastPlatformStream {
+    fn stop_capture(&self) -> AudioResult<()> {
+        self.stop_thread()
+    }
+
+    fn is_active(&self) -> bool {
+        self.active.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for BroadcastPlatformStream {
+    /// Deterministic shutdown: dropping the handle never leaks a drain thread
+    /// or leaves a parked reader hanging (ADR-0010).
+    fn drop(&mut self) {
+        if self.active.load(Ordering::SeqCst) {
+            if let Err(e) = self.stop_thread() {
+                log::warn!("BroadcastPlatformStream::drop: stop failed: {:?}", e);
+            }
+        }
+    }
+}
+
+/// Assert that `BroadcastPlatformStream` is `Send + Sync` (required by
+/// `PlatformStream` and `BridgeStream<S>`).
+fn _assert_broadcast_platform_stream_send_sync() {
+    fn _assert<T: Send + Sync>() {}
+    _assert::<BroadcastPlatformStream>();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BroadcastAudioDevice — the logical system-capture device
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// The logical iOS system-audio capture device (ReplayKit broadcast).
+///
+/// A metadata-only handle: constructing it touches no OS resources; the ring
+/// polling/mapping happens in [`create_stream`](AudioDevice::create_stream).
+/// This is what [`IosDeviceEnumerator::default_device`] returns — matching
+/// the desktop convention where the *default device* is the system-loopback
+/// endpoint — and it also appears in `enumerate_devices()` alongside the mic.
+///
+/// [`IosDeviceEnumerator::default_device`]: crate::audio::ios::IosDeviceEnumerator
+#[derive(Debug, Clone, Copy)]
+pub struct BroadcastAudioDevice;
+
+impl BroadcastAudioDevice {
+    /// Creates the logical broadcast-capture device handle.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for BroadcastAudioDevice {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Validates a [`CaptureTarget`] against the broadcast device.
+///
+/// | Target | Outcome |
+/// |---|---|
+/// | `SystemDefault` | `Ok(())` — the broadcast mix |
+/// | `Device("replaykit-broadcast")` | `Ok(())` — this device, selected explicitly |
+/// | `Device(other)` | [`AudioError::DeviceNotFound`] |
+/// | `Application*` / `ProcessTree` | [`AudioError::PlatformNotSupported`] — **permanent** (no iOS API) |
+///
+/// Exhaustive on purpose (no wildcard) so a new `CaptureTarget` variant must
+/// be classified before the crate compiles for iOS.
+fn ensure_broadcast_target(target: &CaptureTarget) -> AudioResult<()> {
+    match target {
+        CaptureTarget::SystemDefault => Ok(()),
+        CaptureTarget::Device(id) if id.0.eq_ignore_ascii_case(BROADCAST_DEVICE_ID) => Ok(()),
+        CaptureTarget::Device(id) => Err(AudioError::DeviceNotFound {
+            device_id: id.0.clone(),
+        }),
+        CaptureTarget::Application(_)
+        | CaptureTarget::ApplicationByName(_)
+        | CaptureTarget::ProcessTree(_) => Err(AudioError::PlatformNotSupported {
+            feature: "per-application / process-tree capture on iOS: Apple provides \
+                      no API for capturing another app's audio — this is permanent, \
+                      not a pending feature (ADR-0013). The ReplayKit broadcast \
+                      (CaptureTarget::SystemDefault) captures the whole system mix, \
+                      with no per-app filter"
+                .to_string(),
+            platform: "ios".to_string(),
+        }),
+    }
+}
+
+impl AudioDevice for BroadcastAudioDevice {
+    fn id(&self) -> DeviceId {
+        DeviceId(BROADCAST_DEVICE_ID.to_string())
+    }
+
+    fn name(&self) -> String {
+        "System audio (ReplayKit broadcast)".to_string()
+    }
+
+    /// `true`: this is the default device **of its kind** — the endpoint
+    /// rsac's loopback-oriented `default_device()` returns for system capture
+    /// (the mic device stays the default [`DeviceKind::Input`]).
+    fn is_default(&self) -> bool {
+        true
+    }
+
+    /// Empty by design (the Linux/PipeWire convention): the delivered format
+    /// is whatever the broadcast extension published in the ring header,
+    /// known only at stream creation. `build()`'s negotiation treats an empty
+    /// list as "open with the request as-is"; the authoritative format is
+    /// reported via [`CapturingStream::format`] once the stream exists.
+    fn supported_formats(&self) -> Vec<AudioFormat> {
+        Vec::new()
+    }
+
+    /// [`DeviceKind::Output`]: the broadcast is a loopback of the system's
+    /// audio **output** mix — the closest honest classification for a
+    /// non-hardware transport endpoint.
+    fn kind(&self) -> AudioResult<DeviceKind> {
+        Ok(DeviceKind::Output)
+    }
+
+    /// Attaches to the broadcast ring and returns the live capture stream.
+    ///
+    /// Flow: validate target → require the App Group id
+    /// ([`StreamConfig::ios_app_group`], the ADR-0013 consent artifact) →
+    /// resolve the container → **bounded poll** ([`PUBLISH_POLL_TIMEOUT`]) for
+    /// a live, published ring → read geometry, publish the delivered format
+    /// on the bridge → spawn the non-RT drain thread → wrap in `BridgeStream`.
+    ///
+    /// # Errors
+    ///
+    /// - [`AudioError::UserConsentRequired`] when no App Group id was
+    ///   configured (`AudioCaptureBuilder::with_ios_app_group`) — normally
+    ///   caught earlier by the builder preflight; kept here for direct
+    ///   `AudioDevice` users.
+    /// - [`AudioError::StreamCreationFailed`] when the App Group container is
+    ///   unavailable (entitlement missing / wrong id), when no live ring
+    ///   appears within the poll window (broadcast not started), or on a ring
+    ///   version/geometry contract violation.
+    /// - [`AudioError::PlatformNotSupported`] / [`AudioError::DeviceNotFound`]
+    ///   per [`ensure_broadcast_target`].
+    fn create_stream(&self, config: &StreamConfig) -> AudioResult<Box<dyn CapturingStream>> {
+        ensure_broadcast_target(&config.capture_target)?;
+
+        let group =
+            config
+                .ios_app_group
+                .as_deref()
+                .ok_or_else(|| AudioError::UserConsentRequired {
+                    feature: "iOS broadcast capture".to_string(),
+                    missing: "App Group identifier — call \
+                          AudioCaptureBuilder::with_ios_app_group(\"group.…\") and \
+                          embed the RsacBroadcastKit extension"
+                        .to_string(),
+                })?;
+
+        let container =
+            app_group_container_path(group).ok_or_else(|| AudioError::StreamCreationFailed {
+                reason: format!(
+                    "App Group container unavailable for '{group}' — the host app's \
+                     com.apple.security.application-groups entitlement must list \
+                     this identifier (and the broadcast extension must share it)"
+                ),
+                context: None,
+            })?;
+        let ring_path = container.join(RING_FILE_NAME);
+
+        let ring = poll_for_published_ring(&ring_path, PUBLISH_POLL_TIMEOUT)?;
+
+        // The ring header is the authoritative delivered format (always f32
+        // per the contract's data-region definition).
+        let delivered = AudioFormat {
+            sample_rate: ring.geometry.sample_rate,
+            channels: ring.geometry.channels as u16,
+            sample_format: SampleFormat::F32,
+        };
+
+        // Ring sizing: honour the requested slot count like the mic path
+        // (ADR-0007 direction), defaulting to calculate_capacity(None, 4) = 64.
+        let capacity = calculate_capacity(config.buffer_size, 4);
+        let (producer, consumer) = create_bridge(capacity, delivered.clone());
+
+        // Publish the delivery format BEFORE any push (M1 pattern).
+        producer.set_negotiated_format(&delivered);
+
+        // Transition bridge state Created → Running before the drain thread
+        // starts pushing, so the first buffers are readable.
+        consumer
+            .shared()
+            .state
+            .transition(StreamState::Created, StreamState::Running)
+            .map_err(|actual| AudioError::InternalError {
+                message: format!(
+                    "Failed to transition bridge state to Running (was {:?})",
+                    actual
+                ),
+                source: None,
+            })?;
+
+        let terminal = Arc::clone(consumer.shared());
+        let stop = Arc::new(AtomicBool::new(false));
+        let active = Arc::new(AtomicBool::new(true));
+
+        let ring_capacity_frames = ring.geometry.capacity_frames;
+        let thread_stop = Arc::clone(&stop);
+        let thread_active = Arc::clone(&active);
+        let handle = std::thread::Builder::new()
+            .name("rsac-ios-broadcast-drain".to_string())
+            .spawn(move || run_drain_loop(ring, producer, thread_stop, thread_active))
+            .map_err(|e| AudioError::StreamCreationFailed {
+                reason: format!("failed to spawn the broadcast drain thread: {e}"),
+                context: None,
+            })?;
+
+        log::debug!(
+            "ReplayKit broadcast capture attached ({} Hz, {} ch, ring {} frames)",
+            delivered.sample_rate,
+            delivered.channels,
+            ring_capacity_frames
+        );
+
+        let platform_stream = BroadcastPlatformStream {
+            stop,
+            join: Mutex::new(Some(handle)),
+            active,
+            terminal,
+        };
+
+        Ok(Box::new(BridgeStream::new(
+            consumer,
+            platform_stream,
+            delivered,
+            Duration::from_secs(1),
+        )))
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// Tests — PURE ring math only (no mmap, no ObjC, no threads). They pin the
+// RingLayout.swift v1 contract byte-for-byte, compile for the iOS target
+// under `--tests`, and run on-device later under rsac-97c8.
+// ══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::{ApplicationId, ProcessId};
+
+    // ── Contract pinning ─────────────────────────────────────────────
+
+    #[test]
+    fn contract_constants_match_ring_layout_v1() {
+        // Byte-for-byte mirror of RingLayout.swift (v1). If any of these
+        // asserts needs changing, the layout version must be bumped on BOTH
+        // sides.
+        assert_eq!(RING_MAGIC, 0x4341_5352, "ASCII \"RSAC\" as LE u32");
+        assert_eq!(RING_LAYOUT_VERSION, 1);
+        assert_eq!(PUBLISHED_MAGIC_VERSION, 0x0000_0001_4341_5352);
+        assert_eq!(RING_FILE_NAME, "rsac_broadcast_ring_v1");
+        assert_eq!(OFFSET_SAMPLE_RATE, 8);
+        assert_eq!(OFFSET_CHANNELS, 12);
+        assert_eq!(OFFSET_CAPACITY_FRAMES, 16);
+        assert_eq!(OFFSET_WRITE_CURSOR, 24);
+        assert_eq!(OFFSET_READ_CURSOR, 32);
+        assert_eq!(OFFSET_HEARTBEAT_MILLIS, 40);
+        assert_eq!(OFFSET_PRODUCER_DROP_COUNT, 48);
+        assert_eq!(DATA_OFFSET, 64);
+        assert_eq!(HEARTBEAT_TIMEOUT_MILLIS, 2_000);
+    }
+
+    #[test]
+    fn atomic_header_offsets_are_8_aligned() {
+        for offset in [
+            0,
+            OFFSET_WRITE_CURSOR,
+            OFFSET_READ_CURSOR,
+            OFFSET_HEARTBEAT_MILLIS,
+            OFFSET_PRODUCER_DROP_COUNT,
+        ] {
+            assert_eq!(offset % 8, 0, "atomic field at {offset} must be 8-aligned");
+        }
+    }
+
+    // ── Publish-word classification ──────────────────────────────────
+
+    #[test]
+    fn publish_word_v1_is_published() {
+        assert_eq!(
+            classify_publish_word(PUBLISHED_MAGIC_VERSION),
+            PublishState::PublishedV1
+        );
+    }
+
+    #[test]
+    fn publish_word_zero_and_garbage_are_unpublished() {
+        assert_eq!(classify_publish_word(0), PublishState::Unpublished);
+        // Magic bytes absent → unpublished, regardless of the high half.
+        assert_eq!(
+            classify_publish_word(0x0000_0001_DEAD_BEEF),
+            PublishState::Unpublished
+        );
+        // Magic alone (version half still 0) is NOT the committed word: the
+        // producer commits magic+version as a single u64 store.
+        assert_eq!(
+            classify_publish_word(u64::from(RING_MAGIC)),
+            PublishState::VersionMismatch(0)
+        );
+    }
+
+    #[test]
+    fn publish_word_future_version_is_a_mismatch_not_a_wait() {
+        assert_eq!(
+            classify_publish_word((2u64 << 32) | u64::from(RING_MAGIC)),
+            PublishState::VersionMismatch(2)
+        );
+    }
+
+    // ── Geometry validation ──────────────────────────────────────────
+
+    #[test]
+    fn geometry_happy_path_48k_stereo_2s() {
+        // The producer default: 2 s at 48 kHz stereo = 96 000 frames,
+        // 64 + 96_000 * 2 * 4 = 768_064 bytes.
+        let len = ring_file_size(96_000, 2).unwrap();
+        assert_eq!(len, 64 + 96_000 * 2 * 4);
+        let g = validate_geometry(48_000, 2, 96_000, len).unwrap();
+        assert_eq!(g.sample_rate, 48_000);
+        assert_eq!(g.channels, 2);
+        assert_eq!(g.capacity_frames, 96_000);
+    }
+
+    #[test]
+    fn geometry_rejects_zero_fields() {
+        let len = ring_file_size(1_000, 2).unwrap();
+        assert!(validate_geometry(0, 2, 1_000, len).is_err());
+        assert!(validate_geometry(48_000, 0, 1_000, len).is_err());
+        assert!(validate_geometry(48_000, 2, 0, len).is_err());
+    }
+
+    #[test]
+    fn geometry_rejects_absurd_channel_counts() {
+        let len = ring_file_size(1_000, 33).unwrap();
+        assert!(validate_geometry(48_000, 33, 1_000, len).is_err());
+    }
+
+    #[test]
+    fn geometry_rejects_file_too_small() {
+        let needed = ring_file_size(96_000, 2).unwrap();
+        assert!(validate_geometry(48_000, 2, 96_000, needed - 1).is_err());
+        assert!(validate_geometry(48_000, 2, 96_000, needed).is_ok());
+    }
+
+    #[test]
+    fn geometry_size_math_never_panics_on_huge_headers() {
+        // A (corrupt) header claiming a gigantic ring must degrade to a clean
+        // rejection — checked math, no overflow panic, no wrap-around into a
+        // small "needed" size that a tiny file could satisfy.
+        assert!(validate_geometry(48_000, 32, u32::MAX, 1024).is_err());
+    }
+
+    // ── Cursor / slot math ───────────────────────────────────────────
+
+    #[test]
+    fn available_frames_basic_and_empty() {
+        assert_eq!(available_frames(0, 0, 100), Some(0));
+        assert_eq!(available_frames(42, 0, 100), Some(42));
+        assert_eq!(available_frames(150, 70, 100), Some(80));
+        // Full ring is legal.
+        assert_eq!(available_frames(100, 0, 100), Some(100));
+    }
+
+    #[test]
+    fn available_frames_detects_inconsistent_cursors() {
+        // Fill level above capacity: corrupt / re-initialized generation.
+        assert_eq!(available_frames(201, 100, 100), None);
+        // A reset writeCursor behind readCursor wraps to a huge value → None.
+        assert_eq!(available_frames(0, 1_000, 100), None);
+    }
+
+    #[test]
+    fn segments_without_wrap() {
+        // read at slot 10 of 100, taking 20: one contiguous segment.
+        assert_eq!(contiguous_segments(10, 20, 100), (20, 0));
+    }
+
+    #[test]
+    fn segments_exactly_to_the_edge() {
+        // Taking exactly up to the physical end: still no wrap.
+        assert_eq!(contiguous_segments(90, 10, 100), (10, 0));
+    }
+
+    #[test]
+    fn segments_with_wrap() {
+        // read at slot 90 of 100, taking 30: 10 to the edge + 20 wrapped.
+        assert_eq!(contiguous_segments(90, 30, 100), (10, 20));
+    }
+
+    #[test]
+    fn segments_at_large_monotonic_cursors() {
+        // Cursors are monotonic (never wrapped); slot math must hold at
+        // arbitrary magnitudes. 1e12 % 96_000 = 62_500... compute directly.
+        let read: u64 = 1_000_000_000_000;
+        let capacity: u64 = 96_000;
+        let slot = read % capacity;
+        let take = 96_000; // full ring
+        let (first, second) = contiguous_segments(read, take, capacity);
+        assert_eq!(first, capacity - slot);
+        assert_eq!(second, take - first);
+        assert_eq!(first + second, take);
+    }
+
+    // ── Heartbeat staleness ──────────────────────────────────────────
+
+    #[test]
+    fn heartbeat_fresh_and_boundary() {
+        assert!(!heartbeat_is_stale(10_000, 10_000));
+        assert!(!heartbeat_is_stale(10_000, 11_999));
+        // Exactly the timeout is NOT stale ("older than" is strict, matching
+        // the Swift contract's wording).
+        assert!(!heartbeat_is_stale(10_000, 12_000));
+        assert!(heartbeat_is_stale(10_000, 12_001));
+    }
+
+    #[test]
+    fn heartbeat_from_the_future_reads_fresh() {
+        // Same clock domain, so this cannot happen — but it must not
+        // underflow into "stale".
+        assert!(!heartbeat_is_stale(20_000, 10_000));
+    }
+
+    // ── Drain sizing ─────────────────────────────────────────────────
+
+    #[test]
+    fn drain_chunk_is_about_20ms_with_a_floor() {
+        assert_eq!(drain_chunk_frames(48_000), 960);
+        assert_eq!(drain_chunk_frames(44_100), 882);
+        // Low rates hit the 256-frame floor.
+        assert_eq!(drain_chunk_frames(8_000), 256);
+    }
+
+    // ── Target classification / device metadata ──────────────────────
+
+    #[test]
+    fn broadcast_target_accepts_system_default_and_own_id() {
+        assert!(ensure_broadcast_target(&CaptureTarget::SystemDefault).is_ok());
+        for id in [BROADCAST_DEVICE_ID, "REPLAYKIT-BROADCAST"] {
+            assert!(
+                ensure_broadcast_target(&CaptureTarget::Device(DeviceId(id.to_string()))).is_ok()
+            );
+        }
+    }
+
+    #[test]
+    fn broadcast_target_rejects_other_devices_and_per_app() {
+        match ensure_broadcast_target(&CaptureTarget::Device(DeviceId("default".into()))) {
+            Err(AudioError::DeviceNotFound { device_id }) => assert_eq!(device_id, "default"),
+            other => panic!("expected DeviceNotFound, got {other:?}"),
+        }
+        let per_app = [
+            CaptureTarget::Application(ApplicationId("1".into())),
+            CaptureTarget::ApplicationByName("Safari".into()),
+            CaptureTarget::ProcessTree(ProcessId(1)),
+        ];
+        for target in per_app {
+            match ensure_broadcast_target(&target) {
+                Err(AudioError::PlatformNotSupported { feature, platform }) => {
+                    assert_eq!(platform, "ios");
+                    assert!(feature.contains("permanent"), "{feature}");
+                }
+                other => panic!("expected PlatformNotSupported for {target:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn broadcast_device_metadata_is_honest() {
+        let device = BroadcastAudioDevice::new();
+        assert_eq!(device.id(), DeviceId(BROADCAST_DEVICE_ID.to_string()));
+        assert!(device.name().contains("ReplayKit"));
+        assert_eq!(device.kind().unwrap(), DeviceKind::Output);
+        assert!(device.is_default());
+        // Formats are negotiated from the ring header at stream creation —
+        // the advertised list is empty by design (Linux/PipeWire precedent).
+        assert!(device.supported_formats().is_empty());
+    }
+}

--- a/src/audio/ios/mod.rs
+++ b/src/audio/ios/mod.rs
@@ -1,36 +1,42 @@
-//! iOS audio capture backend — AVAudioEngine **microphone slice** (rsac-9e02).
+//! iOS audio capture backend — AVAudioEngine microphone (rsac-9e02) +
+//! ReplayKit broadcast system capture (rsac-b3aa).
 //!
 //! # Current scope (honest status)
 //!
-//! This backend captures the **session's current audio input** (microphone,
-//! or whatever input route `AVAudioSession` has active — wired headset, BT,
-//! USB) via an `AVAudioEngine` input-node tap. That is the *entire* shipped
-//! surface today:
+//! Two capture paths ship today:
 //!
 //! | `CaptureTarget` | iOS behaviour |
 //! |---|---|
 //! | `Device(DeviceId("default"))` | ✅ mic capture via AVAudioEngine input tap |
-//! | `SystemDefault` | ❌ pending — the ReplayKit Broadcast Upload Extension path (rsac-b3aa) |
+//! | `SystemDefault` | ✅ system mix via the ReplayKit Broadcast Upload Extension transport ([`broadcast`]) — **user-initiated**, requires an App Group + the embedded `RsacBroadcastKit` extension |
 //! | `Application` / `ApplicationByName` / `ProcessTree` | ❌ **permanently unsupported** — Apple provides no API for capturing another app's audio (ADR-0013; never soften this) |
 //!
 //! [`PlatformCapabilities::query`](crate::core::capabilities::PlatformCapabilities::query)
-//! reports exactly this (`backend_name = "AVAudioEngine"`, all per-app flags
-//! `false`).
+//! reports exactly this (`backend_name = "AVAudioEngine"`, per-app flags
+//! `false`, `requires_user_consent = true` — the App Group id is the
+//! config-time consent artifact for `SystemDefault`).
 //!
 //! # Host-app responsibilities (NOT this library's job)
 //!
 //! rsac deliberately does **not** touch the shared `AVAudioSession` — session
 //! configuration is app-global policy that only the host application can own.
-//! Before building a capture, the host app must:
+//! For **mic capture**, before building a capture the host app must:
 //!
 //! 1. declare `NSMicrophoneUsageDescription` in its `Info.plist`,
 //! 2. obtain the microphone permission (the first mic access prompts), and
 //! 3. configure + activate an `AVAudioSession` with a record-capable category
 //!    (`.record` or `.playAndRecord`).
 //!
+//! For **system capture** (`SystemDefault`), the app must embed a Broadcast
+//! Upload Extension built on `RsacBroadcastKit`, share an App Group with it,
+//! pass the App Group id via
+//! [`AudioCaptureBuilder::with_ios_app_group`](crate::api::AudioCaptureBuilder::with_ios_app_group),
+//! and the **user** must start the broadcast (there is no programmatic
+//! start). See the [`broadcast`] module docs and `mobile/ios/README.md`.
+//!
 //! The Swift helpers shipped in `mobile/ios/` (ADR-0012's SwiftPM package)
-//! wrap this consent/session flow. If the session has no active input route,
-//! stream creation fails with an actionable
+//! wrap these consent/session flows. If the session has no active input
+//! route, mic stream creation fails with an actionable
 //! [`AudioError::StreamCreationFailed`](crate::core::error::AudioError::StreamCreationFailed)
 //! rather than delivering silence.
 //!
@@ -44,6 +50,12 @@
 //! AVAudioNodeTapBlock                        BridgeStream<IosPlatformStream>
 //!   → interleave into scratch                  ::read_chunk()
 //!   → BridgeProducer::push_samples_…
+//!
+//! Broadcast drain thread (non-RT)            Consumer thread
+//! ───────────────────────────────            ───────────────
+//! App-Group mmap ring (extension = producer) BridgeStream<BroadcastPlatformStream>
+//!   → copy frames into scratch                 ::read_chunk()
+//!   → BridgeProducer::push_samples_…
 //! ```
 //!
 //! - `avaudio` owns the ObjC interop: engine/tap setup and the tap block
@@ -55,8 +67,12 @@
 //!   impl) whose stop path removes the tap, stops the engine, and drives the
 //!   bridge to its graceful ending state (producer terminal signal,
 //!   ADR-0010).
+//! - [`broadcast`] provides the host-side consumer of the canonical
+//!   cross-process mmap ring (`mobile/ios/…/RingLayout.swift`) plus
+//!   `BroadcastPlatformStream` and [`BroadcastAudioDevice`].
 
 pub(crate) mod avaudio;
+pub(crate) mod broadcast;
 pub(crate) mod thread;
 
 use std::sync::Arc;
@@ -67,6 +83,8 @@ use crate::bridge::{calculate_capacity, create_bridge, BridgeStream};
 use crate::core::config::{AudioFormat, DeviceId, SampleFormat, StreamConfig};
 use crate::core::error::{AudioError, AudioResult};
 use crate::core::interface::{AudioDevice, CapturingStream, DeviceEnumerator, DeviceKind};
+
+pub use broadcast::BroadcastAudioDevice;
 
 /// The [`DeviceId`] string of the single logical iOS input device.
 ///
@@ -82,13 +100,18 @@ pub(crate) const DEFAULT_INPUT_DEVICE_ID: &str = "default";
 
 // ── IosDeviceEnumerator ──────────────────────────────────────────────────
 
-/// [`DeviceEnumerator`] for iOS (AVAudioEngine backend, mic slice).
+/// [`DeviceEnumerator`] for iOS (AVAudioEngine mic + ReplayKit broadcast).
 ///
-/// Enumeration on iOS is intentionally minimal: the OS routes audio input at
-/// the `AVAudioSession` level, so there is exactly **one logical input
-/// device** — `"default"` — representing the session's current input route.
-/// See [`DeviceEnumerator::default_device`] for why the *default device*
-/// (rsac's loopback-oriented notion) is an error on iOS today.
+/// Enumeration on iOS is intentionally minimal — two logical devices:
+///
+/// - `"default"` ([`IosAudioDevice`]): the session's current audio **input**
+///   (mic/headset/BT/USB — the OS routes input at the `AVAudioSession`
+///   level; per-route enumeration is host-app session state and is
+///   deliberately not duplicated here).
+/// - `"replaykit-broadcast"` ([`BroadcastAudioDevice`]): the system-audio
+///   capture endpoint backed by the ReplayKit broadcast transport
+///   (rsac-b3aa). Not a hardware device — listed so device-driven consumers
+///   can discover and select the system-capture path explicitly.
 #[derive(Debug, Clone, Copy)]
 pub struct IosDeviceEnumerator;
 
@@ -110,46 +133,33 @@ impl Default for IosDeviceEnumerator {
 }
 
 impl DeviceEnumerator for IosDeviceEnumerator {
-    /// Lists the single logical iOS audio input device.
+    /// Lists the two logical iOS audio devices: the default input (mic) and
+    /// the ReplayKit broadcast system-capture endpoint.
     ///
-    /// Returns exactly one device — `DeviceId("default")`, the session's
-    /// current audio input. Per-route enumeration
-    /// (`AVAudioSession.availableInputs`) is session state owned by the host
-    /// app and is deliberately not duplicated here.
+    /// Each is the default **of its kind**: the mic is the default
+    /// [`DeviceKind::Input`], the broadcast device the default (and only)
+    /// [`DeviceKind::Output`]-loopback endpoint.
     fn enumerate_devices(&self) -> AudioResult<Vec<Box<dyn AudioDevice>>> {
-        Ok(vec![Box::new(IosAudioDevice::new())])
+        Ok(vec![
+            Box::new(IosAudioDevice::new()),
+            Box::new(BroadcastAudioDevice::new()),
+        ])
     }
 
-    /// The rsac *default device* is not available on iOS yet — errors with
-    /// guidance.
+    /// Returns the ReplayKit broadcast device — rsac's *default device* on
+    /// iOS.
     ///
-    /// On desktop backends `default_device()` returns the default **output**
-    /// endpoint because rsac's headline capability there is system-audio
-    /// loopback. On iOS, system audio (`CaptureTarget::SystemDefault`) is the
-    /// ReplayKit Broadcast Upload Extension path, which is **not wired yet**
-    /// (rsac-b3aa). Pretending the microphone is "the default device" would
-    /// silently deliver different audio than the desktop contract promises
-    /// (the dishonest-fallback option ADR-0013 explicitly rejected), so this
-    /// returns [`AudioError::PlatformNotSupported`] with the honest state:
-    ///
-    /// - **Supported now:** microphone capture via
-    ///   `CaptureTarget::Device(DeviceId("default".into()))`.
-    /// - **Pending:** system audio via the ReplayKit broadcast path
-    ///   (rsac-b3aa).
-    /// - **Permanent:** per-app / process-tree capture does not exist on iOS
-    ///   — Apple provides no API.
+    /// On every desktop backend `default_device()` returns the default
+    /// **output** endpoint because rsac's headline capability is system-audio
+    /// loopback; the iOS equivalent of that endpoint is the broadcast
+    /// transport (rsac-b3aa), so `CaptureTarget::SystemDefault` resolves
+    /// here. Creating a stream from it has real preconditions — an App Group
+    /// id on the builder, an embedded `RsacBroadcastKit` extension, and a
+    /// user-started broadcast — surfaced as actionable errors at
+    /// `create_stream` time (see [`BroadcastAudioDevice`]). For the
+    /// microphone, use `CaptureTarget::Device(DeviceId("default".into()))`.
     fn default_device(&self) -> AudioResult<Box<dyn AudioDevice>> {
-        Err(AudioError::PlatformNotSupported {
-            feature: "default-device (system audio loopback) capture on iOS: \
-                      SystemDefault is the ReplayKit Broadcast Upload Extension \
-                      path, which is not wired yet (rsac-b3aa). Use \
-                      CaptureTarget::Device(DeviceId(\"default\".into())) to \
-                      capture the microphone (the session's current audio \
-                      input). Per-application capture does not exist on iOS, \
-                      permanently — Apple provides no API for it"
-                .to_string(),
-            platform: "ios".to_string(),
-        })
+        Ok(Box::new(BroadcastAudioDevice::new()))
     }
 
     // watch(): inherits the trait default (PlatformNotSupported) — consistent
@@ -240,9 +250,9 @@ impl AudioDevice for IosAudioDevice {
     ///
     /// # Errors
     ///
-    /// - [`AudioError::PlatformNotSupported`] for `SystemDefault`
-    ///   (ReplayKit path pending, rsac-b3aa) and for `Application*` /
-    ///   `ProcessTree` (permanently impossible on iOS).
+    /// - [`AudioError::PlatformNotSupported`] for `SystemDefault` (served by
+    ///   [`BroadcastAudioDevice`], not this mic device) and for
+    ///   `Application*` / `ProcessTree` (permanently impossible on iOS).
     /// - [`AudioError::DeviceNotFound`] for a `Device` id other than
     ///   `"default"`.
     /// - [`AudioError::StreamCreationFailed`] when the engine cannot start
@@ -296,43 +306,45 @@ impl AudioDevice for IosAudioDevice {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::error::ErrorKind;
 
     #[test]
-    fn enumerate_devices_returns_single_default_input() {
+    fn enumerate_devices_lists_mic_and_broadcast() {
         let enumerator = IosDeviceEnumerator::new();
         let devices = enumerator
             .enumerate_devices()
             .expect("enumeration is infallible metadata");
-        assert_eq!(devices.len(), 1, "exactly one logical iOS input device");
+        assert_eq!(devices.len(), 2, "mic + broadcast endpoint");
 
-        let device = &devices[0];
-        assert_eq!(device.id(), DeviceId(DEFAULT_INPUT_DEVICE_ID.to_string()));
-        assert_eq!(device.name(), "Default audio input (AVAudioEngine)");
-        assert!(device.is_default());
-        assert_eq!(device.kind().unwrap(), DeviceKind::Input);
+        let mic = &devices[0];
+        assert_eq!(mic.id(), DeviceId(DEFAULT_INPUT_DEVICE_ID.to_string()));
+        assert_eq!(mic.name(), "Default audio input (AVAudioEngine)");
+        assert!(mic.is_default(), "mic stays the default Input device");
+        assert_eq!(mic.kind().unwrap(), DeviceKind::Input);
+
+        let broadcast = &devices[1];
+        assert_eq!(
+            broadcast.id(),
+            DeviceId(broadcast::BROADCAST_DEVICE_ID.to_string())
+        );
+        assert_eq!(broadcast.kind().unwrap(), DeviceKind::Output);
+        assert!(broadcast.is_default(), "default of its (Output) kind");
     }
 
     #[test]
-    fn default_device_is_honest_platform_not_supported() {
+    fn default_device_is_the_broadcast_endpoint() {
+        // rsac-b3aa: SystemDefault resolves to the ReplayKit broadcast device
+        // (the desktop convention — default_device() is the system-loopback
+        // endpoint), no longer an error.
         let enumerator = IosDeviceEnumerator::new();
-        let err = match enumerator.default_device() {
-            Ok(_) => panic!("default_device must error until rsac-b3aa"),
-            Err(err) => err,
-        };
-        assert_eq!(err.kind(), ErrorKind::Platform);
-        match err {
-            AudioError::PlatformNotSupported { feature, platform } => {
-                assert_eq!(platform, "ios");
-                // The three honesty pillars: what works, what's pending, what
-                // is permanent.
-                assert!(feature.contains("default"), "mic guidance: {feature}");
-                assert!(feature.contains("rsac-b3aa"), "pending seed: {feature}");
-                assert!(feature.contains("permanently"), "permanence: {feature}");
-                assert!(feature.contains("ReplayKit"), "system path: {feature}");
-            }
-            other => panic!("expected PlatformNotSupported, got {other:?}"),
-        }
+        let device = enumerator
+            .default_device()
+            .expect("default device is metadata-only until create_stream");
+        assert_eq!(
+            device.id(),
+            DeviceId(broadcast::BROADCAST_DEVICE_ID.to_string())
+        );
+        assert_eq!(device.kind().unwrap(), DeviceKind::Output);
+        assert!(device.name().contains("ReplayKit"), "{}", device.name());
     }
 
     #[test]

--- a/src/audio/ios/mod.rs
+++ b/src/audio/ios/mod.rs
@@ -1,0 +1,361 @@
+//! iOS audio capture backend — AVAudioEngine **microphone slice** (rsac-9e02).
+//!
+//! # Current scope (honest status)
+//!
+//! This backend captures the **session's current audio input** (microphone,
+//! or whatever input route `AVAudioSession` has active — wired headset, BT,
+//! USB) via an `AVAudioEngine` input-node tap. That is the *entire* shipped
+//! surface today:
+//!
+//! | `CaptureTarget` | iOS behaviour |
+//! |---|---|
+//! | `Device(DeviceId("default"))` | ✅ mic capture via AVAudioEngine input tap |
+//! | `SystemDefault` | ❌ pending — the ReplayKit Broadcast Upload Extension path (rsac-b3aa) |
+//! | `Application` / `ApplicationByName` / `ProcessTree` | ❌ **permanently unsupported** — Apple provides no API for capturing another app's audio (ADR-0013; never soften this) |
+//!
+//! [`PlatformCapabilities::query`](crate::core::capabilities::PlatformCapabilities::query)
+//! reports exactly this (`backend_name = "AVAudioEngine"`, all per-app flags
+//! `false`).
+//!
+//! # Host-app responsibilities (NOT this library's job)
+//!
+//! rsac deliberately does **not** touch the shared `AVAudioSession` — session
+//! configuration is app-global policy that only the host application can own.
+//! Before building a capture, the host app must:
+//!
+//! 1. declare `NSMicrophoneUsageDescription` in its `Info.plist`,
+//! 2. obtain the microphone permission (the first mic access prompts), and
+//! 3. configure + activate an `AVAudioSession` with a record-capable category
+//!    (`.record` or `.playAndRecord`).
+//!
+//! The Swift helpers shipped in `mobile/ios/` (ADR-0012's SwiftPM package)
+//! wrap this consent/session flow. If the session has no active input route,
+//! stream creation fails with an actionable
+//! [`AudioError::StreamCreationFailed`](crate::core::error::AudioError::StreamCreationFailed)
+//! rather than delivering silence.
+//!
+//! # Architecture
+//!
+//! Same shape as every other rsac backend (no bespoke stream type):
+//!
+//! ```text
+//! AVFAudio tap thread (non-RT)              Consumer thread
+//! ───────────────────────────               ───────────────
+//! AVAudioNodeTapBlock                        BridgeStream<IosPlatformStream>
+//!   → interleave into scratch                  ::read_chunk()
+//!   → BridgeProducer::push_samples_…
+//! ```
+//!
+//! - `avaudio` owns the ObjC interop: engine/tap setup and the tap block
+//!   that interleaves each `AVAudioPCMBuffer` into a pre-allocated scratch
+//!   buffer and pushes it through the lock-free bridge (ADR-0001 adapted:
+//!   no per-callback heap allocation; oversized buffers are dropped and
+//!   counted, never allocated for).
+//! - `thread` provides `IosPlatformStream` (the internal `PlatformStream`
+//!   impl) whose stop path removes the tap, stops the engine, and drives the
+//!   bridge to its graceful ending state (producer terminal signal,
+//!   ADR-0010).
+
+pub(crate) mod avaudio;
+pub(crate) mod thread;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::bridge::state::StreamState;
+use crate::bridge::{calculate_capacity, create_bridge, BridgeStream};
+use crate::core::config::{AudioFormat, DeviceId, SampleFormat, StreamConfig};
+use crate::core::error::{AudioError, AudioResult};
+use crate::core::interface::{AudioDevice, CapturingStream, DeviceEnumerator, DeviceKind};
+
+/// The [`DeviceId`] string of the single logical iOS input device.
+///
+/// iOS does not offer free device selection to apps — the active input is
+/// chosen by the shared `AVAudioSession` route (mic / headset / BT / USB).
+/// rsac therefore exposes exactly one logical device, `"default"`, meaning
+/// "whatever input the session currently routes". The empty string is also
+/// accepted as an alias when resolving a [`CaptureTarget::Device`]
+/// (matching the Windows backend's default-endpoint convention).
+///
+/// [`CaptureTarget::Device`]: crate::core::config::CaptureTarget::Device
+pub(crate) const DEFAULT_INPUT_DEVICE_ID: &str = "default";
+
+// ── IosDeviceEnumerator ──────────────────────────────────────────────────
+
+/// [`DeviceEnumerator`] for iOS (AVAudioEngine backend, mic slice).
+///
+/// Enumeration on iOS is intentionally minimal: the OS routes audio input at
+/// the `AVAudioSession` level, so there is exactly **one logical input
+/// device** — `"default"` — representing the session's current input route.
+/// See [`DeviceEnumerator::default_device`] for why the *default device*
+/// (rsac's loopback-oriented notion) is an error on iOS today.
+#[derive(Debug, Clone, Copy)]
+pub struct IosDeviceEnumerator;
+
+impl IosDeviceEnumerator {
+    /// Creates a new iOS device enumerator.
+    ///
+    /// Non-fallible: no OS resources are touched until a stream is created
+    /// (matching the factory contract in
+    /// [`get_device_enumerator`](crate::audio::get_device_enumerator)).
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for IosDeviceEnumerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeviceEnumerator for IosDeviceEnumerator {
+    /// Lists the single logical iOS audio input device.
+    ///
+    /// Returns exactly one device — `DeviceId("default")`, the session's
+    /// current audio input. Per-route enumeration
+    /// (`AVAudioSession.availableInputs`) is session state owned by the host
+    /// app and is deliberately not duplicated here.
+    fn enumerate_devices(&self) -> AudioResult<Vec<Box<dyn AudioDevice>>> {
+        Ok(vec![Box::new(IosAudioDevice::new())])
+    }
+
+    /// The rsac *default device* is not available on iOS yet — errors with
+    /// guidance.
+    ///
+    /// On desktop backends `default_device()` returns the default **output**
+    /// endpoint because rsac's headline capability there is system-audio
+    /// loopback. On iOS, system audio (`CaptureTarget::SystemDefault`) is the
+    /// ReplayKit Broadcast Upload Extension path, which is **not wired yet**
+    /// (rsac-b3aa). Pretending the microphone is "the default device" would
+    /// silently deliver different audio than the desktop contract promises
+    /// (the dishonest-fallback option ADR-0013 explicitly rejected), so this
+    /// returns [`AudioError::PlatformNotSupported`] with the honest state:
+    ///
+    /// - **Supported now:** microphone capture via
+    ///   `CaptureTarget::Device(DeviceId("default".into()))`.
+    /// - **Pending:** system audio via the ReplayKit broadcast path
+    ///   (rsac-b3aa).
+    /// - **Permanent:** per-app / process-tree capture does not exist on iOS
+    ///   — Apple provides no API.
+    fn default_device(&self) -> AudioResult<Box<dyn AudioDevice>> {
+        Err(AudioError::PlatformNotSupported {
+            feature: "default-device (system audio loopback) capture on iOS: \
+                      SystemDefault is the ReplayKit Broadcast Upload Extension \
+                      path, which is not wired yet (rsac-b3aa). Use \
+                      CaptureTarget::Device(DeviceId(\"default\".into())) to \
+                      capture the microphone (the session's current audio \
+                      input). Per-application capture does not exist on iOS, \
+                      permanently — Apple provides no API for it"
+                .to_string(),
+            platform: "ios".to_string(),
+        })
+    }
+
+    // watch(): inherits the trait default (PlatformNotSupported) — consistent
+    // with `supports_device_change_notifications: false` in
+    // PlatformCapabilities::ios(). Route changes are AVAudioSession
+    // notifications, which belong to the host app / mobile/ios helpers.
+}
+
+// ── IosAudioDevice ───────────────────────────────────────────────────────
+
+/// The single logical iOS audio input device (the session's current input).
+///
+/// A metadata-only handle: constructing it touches no OS resources. The
+/// AVAudioEngine machinery is created lazily in
+/// [`create_stream`](AudioDevice::create_stream).
+#[derive(Debug, Clone, Copy)]
+pub struct IosAudioDevice;
+
+impl IosAudioDevice {
+    /// Creates the logical default-input device handle.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for IosAudioDevice {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AudioDevice for IosAudioDevice {
+    fn id(&self) -> DeviceId {
+        DeviceId(DEFAULT_INPUT_DEVICE_ID.to_string())
+    }
+
+    fn name(&self) -> String {
+        "Default audio input (AVAudioEngine)".to_string()
+    }
+
+    fn is_default(&self) -> bool {
+        true
+    }
+
+    /// Advisory format list: f32 at common iOS session rates, mono/stereo.
+    ///
+    /// iOS negotiates the *actual* rate/channels at the `AVAudioSession`
+    /// level (e.g. `setPreferredSampleRate`), not per-stream — so this list
+    /// is a hint, not a contract. The **delivered** format is read from the
+    /// live input node at stream creation and reported authoritatively via
+    /// [`CapturingStream::format`]; requested rate/channels that differ from
+    /// the session's native input format are not converted by this backend.
+    fn supported_formats(&self) -> Vec<AudioFormat> {
+        const RATES_STEREO: [u32; 2] = [48_000, 44_100];
+        const RATES_MONO: [u32; 4] = [48_000, 44_100, 16_000, 8_000];
+        let mut formats = Vec::with_capacity(RATES_STEREO.len() + RATES_MONO.len());
+        for rate in RATES_STEREO {
+            formats.push(AudioFormat {
+                sample_rate: rate,
+                channels: 2,
+                sample_format: SampleFormat::F32,
+            });
+        }
+        for rate in RATES_MONO {
+            formats.push(AudioFormat {
+                sample_rate: rate,
+                channels: 1,
+                sample_format: SampleFormat::F32,
+            });
+        }
+        formats
+    }
+
+    fn kind(&self) -> AudioResult<DeviceKind> {
+        Ok(DeviceKind::Input)
+    }
+
+    /// Creates a live microphone capture stream through the ring-buffer
+    /// bridge.
+    ///
+    /// Wiring (identical shape to the desktop backends): create the bridge
+    /// (ring depth honours `config.buffer_size`, ADR-0007 pattern), transition
+    /// it to `Running`, start the AVAudioEngine input tap
+    /// (`thread::create_ios_capture`), and wrap everything in a
+    /// `BridgeStream`. The stream's [`format`](CapturingStream::format)
+    /// reports the **delivered** (session-native) format, which may differ
+    /// from the requested one — see [`AudioDevice::supported_formats`].
+    ///
+    /// # Errors
+    ///
+    /// - [`AudioError::PlatformNotSupported`] for `SystemDefault`
+    ///   (ReplayKit path pending, rsac-b3aa) and for `Application*` /
+    ///   `ProcessTree` (permanently impossible on iOS).
+    /// - [`AudioError::DeviceNotFound`] for a `Device` id other than
+    ///   `"default"`.
+    /// - [`AudioError::StreamCreationFailed`] when the engine cannot start
+    ///   (typically: no active input route / missing mic permission — a
+    ///   host-app `AVAudioSession` responsibility; see the module docs).
+    fn create_stream(&self, config: &StreamConfig) -> AudioResult<Box<dyn CapturingStream>> {
+        let requested = config.to_audio_format();
+
+        // Ring sizing: honour the requested slot count like Windows/Linux do
+        // (ADR-0007 direction), defaulting to calculate_capacity(None, 4) = 64.
+        let capacity = calculate_capacity(config.buffer_size, 4);
+        let (producer, consumer) = create_bridge(capacity, requested);
+
+        // Transition bridge state Created → Running before the tap starts
+        // pushing, so the first callback's buffers are readable.
+        consumer
+            .shared()
+            .state
+            .transition(StreamState::Created, StreamState::Running)
+            .map_err(|actual| AudioError::InternalError {
+                message: format!(
+                    "Failed to transition bridge state to Running (was {:?})",
+                    actual
+                ),
+                source: None,
+            })?;
+
+        // Producer-terminal-signal handle (ADR-0010): the platform stream's
+        // stop/Drop choke point drives the bridge to its graceful ending
+        // state so a parked reader observes end-of-stream instead of hanging.
+        let terminal = Arc::clone(consumer.shared());
+
+        // Resolve the target, start the engine + tap. `delivered` is the REAL
+        // session-native format (also published on the bridge as the
+        // negotiated format before the tap is installed).
+        let (platform_stream, delivered) =
+            thread::create_ios_capture(&config.capture_target, producer, terminal)?;
+
+        let bridge_stream =
+            BridgeStream::new(consumer, platform_stream, delivered, Duration::from_secs(1));
+
+        Ok(Box::new(bridge_stream))
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// Tests — metadata-only (no ObjC): compile for the iOS target under --tests,
+// run on-device. They never touch AVAudioEngine.
+// ══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::error::ErrorKind;
+
+    #[test]
+    fn enumerate_devices_returns_single_default_input() {
+        let enumerator = IosDeviceEnumerator::new();
+        let devices = enumerator
+            .enumerate_devices()
+            .expect("enumeration is infallible metadata");
+        assert_eq!(devices.len(), 1, "exactly one logical iOS input device");
+
+        let device = &devices[0];
+        assert_eq!(device.id(), DeviceId(DEFAULT_INPUT_DEVICE_ID.to_string()));
+        assert_eq!(device.name(), "Default audio input (AVAudioEngine)");
+        assert!(device.is_default());
+        assert_eq!(device.kind().unwrap(), DeviceKind::Input);
+    }
+
+    #[test]
+    fn default_device_is_honest_platform_not_supported() {
+        let enumerator = IosDeviceEnumerator::new();
+        let err = match enumerator.default_device() {
+            Ok(_) => panic!("default_device must error until rsac-b3aa"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), ErrorKind::Platform);
+        match err {
+            AudioError::PlatformNotSupported { feature, platform } => {
+                assert_eq!(platform, "ios");
+                // The three honesty pillars: what works, what's pending, what
+                // is permanent.
+                assert!(feature.contains("default"), "mic guidance: {feature}");
+                assert!(feature.contains("rsac-b3aa"), "pending seed: {feature}");
+                assert!(feature.contains("permanently"), "permanence: {feature}");
+                assert!(feature.contains("ReplayKit"), "system path: {feature}");
+            }
+            other => panic!("expected PlatformNotSupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn supported_formats_are_all_f32_and_non_empty() {
+        let device = IosAudioDevice::new();
+        let formats = device.supported_formats();
+        assert!(!formats.is_empty());
+        for fmt in &formats {
+            assert_eq!(fmt.sample_format, SampleFormat::F32);
+            assert!(fmt.sample_rate > 0);
+            assert!(fmt.channels == 1 || fmt.channels == 2);
+        }
+        // First entry (the DeviceInfo::default_format seed) is 48 kHz stereo.
+        assert_eq!(formats[0].sample_rate, 48_000);
+        assert_eq!(formats[0].channels, 2);
+    }
+
+    #[test]
+    fn describe_snapshot_is_consistent() {
+        let info = IosAudioDevice::new().describe();
+        assert_eq!(info.id, DeviceId(DEFAULT_INPUT_DEVICE_ID.to_string()));
+        assert_eq!(info.kind, DeviceKind::Input);
+        assert!(info.is_default);
+        assert!(info.default_format.is_some());
+    }
+}

--- a/src/audio/ios/thread.rs
+++ b/src/audio/ios/thread.rs
@@ -1,0 +1,338 @@
+//! `IosPlatformStream` — the iOS backend's `PlatformStream` implementation.
+//!
+//! Mirrors the macOS `MacosPlatformStream` shape: an atomic active flag, the
+//! live ObjC capture objects behind a `Mutex`, and a clone of the bridge's
+//! shared state (`terminal`) so the stop/Drop choke point can drive the
+//! bridge to its graceful ending state (producer terminal signal,
+//! FH-1 / ADR-0010) — a parked reader then observes end-of-stream instead of
+//! hanging on a stopped engine.
+//!
+//! # Threading model
+//!
+//! Unlike Linux (dedicated PipeWire thread) and Windows (rsac-owned capture
+//! loop), AVFAudio manages its own threads: the engine drives the audio
+//! hardware, and the input-node tap block fires on AVFAudio's internal tap
+//! thread. There is **no rsac-owned capture thread** — the module name
+//! follows the per-backend convention, not an actual `std::thread`.
+
+#![cfg(all(target_os = "ios", feature = "feat_ios"))]
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::bridge::ring_buffer::{BridgeProducer, BridgeShared};
+use crate::bridge::state::StreamState;
+use crate::bridge::stream::PlatformStream;
+use crate::core::config::{AudioFormat, CaptureTarget};
+use crate::core::error::{AudioError, AudioResult};
+
+use super::avaudio::{start_input_capture, AvAudioEngineCapture};
+use super::DEFAULT_INPUT_DEVICE_ID;
+
+// ── IosPlatformStream ────────────────────────────────────────────────────
+
+/// Platform-specific stream handle for iOS (AVAudioEngine backend).
+///
+/// Wraps the live [`AvAudioEngineCapture`] (engine + input node, kept
+/// retained for the stream's lifetime) and implements [`PlatformStream`] so
+/// it can be used with `BridgeStream`.
+///
+/// # Shutdown
+///
+/// [`stop_capture`](PlatformStream::stop_capture) (and `Drop`, via the same
+/// choke point) removes the tap, stops the engine, and then drives the
+/// bridge `Running → Stopping` — the graceful producer terminal signal
+/// (ADR-0010). The ordering matters: the terminal transition happens only
+/// **after** the tap is removed, so no callback can push a buffer past the
+/// declared end.
+pub(crate) struct IosPlatformStream {
+    /// Live AVAudioEngine objects, protected by a `Mutex` for `&self` access.
+    /// Held for the stream's lifetime; dropping releases the ObjC strong
+    /// references (thread-safe refcounting).
+    capture: Mutex<AvAudioEngineCapture>,
+    /// `true` while the engine/tap are running. `swap(false)` in the stop
+    /// path makes teardown idempotent and race-free.
+    is_active: AtomicBool,
+    /// Producer-terminal-signal handle (FH-1 / ADR-0010): a clone of the
+    /// bridge's shared state, used to drive `Running → Stopping` (+ reader
+    /// wake) once the engine has stopped.
+    terminal: Arc<BridgeShared>,
+}
+
+// SAFETY: `IosPlatformStream` carries `Retained<AVAudioEngine>` /
+// `Retained<AVAudioInputNode>` (inside `AvAudioEngineCapture`), which are not
+// `Send`/`Sync` by default — but `PlatformStream: Send` and
+// `BridgeStream<S>: Sync` require both. This is sound because:
+//
+// - every access to the ObjC objects after construction goes through the
+//   `Mutex<AvAudioEngineCapture>` (only `stop()` touches them), so no
+//   unsynchronized concurrent ObjC calls can occur;
+// - the calls made cross-thread (`removeTapOnBus:`, `AVAudioEngine stop`) are
+//   documented safe off the main thread ("Taps may be safely installed and
+//   removed while the engine is running"); AVAudioEngine has no
+//   main-thread-only requirement for these lifecycle methods;
+// - releasing the strong references from an arbitrary thread on drop is safe:
+//   ObjC reference counting is thread-safe.
+//
+// Mirrors the `unsafe impl Send/Sync` discipline on `MacosPlatformStream`.
+unsafe impl Send for IosPlatformStream {}
+// SAFETY: see the `Send` justification above — all interior access is
+// serialized by the `Mutex`; the remaining fields (`AtomicBool`,
+// `Arc<BridgeShared>`) are `Send + Sync` already.
+unsafe impl Sync for IosPlatformStream {}
+
+impl IosPlatformStream {
+    /// Stops the engine + tap (once) and signals the bridge terminal.
+    ///
+    /// Idempotent: the `swap(false)` ensures the ObjC teardown and the
+    /// terminal transition run at most once; later calls are no-ops. Shared
+    /// by [`stop_capture`](PlatformStream::stop_capture) and `Drop` so
+    /// dropping the handle (without an explicit stop) also lands the stream
+    /// terminal.
+    fn stop_engine(&self) -> AudioResult<()> {
+        if !self.is_active.swap(false, Ordering::SeqCst) {
+            // Already stopped — idempotent no-op.
+            return Ok(());
+        }
+
+        {
+            let capture = self.capture.lock().map_err(|_| AudioError::InternalError {
+                message: "AVAudioEngine capture mutex poisoned".to_string(),
+                source: None,
+            })?;
+            // removeTapOnBus:0 first, then engine stop (no further tap
+            // invocations are queued once this returns).
+            capture.stop();
+        }
+
+        // Producer-terminal-signal (FH-1 / ADR-0010): the engine is stopped
+        // and the tap removed, so no more pushes can occur — drive the bridge
+        // to the graceful ending state (the `signal_done` semantics, applied
+        // via the shared handle because the `BridgeProducer` itself lives
+        // inside AVFAudio's copy of the tap block). `Running → Stopping`
+        // keeps a buffered tail drainable; the CAS no-ops if the state
+        // already advanced (e.g. `BridgeStream::stop` got there first).
+        let _ = self
+            .terminal
+            .state
+            .transition(StreamState::Running, StreamState::Stopping);
+        // Wake a parked blocking reader so it observes the ending state
+        // promptly (PU-5). Non-RT stop path — the notify is allowed here
+        // (ADR-0001 forbids it only on the RT callback push path).
+        self.terminal.notify_wake();
+        #[cfg(feature = "async-stream")]
+        self.terminal.waker.wake();
+
+        Ok(())
+    }
+}
+
+impl PlatformStream for IosPlatformStream {
+    fn stop_capture(&self) -> AudioResult<()> {
+        self.stop_engine()
+    }
+
+    fn is_active(&self) -> bool {
+        self.is_active.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for IosPlatformStream {
+    /// Deterministic shutdown: stop the engine (and signal the bridge
+    /// terminal) if the stream is still active, so dropping the handle never
+    /// leaves a running tap pushing into a bridge nobody reads — nor a parked
+    /// reader hanging (ADR-0010).
+    fn drop(&mut self) {
+        if self.is_active.load(Ordering::SeqCst) {
+            if let Err(e) = self.stop_engine() {
+                log::warn!("IosPlatformStream::drop: engine stop failed: {:?}", e);
+            }
+        }
+    }
+}
+
+// ── Target resolution (mic-only slice) ───────────────────────────────────
+
+/// Returns `true` if a [`CaptureTarget::Device`] id selects the single
+/// logical iOS input device.
+///
+/// Accepts [`DEFAULT_INPUT_DEVICE_ID`] case-insensitively, plus the empty
+/// string (the "default endpoint" convention shared with the Windows
+/// backend).
+fn is_default_input_id(id: &str) -> bool {
+    id.is_empty() || id.eq_ignore_ascii_case(DEFAULT_INPUT_DEVICE_ID)
+}
+
+/// Validates a [`CaptureTarget`] against the iOS **mic slice** (ADR-0013).
+///
+/// | Target | Outcome |
+/// |---|---|
+/// | `Device("default")` (or `""`) | `Ok(())` — the microphone |
+/// | `Device(other)` | [`AudioError::DeviceNotFound`] |
+/// | `SystemDefault` | [`AudioError::PlatformNotSupported`] — **pending** rsac-b3aa (ReplayKit) |
+/// | `Application` / `ApplicationByName` / `ProcessTree` | [`AudioError::PlatformNotSupported`] — **permanent** (no iOS API) |
+///
+/// The match is intentionally exhaustive (no wildcard): a new
+/// `CaptureTarget` variant must be classified here before the crate
+/// compiles for iOS.
+fn ensure_mic_target(target: &CaptureTarget) -> AudioResult<()> {
+    match target {
+        CaptureTarget::Device(id) if is_default_input_id(&id.0) => Ok(()),
+        CaptureTarget::Device(id) => Err(AudioError::DeviceNotFound {
+            device_id: id.0.clone(),
+        }),
+        CaptureTarget::SystemDefault => Err(AudioError::PlatformNotSupported {
+            feature: "system-audio capture on iOS: SystemDefault is the ReplayKit \
+                      Broadcast Upload Extension path, which is not wired yet \
+                      (rsac-b3aa). Supported today: the microphone via \
+                      CaptureTarget::Device(DeviceId(\"default\".into())). \
+                      Per-application capture does not exist on iOS, permanently"
+                .to_string(),
+            platform: "ios".to_string(),
+        }),
+        CaptureTarget::Application(_)
+        | CaptureTarget::ApplicationByName(_)
+        | CaptureTarget::ProcessTree(_) => Err(AudioError::PlatformNotSupported {
+            feature: "per-application / process-tree capture on iOS: Apple \
+                      provides no API for capturing another app's audio — this \
+                      is permanent, not a pending feature (ADR-0013). Supported \
+                      today: the microphone via \
+                      CaptureTarget::Device(DeviceId(\"default\".into())); \
+                      system audio arrives with the ReplayKit broadcast path \
+                      (rsac-b3aa)"
+                .to_string(),
+            platform: "ios".to_string(),
+        }),
+    }
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────
+
+/// Creates and starts an AVAudioEngine microphone capture, returning the
+/// [`IosPlatformStream`] handle plus the **delivered** (session-native)
+/// [`AudioFormat`].
+///
+/// Steps:
+///
+/// 1. Validate `target` against the mic slice ([`ensure_mic_target`]).
+/// 2. Start the engine + input tap
+///    ([`start_input_capture`]) — this also publishes the delivered format
+///    on the bridge before the first push.
+/// 3. Wrap the live objects in an [`IosPlatformStream`] carrying the
+///    `terminal` handle (ADR-0010).
+///
+/// # Errors
+///
+/// Target errors per [`ensure_mic_target`];
+/// [`AudioError::StreamCreationFailed`] from the engine start path (no
+/// active input route / denied mic permission — host-app `AVAudioSession`
+/// responsibilities, see the module docs of [`super`]).
+pub(crate) fn create_ios_capture(
+    target: &CaptureTarget,
+    producer: BridgeProducer,
+    terminal: Arc<BridgeShared>,
+) -> AudioResult<(IosPlatformStream, AudioFormat)> {
+    ensure_mic_target(target)?;
+
+    let (capture, delivered) = start_input_capture(producer)?;
+
+    log::debug!(
+        "AVAudioEngine: capture started (target={:?}, delivered {} Hz, {} ch)",
+        target,
+        delivered.sample_rate,
+        delivered.channels
+    );
+
+    Ok((
+        IosPlatformStream {
+            capture: Mutex::new(capture),
+            is_active: AtomicBool::new(true),
+            terminal,
+        },
+        delivered,
+    ))
+}
+
+// ── Compile-time assertions ──────────────────────────────────────────────
+
+/// Assert that `IosPlatformStream` is `Send + Sync` (required by
+/// `PlatformStream` and `BridgeStream<S>`).
+fn _assert_ios_platform_stream_send_sync() {
+    fn _assert<T: Send + Sync>() {}
+    _assert::<IosPlatformStream>();
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// Tests — pure logic only (no ObjC): target classification. Compile for the
+// iOS target under `--tests`, run on-device.
+// ══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::{ApplicationId, DeviceId, ProcessId};
+    use crate::core::error::ErrorKind;
+
+    #[test]
+    fn default_device_ids_are_accepted() {
+        for id in ["default", "DEFAULT", "Default", ""] {
+            let target = CaptureTarget::Device(DeviceId(id.to_string()));
+            assert!(
+                ensure_mic_target(&target).is_ok(),
+                "id {id:?} must select the mic"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_device_id_is_device_not_found() {
+        let target = CaptureTarget::Device(DeviceId("42".to_string()));
+        match ensure_mic_target(&target).unwrap_err() {
+            AudioError::DeviceNotFound { device_id } => assert_eq!(device_id, "42"),
+            other => panic!("expected DeviceNotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn system_default_is_pending_not_permanent() {
+        let err = ensure_mic_target(&CaptureTarget::SystemDefault).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Platform);
+        match err {
+            AudioError::PlatformNotSupported { feature, platform } => {
+                assert_eq!(platform, "ios");
+                assert!(feature.contains("rsac-b3aa"), "pending seed: {feature}");
+                assert!(feature.contains("ReplayKit"), "the real path: {feature}");
+                assert!(
+                    feature.contains("Device(DeviceId(\"default\""),
+                    "mic guidance: {feature}"
+                );
+            }
+            other => panic!("expected PlatformNotSupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn per_app_targets_are_permanently_unsupported() {
+        let targets = [
+            CaptureTarget::Application(ApplicationId("1234".to_string())),
+            CaptureTarget::ApplicationByName("Safari".to_string()),
+            CaptureTarget::ProcessTree(ProcessId(1234)),
+        ];
+        for target in targets {
+            match ensure_mic_target(&target).unwrap_err() {
+                AudioError::PlatformNotSupported { feature, platform } => {
+                    assert_eq!(platform, "ios");
+                    assert!(
+                        feature.contains("permanent"),
+                        "must state permanence for {target:?}: {feature}"
+                    );
+                    assert!(
+                        feature.contains("no API"),
+                        "must state the reason for {target:?}: {feature}"
+                    );
+                }
+                other => panic!("expected PlatformNotSupported for {target:?}, got {other:?}"),
+            }
+        }
+    }
+}

--- a/src/audio/ios/thread.rs
+++ b/src/audio/ios/thread.rs
@@ -163,14 +163,20 @@ fn is_default_input_id(id: &str) -> bool {
     id.is_empty() || id.eq_ignore_ascii_case(DEFAULT_INPUT_DEVICE_ID)
 }
 
-/// Validates a [`CaptureTarget`] against the iOS **mic slice** (ADR-0013).
+/// Validates a [`CaptureTarget`] against the iOS **mic path** (ADR-0013).
 ///
 /// | Target | Outcome |
 /// |---|---|
 /// | `Device("default")` (or `""`) | `Ok(())` — the microphone |
 /// | `Device(other)` | [`AudioError::DeviceNotFound`] |
-/// | `SystemDefault` | [`AudioError::PlatformNotSupported`] — **pending** rsac-b3aa (ReplayKit) |
+/// | `SystemDefault` | [`AudioError::PlatformNotSupported`] — served by the **broadcast device** (`super::broadcast`), never by the mic |
 /// | `Application` / `ApplicationByName` / `ProcessTree` | [`AudioError::PlatformNotSupported`] — **permanent** (no iOS API) |
+///
+/// The `SystemDefault` arm exists only for direct `AudioDevice` users: the
+/// builder path never routes `SystemDefault` here (its device resolution
+/// picks [`BroadcastAudioDevice`](super::broadcast::BroadcastAudioDevice)).
+/// Silently serving the microphone instead would be the dishonest fallback
+/// ADR-0013 explicitly rejected.
 ///
 /// The match is intentionally exhaustive (no wildcard): a new
 /// `CaptureTarget` variant must be classified here before the crate
@@ -182,11 +188,13 @@ fn ensure_mic_target(target: &CaptureTarget) -> AudioResult<()> {
             device_id: id.0.clone(),
         }),
         CaptureTarget::SystemDefault => Err(AudioError::PlatformNotSupported {
-            feature: "system-audio capture on iOS: SystemDefault is the ReplayKit \
-                      Broadcast Upload Extension path, which is not wired yet \
-                      (rsac-b3aa). Supported today: the microphone via \
-                      CaptureTarget::Device(DeviceId(\"default\".into())). \
-                      Per-application capture does not exist on iOS, permanently"
+            feature: "system-audio capture through the iOS microphone device: \
+                      SystemDefault is served by the ReplayKit broadcast device \
+                      (build with CaptureTarget::SystemDefault and an App Group \
+                      via AudioCaptureBuilder::with_ios_app_group), not by this \
+                      mic device. Serving the mic instead would deliver \
+                      different audio than requested (ADR-0013). The microphone \
+                      is CaptureTarget::Device(DeviceId(\"default\".into()))"
                 .to_string(),
             platform: "ios".to_string(),
         }),
@@ -197,9 +205,9 @@ fn ensure_mic_target(target: &CaptureTarget) -> AudioResult<()> {
                       provides no API for capturing another app's audio — this \
                       is permanent, not a pending feature (ADR-0013). Supported \
                       today: the microphone via \
-                      CaptureTarget::Device(DeviceId(\"default\".into())); \
-                      system audio arrives with the ReplayKit broadcast path \
-                      (rsac-b3aa)"
+                      CaptureTarget::Device(DeviceId(\"default\".into())) and \
+                      the system mix via CaptureTarget::SystemDefault (ReplayKit \
+                      broadcast)"
                 .to_string(),
             platform: "ios".to_string(),
         }),
@@ -294,14 +302,19 @@ mod tests {
     }
 
     #[test]
-    fn system_default_is_pending_not_permanent() {
+    fn system_default_is_redirected_to_the_broadcast_device() {
+        // The mic device must not silently serve SystemDefault (the dishonest
+        // fallback ADR-0013 rejected) — it points at the broadcast path.
         let err = ensure_mic_target(&CaptureTarget::SystemDefault).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::Platform);
         match err {
             AudioError::PlatformNotSupported { feature, platform } => {
                 assert_eq!(platform, "ios");
-                assert!(feature.contains("rsac-b3aa"), "pending seed: {feature}");
                 assert!(feature.contains("ReplayKit"), "the real path: {feature}");
+                assert!(
+                    feature.contains("with_ios_app_group"),
+                    "consent guidance: {feature}"
+                );
                 assert!(
                     feature.contains("Device(DeviceId(\"default\""),
                     "mic guidance: {feature}"

--- a/src/audio/linux/mod.rs
+++ b/src/audio/linux/mod.rs
@@ -11,21 +11,24 @@
 //! Every non-default target is resolved to a PipeWire node `object.serial`
 //! **on the caller thread** (in `thread::PipeWireThread::start_capture`) before
 //! the work is handed to the PipeWire event loop, so the event loop never
-//! blocks on `pw-dump` or a `/proc` walk while pumping audio.
+//! blocks on discovery while pumping audio. Resolution is **native-first**
+//! (H4 part 3 / `rsac-nat1`): it takes an in-process registry snapshot on a
+//! short-lived `PipeWireThread` and matches it, using the `pw-dump` subprocess
+//! only as a fallback when the native path cannot resolve.
 //!
 //! - `SystemDefault` — attach a monitor stream to the default sink node
 //!   (no `TARGET_OBJECT`; `STREAM_CAPTURE_SINK` + `STREAM_MONITOR` route it).
-//! - `Device(DeviceId)` — the `DeviceId` is a PipeWire node `id`/`object.serial`;
-//!   it is validated against `pw-dump` and normalised to the node's
-//!   `object.serial`. A missing device yields `DeviceNotFound`.
+//! - `Device(DeviceId)` — the `DeviceId` is a PipeWire node `object.serial`
+//!   (or node name); matched against the registry snapshot and normalised to
+//!   the node's `object.serial`. A missing device yields `DeviceNotFound`.
 //! - `Application(ApplicationId)` — like the Windows/macOS backends, the
 //!   `ApplicationId` carries a **numeric PID string**. It is parsed to a PID
-//!   and resolved to the app's audio-output node via `pw-dump` (matching
-//!   `application.process.id`), exactly as `ApplicationByName` does for names.
-//! - `ApplicationByName` — resolve the app's node via `pw-dump`, matching
-//!   `application.name` / `application.process.binary`.
+//!   and matched against each stream node's `application.process.id`.
+//! - `ApplicationByName` — matched by name using the tightened contract
+//!   (exact / basename / `.exe`-stripped, case-insensitive — never arbitrary
+//!   substring; see `thread::app_name_matches`).
 //! - `ProcessTree(ProcessId)` — walk `/proc` for the PID's descendants, then
-//!   match any tree member's audio-output node via `pw-dump`.
+//!   match any tree member's audio-output node.
 //!
 //! ## Format negotiation
 //!
@@ -110,6 +113,15 @@ pub fn enumerate_audio_applications() -> crate::core::error::Result<Vec<LinuxApp
         .collect())
 }
 
+/// PipeWire-backed [`DeviceEnumerator`](crate::core::interface::DeviceEnumerator)
+/// implementation for Linux.
+///
+/// Enumerates audio nodes via the native in-process PipeWire registry, falling
+/// back to the `pw-cli`/`pw-dump` subprocess tools when the native path fails
+/// (see [`DeviceEnumerator::enumerate_devices`](crate::core::interface::DeviceEnumerator::enumerate_devices)
+/// on this type). Obtain one through
+/// [`get_device_enumerator`](crate::audio::get_device_enumerator) rather than
+/// constructing it directly in cross-platform code.
 pub struct LinuxDeviceEnumerator;
 
 impl Default for LinuxDeviceEnumerator {
@@ -119,6 +131,7 @@ impl Default for LinuxDeviceEnumerator {
 }
 
 impl LinuxDeviceEnumerator {
+    /// Creates a new enumerator. The type is stateless; construction never fails.
     pub fn new() -> Self {
         LinuxDeviceEnumerator
     }
@@ -521,12 +534,20 @@ impl LinuxDeviceEnumerator {
     }
 }
 
-// Simple Linux audio device implementation
+/// A PipeWire audio node as seen by [`LinuxDeviceEnumerator`], implementing
+/// the [`AudioDevice`](crate::core::interface::AudioDevice) trait.
 #[derive(Debug, Clone)]
 pub struct LinuxAudioDevice {
+    /// PipeWire node identifier — the node's `object.serial` on the native
+    /// enumeration path (round-trippable through
+    /// [`CaptureTarget::Device`](crate::core::config::CaptureTarget::Device)),
+    /// or a node id/name on the subprocess fallback paths.
     pub id: String,
+    /// Human-readable node name (e.g. `alsa_output.pci-...`).
     pub name: String,
+    /// Whether the node is a capture source (`media.class` contains `Audio/Source`).
     pub is_input: bool,
+    /// Whether the node is a playback sink (`media.class` contains `Audio/Sink`).
     pub is_output: bool,
 }
 
@@ -626,8 +647,14 @@ impl crate::core::interface::AudioDevice for LinuxAudioDevice {
             // 2. Use the capture target from StreamConfig (propagated from builder)
             let target = config.capture_target.clone();
 
-            // 3. Create the ring buffer bridge (64 AudioBuffer slots by default)
-            let capacity = calculate_capacity(None, 4);
+            // 3. Create the ring buffer bridge. Honor the caller's requested
+            //    ring depth (`StreamConfig::buffer_size`, a slot count) exactly
+            //    as the Windows/WASAPI backend does — `calculate_capacity`
+            //    rounds it up to a power of two with a floor of 4, and falls
+            //    back to the 64-slot default when `None`. This closes the
+            //    Linux-ignores-buffer_size gap called out in ADR-0007 / the
+            //    field docs; period-derived sizing remains future work.
+            let capacity = calculate_capacity(config.buffer_size, 4);
             let (producer, consumer) = create_bridge(capacity, format.clone());
 
             // 4. Transition bridge state from Created → Running so reads work

--- a/src/audio/linux/thread.rs
+++ b/src/audio/linux/thread.rs
@@ -261,6 +261,20 @@ pub(crate) enum PipeWireCommand {
         response_tx: std_mpsc::Sender<AudioResult<Vec<PwAppSnapshot>>>,
     },
 
+    /// Resolve a capture [`TargetQuery`] against the native registry snapshot,
+    /// returning the matched node's `object.serial` (H4 part 3 / `rsac-nat1`).
+    ///
+    /// Like [`SnapshotDevices`](PipeWireCommand::SnapshotDevices), the handler
+    /// waits for a `core.sync()`/`done` roundtrip so the registry's initial dump
+    /// has settled before matching — otherwise it would race an empty registry
+    /// and spuriously report "no match" on a healthy system. `Ok(None)` means
+    /// the registry settled but held no matching node (the caller may then try
+    /// the `pw-dump` fallback); an `Err` is a spawn/roundtrip failure.
+    ResolveTarget {
+        query: TargetQuery,
+        response_tx: std_mpsc::Sender<AudioResult<Option<String>>>,
+    },
+
     /// Enumerate the `SPA_PARAM_EnumFormat` parameters a node advertises and map
     /// each to a [`crate::core::config::AudioFormat`] (PR-5 / `rsac-7469`).
     ///
@@ -409,10 +423,48 @@ struct CaptureStreamData {
     /// existing capacity keeps the RT push allocation-free in steady state
     /// (ADR-0001).
     realign_scratch: Vec<f32>,
-    /// One-shot latch so the rare non-word-aligned chunk is logged **once**
-    /// rather than on every callback, making otherwise-silent data realignment
-    /// (or a truncated trailing sample) visible without flooding the log (#30).
-    misaligned_logged: bool,
+    /// Number of chunks whose valid region was **not** word-aligned and took
+    /// the [`decode_unaligned_f32_le`] realignment fallback (#30 / rsac-9096).
+    ///
+    /// Bumped in the `.process` RT callback with a plain saturating add — the
+    /// callback must NOT log (formatting allocates; typical logger backends
+    /// lock + syscall), so the diagnostic is deferred: the one-shot summary is
+    /// emitted from the non-RT [`Drop`] impl below at session teardown. Plain
+    /// `u64`, no atomic: the listener callbacks hold exclusive `&mut` access,
+    /// and `Drop` runs with ownership after the listener hook is removed, so
+    /// no concurrent reader exists.
+    misaligned_chunks: u64,
+    /// Cumulative count of trailing bytes that formed a truncated partial
+    /// sample (unrecoverable by realignment) across all misaligned chunks
+    /// (rsac-9096). Same write/read discipline as
+    /// [`misaligned_chunks`](Self::misaligned_chunks).
+    misaligned_truncated_bytes: u64,
+}
+
+/// rsac-9096: emit the misaligned-chunk diagnostic from a **non-RT** point.
+///
+/// The `.process` callback (where misalignment is detected) is a C callback
+/// invoked from inside `main_loop.iterate()` on the real-time data path,
+/// outside any panic guard — `log::warn!` there would format (allocate) and
+/// let a typical logger backend lock and syscall, violating the callback's own
+/// "no logging" contract (ADR-0001). The callback therefore only bumps the
+/// plain counters above; this `Drop` — which runs on the loop thread during
+/// session teardown (`capture_listener = None` / the StopCapture, Shutdown,
+/// and channel-disconnect arms), strictly after the listener hook is removed
+/// so no further callback can fire — surfaces the one-shot summary.
+impl Drop for CaptureStreamData {
+    fn drop(&mut self) {
+        if self.misaligned_chunks > 0 {
+            log::warn!(
+                "PipeWire delivered {} non-word-aligned audio chunk(s) during this \
+                 capture session (realigned via copy in the process callback); {} \
+                 trailing byte(s) formed truncated partial samples and were not \
+                 recoverable.",
+                self.misaligned_chunks,
+                self.misaligned_truncated_bytes
+            );
+        }
+    }
 }
 
 // ── PipeWireThread ───────────────────────────────────────────────────────
@@ -723,6 +775,48 @@ impl PipeWireThread {
         }
     }
 
+    /// Resolve a capture [`TargetQuery`] to a node `object.serial` using the
+    /// **native** registry snapshot (H4 part 3 / `rsac-nat1`) — no `pw-dump`.
+    ///
+    /// Sends a [`ResolveTarget`](PipeWireCommand::ResolveTarget) command and
+    /// blocks (bounded by [`SNAPSHOT_TIMEOUT`]) for the reply. The PipeWire
+    /// thread waits for a `core.sync()`/`done` roundtrip so the registry has
+    /// settled before matching. `Ok(None)` means the registry settled but held
+    /// no matching node (the caller may then fall back to the `pw-dump` path).
+    ///
+    /// # Errors
+    ///
+    /// - [`AudioError::BackendError`] if the PipeWire thread is not running or
+    ///   exits without replying.
+    /// - [`AudioError::Timeout`] if resolution does not complete within
+    ///   [`SNAPSHOT_TIMEOUT`].
+    pub fn resolve_target(&self, query: TargetQuery) -> AudioResult<Option<String>> {
+        let (response_tx, response_rx) = std_mpsc::channel();
+
+        self.command_tx
+            .send(PipeWireCommand::ResolveTarget { query, response_tx })
+            .map_err(|_| AudioError::BackendError {
+                backend: "PipeWire".to_string(),
+                operation: "resolve_target".to_string(),
+                message: "PipeWire thread is not running (command channel closed)".to_string(),
+                context: None,
+            })?;
+
+        match response_rx.recv_timeout(SNAPSHOT_TIMEOUT) {
+            Ok(result) => result,
+            Err(std_mpsc::RecvTimeoutError::Timeout) => Err(AudioError::Timeout {
+                operation: "PipeWire ResolveTarget roundtrip".to_string(),
+                duration: SNAPSHOT_TIMEOUT,
+            }),
+            Err(std_mpsc::RecvTimeoutError::Disconnected) => Err(AudioError::BackendError {
+                backend: "PipeWire".to_string(),
+                operation: "resolve_target".to_string(),
+                message: "PipeWire thread exited before responding to ResolveTarget".to_string(),
+                context: None,
+            }),
+        }
+    }
+
     /// Enumerate the audio formats a node advertises via its
     /// `SPA_PARAM_EnumFormat` parameters (PR-5 / `rsac-7469`).
     ///
@@ -961,6 +1055,114 @@ fn parse_ppid_from_stat(stat_contents: &str) -> Option<u32> {
     ppid_str.parse::<u32>().ok()
 }
 
+// ── Native registry target resolution (H4 part 3 / rsac-nat1) ────────────
+//
+// The capture path historically resolved every non-default `CaptureTarget` to a
+// PipeWire node `object.serial` by shelling out to `pw-dump` and parsing its
+// JSON (`find_pipewire_node_serial`). Device/Application discovery already has a
+// *native* in-process path (the registry `global` snapshot — `PwDeviceSnapshot`
+// / `PwAppSnapshot`), so the capture path can reuse that same snapshot instead
+// of a subprocess. These pure helpers do the matching against an already-taken
+// snapshot; `resolve_capture_target` drives the snapshot + these helpers, and
+// falls back to `pw-dump` only when the native path can't resolve (e.g. a
+// permission-restricted registry that hides stream nodes).
+
+/// How to match a capture target against a native registry snapshot.
+///
+/// This mirrors the [`PwNodeLookup`] strategies but operates on the owned
+/// [`PwDeviceSnapshot`] / [`PwAppSnapshot`] lists produced by the registry
+/// `global` callback rather than on `pw-dump` JSON — so no subprocess and no
+/// `PATH` dependency is involved.
+#[derive(Debug, Clone)]
+pub(crate) enum TargetQuery {
+    /// Match a *device/sink/source* node by its [`DeviceId`] string against a
+    /// snapshot node's `object.serial` (or global-id fallback) `id`.
+    ///
+    /// [`DeviceId`]: crate::core::config::DeviceId
+    Device(String),
+    /// Match an application stream node by exact process id.
+    ByPid(u32),
+    /// Match an application stream node by name (see
+    /// [`app_name_matches`] for the exact/relaxed contract).
+    ByAppName(String),
+    /// Match the first application stream node whose PID is in the set (process
+    /// tree capture).
+    ByPidSet(Vec<u32>),
+}
+
+/// The tightened `ApplicationByName` matching contract (native + subprocess).
+///
+/// A candidate application name matches `query` when either:
+/// 1. it is an **exact**, case-insensitive equality, or
+/// 2. after case-folding, the candidate's file-stem (the binary name with any
+///    directory prefix and trailing `.exe`/version suffix stripped) equals the
+///    query.
+///
+/// It intentionally does **not** do arbitrary substring containment: a query of
+/// `"Fire"` must not silently bind to `"Firefox"` (that surprised callers and
+/// could attach to the wrong app). Callers wanting fuzzy discovery should
+/// enumerate via `list_audio_applications()` and pick a PID explicitly.
+///
+/// `candidate` is compared both as-is and as its trailing path component so a
+/// registry `application.process.binary` like `/usr/lib/firefox/firefox` still
+/// matches a query of `firefox`.
+pub(crate) fn app_name_matches(candidate: &str, query: &str) -> bool {
+    let q = query.trim();
+    if q.is_empty() {
+        return false;
+    }
+    if candidate.eq_ignore_ascii_case(q) {
+        return true;
+    }
+    // Compare the candidate's trailing path component (basename) too, so a full
+    // binary path resolves against a bare program name.
+    let base = candidate.rsplit(['/', '\\']).next().unwrap_or(candidate);
+    if base.eq_ignore_ascii_case(q) {
+        return true;
+    }
+    // Strip a trailing ".exe" (cross-platform binary names) from the basename
+    // for the final comparison — never a broad substring match.
+    let stem = base.strip_suffix(".exe").unwrap_or(base);
+    stem.eq_ignore_ascii_case(q)
+}
+
+/// Resolve a [`TargetQuery`] against native registry snapshots, returning the
+/// matched node's `object.serial` (the string the capture path stamps into
+/// `TARGET_OBJECT`).
+///
+/// `devices` and `apps` are the owned snapshots taken on the PipeWire loop
+/// thread (via [`SnapshotDevices`](PipeWireCommand::SnapshotDevices) /
+/// [`SnapshotApplications`](PipeWireCommand::SnapshotApplications)). This is a
+/// **pure** function — no I/O, no subprocess — so it is unit-testable without a
+/// live daemon.
+///
+/// Returns `None` when nothing matches; the caller decides whether that is a
+/// `*NotFound` error or a reason to try the `pw-dump` fallback.
+pub(crate) fn resolve_target_from_snapshot(
+    query: &TargetQuery,
+    devices: &[PwDeviceSnapshot],
+    apps: &[PwAppSnapshot],
+) -> Option<String> {
+    match query {
+        TargetQuery::Device(id) => devices
+            .iter()
+            .find(|d| &d.id == id || d.node_name == *id || d.name == *id)
+            .map(|d| d.id.clone()),
+        TargetQuery::ByPid(pid) => apps
+            .iter()
+            .find(|a| a.pid == *pid)
+            .map(|a| a.node_serial.clone()),
+        TargetQuery::ByAppName(name) => apps
+            .iter()
+            .find(|a| app_name_matches(&a.app_name, name))
+            .map(|a| a.node_serial.clone()),
+        TargetQuery::ByPidSet(pids) => apps
+            .iter()
+            .find(|a| pids.contains(&a.pid))
+            .map(|a| a.node_serial.clone()),
+    }
+}
+
 // ── pw-dump Node Lookup ──────────────────────────────────────────────────
 
 /// Specifies how to look up a PipeWire node via `pw-dump`.
@@ -1108,7 +1310,9 @@ fn find_pipewire_node_serial(lookup: &PwNodeLookup<'_>) -> AudioResult<String> {
                     .get("application.process.binary")
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
-                app_name.eq_ignore_ascii_case(name) || app_binary.eq_ignore_ascii_case(name)
+                // Same tightened contract as the native path (exact / basename /
+                // .exe-stripped, case-insensitive — never arbitrary substring).
+                app_name_matches(app_name, name) || app_name_matches(app_binary, name)
             }
             PwNodeLookup::ByPid(_) => {
                 let proc_id = props
@@ -1187,21 +1391,37 @@ fn find_pipewire_node_serial(lookup: &PwNodeLookup<'_>) -> AudioResult<String> {
 /// Resolve a [`CaptureTarget`] into a ready-to-use [`ResolvedTarget`].
 ///
 /// This is the off-the-event-loop resolution step (audit findings M2/M3): it
-/// runs `pw-dump` and walks `/proc` on the **caller** thread so the PipeWire
-/// event loop never blocks on a subprocess or filesystem traversal while it is
-/// pumping audio. The returned [`ResolvedTarget`] carries only a plain
-/// `object.serial` string (or "no target" for the default sink monitor).
+/// resolves the target **on the caller thread** so the capture PipeWire event
+/// loop never blocks on discovery while pumping audio. The returned
+/// [`ResolvedTarget`] carries only a plain `object.serial` string (or "no
+/// target" for the default sink monitor).
+///
+/// # Native-first resolution (H4 part 3 / `rsac-nat1`)
+///
+/// `Device`/`Application`/`ApplicationByName`/`ProcessTree` are resolved by
+/// taking an **in-process registry snapshot** on a short-lived
+/// [`PipeWireThread`] and matching it via [`resolve_target_from_snapshot`] — no
+/// `pw-dump` subprocess and no `PATH` dependency. `pw-dump` is used only as a
+/// **fallback** when the native path cannot resolve (the snapshot settled but
+/// held no match, or the short-lived thread failed to spawn — e.g. a
+/// permission-restricted registry that hides per-application stream nodes). A
+/// native match always wins; the subprocess is never consulted when the
+/// registry already answered.
 ///
 /// # Target semantics
 ///
-/// - [`SystemDefault`](CaptureTarget::SystemDefault) — no `TARGET_OBJECT`.
+/// - [`SystemDefault`](CaptureTarget::SystemDefault) — no `TARGET_OBJECT`; never
+///   touches the registry or `pw-dump`.
 /// - [`Device`](CaptureTarget::Device) — the [`DeviceId`] is a PipeWire node
-///   `id`/`object.serial`; validated against `pw-dump` and normalised to the
-///   node's `object.serial`. Returns [`AudioError::DeviceNotFound`] if absent.
+///   `object.serial` (or node name); matched against the registry snapshot and
+///   normalised to the node's `object.serial`. Returns
+///   [`AudioError::DeviceNotFound`] if absent in both paths.
 /// - [`Application`](CaptureTarget::Application) — the [`ApplicationId`] is a
-///   **numeric PID string**, matching the Windows/macOS contract. Resolved to
-///   the application's audio-output node serial via `pw-dump`.
-/// - [`ApplicationByName`](CaptureTarget::ApplicationByName) — resolved by name.
+///   **numeric PID string**, matching the Windows/macOS contract. Matched
+///   against each stream node's `application.process.id`.
+/// - [`ApplicationByName`](CaptureTarget::ApplicationByName) — matched by name
+///   using the tightened [`app_name_matches`] contract (exact / basename /
+///   `.exe`-stripped, case-insensitive — never arbitrary substring).
 /// - [`ProcessTree`](CaptureTarget::ProcessTree) — `/proc` is walked for the
 ///   PID's descendants, then any tree member's audio-output node is matched.
 ///
@@ -1211,9 +1431,12 @@ fn resolve_capture_target(target: &CaptureTarget) -> AudioResult<ResolvedTarget>
     match target {
         CaptureTarget::SystemDefault => Ok(ResolvedTarget::SystemDefault),
         CaptureTarget::Device(device_id) => {
-            // Validate the node exists and normalise to its object.serial so we
-            // never silently connect to a non-existent TARGET_OBJECT (M8).
-            let serial = find_pipewire_node_serial(&PwNodeLookup::Device(device_id.0.as_str()))?;
+            // Native-first: match the DeviceId against the registry snapshot;
+            // fall back to pw-dump only if the native path can't resolve.
+            let serial = resolve_serial_native_or_subprocess(
+                TargetQuery::Device(device_id.0.clone()),
+                &PwNodeLookup::Device(device_id.0.as_str()),
+            )?;
             log::debug!(
                 "PipeWire: Device '{}' validated, resolved to node serial={}",
                 device_id.0,
@@ -1223,8 +1446,8 @@ fn resolve_capture_target(target: &CaptureTarget) -> AudioResult<ResolvedTarget>
         }
         CaptureTarget::Application(app_id) => {
             // ApplicationId carries a numeric PID string — same contract as the
-            // Windows/macOS backends (audit finding M7). Resolve PID → node
-            // serial via pw-dump, mirroring ApplicationByName.
+            // Windows/macOS backends (audit finding M7). Parse PID → match the
+            // registry snapshot's `application.process.id`, pw-dump fallback.
             let pid: u32 = app_id
                 .0
                 .parse()
@@ -1234,7 +1457,10 @@ fn resolve_capture_target(target: &CaptureTarget) -> AudioResult<ResolvedTarget>
                         app_id.0
                     ),
                 })?;
-            let serial = find_pipewire_node_serial(&PwNodeLookup::ByPid(pid))?;
+            let serial = resolve_serial_native_or_subprocess(
+                TargetQuery::ByPid(pid),
+                &PwNodeLookup::ByPid(pid),
+            )?;
             log::debug!(
                 "PipeWire: Application PID {} resolved to node serial={}",
                 pid,
@@ -1243,7 +1469,10 @@ fn resolve_capture_target(target: &CaptureTarget) -> AudioResult<ResolvedTarget>
             Ok(ResolvedTarget::Serial(serial))
         }
         CaptureTarget::ApplicationByName(name) => {
-            let serial = find_pipewire_node_serial(&PwNodeLookup::ByAppName(name))?;
+            let serial = resolve_serial_native_or_subprocess(
+                TargetQuery::ByAppName(name.clone()),
+                &PwNodeLookup::ByAppName(name),
+            )?;
             log::debug!(
                 "PipeWire: ApplicationByName '{}' resolved to node serial={}",
                 name,
@@ -1262,7 +1491,10 @@ fn resolve_capture_target(target: &CaptureTarget) -> AudioResult<ResolvedTarget>
                 tree_pids.len(),
                 tree_pids
             );
-            let serial = find_pipewire_node_serial(&PwNodeLookup::ByPidSet(&tree_pids))?;
+            let serial = resolve_serial_native_or_subprocess(
+                TargetQuery::ByPidSet(tree_pids.clone()),
+                &PwNodeLookup::ByPidSet(&tree_pids),
+            )?;
             log::debug!(
                 "PipeWire: ProcessTree PID {} resolved to node serial={} (searched {} PIDs)",
                 pid.0,
@@ -1272,6 +1504,58 @@ fn resolve_capture_target(target: &CaptureTarget) -> AudioResult<ResolvedTarget>
             Ok(ResolvedTarget::Serial(serial))
         }
     }
+}
+
+/// Resolve a target to a node `object.serial`, preferring the **native**
+/// in-process registry snapshot and falling back to the `pw-dump` subprocess
+/// only when the native path cannot answer (H4 part 3 / `rsac-nat1`).
+///
+/// Resolution order:
+/// 1. Spawn a short-lived [`PipeWireThread`] and ask it to
+///    [`resolve_target`](PipeWireThread::resolve_target) `query` against the
+///    settled registry snapshot. A `Some(serial)` wins immediately — no
+///    subprocess is ever run.
+/// 2. If the native path returns `Ok(None)` (registry settled, no match) or an
+///    `Err` (thread spawn/roundtrip failure), fall back to
+///    [`find_pipewire_node_serial`] with `lookup`.
+///
+/// The subprocess fallback preserves the historical error taxonomy
+/// (`DeviceNotFound` / `ApplicationNotFound` / `BackendError`) so callers and
+/// tests that pattern-match on it keep working even when `pw-dump` is absent.
+fn resolve_serial_native_or_subprocess(
+    query: TargetQuery,
+    lookup: &PwNodeLookup<'_>,
+) -> AudioResult<String> {
+    match PipeWireThread::spawn() {
+        Ok(pw_thread) => match pw_thread.resolve_target(query) {
+            Ok(Some(serial)) => {
+                log::debug!(
+                    "PipeWire: native registry resolution matched serial={}",
+                    serial
+                );
+                return Ok(serial);
+            }
+            Ok(None) => {
+                log::debug!(
+                    "PipeWire: native registry settled with no match; trying pw-dump fallback"
+                );
+            }
+            Err(e) => {
+                log::debug!(
+                    "PipeWire: native registry resolution failed ({}); trying pw-dump fallback",
+                    e
+                );
+            }
+        },
+        Err(e) => {
+            log::debug!(
+                "PipeWire: could not spawn thread for native resolution ({}); \
+                 trying pw-dump fallback",
+                e
+            );
+        }
+    }
+    find_pipewire_node_serial(lookup)
 }
 
 // ── PipeWire Thread Main Function ────────────────────────────────────────
@@ -1724,7 +2008,8 @@ fn pw_thread_main(
                     // rather than allocating in the `.process` callback. Matches
                     // the bridge's worst-case stereo period seed (ADR-0001).
                     realign_scratch: Vec::with_capacity(2048),
-                    misaligned_logged: false,
+                    misaligned_chunks: 0,
+                    misaligned_truncated_bytes: 0,
                 };
 
                 // ── Register stream listener with callbacks ──
@@ -1906,7 +2191,10 @@ fn pw_thread_main(
                                     // overrun counter is incremented; a panic, if
                                     // one ever occurred, is contained rather than
                                     // unwinding into PipeWire's C frames.
-                                    user_data.producer.push_samples_guarded(
+                                    // `_stamped`: stream-position timestamps
+                                    // (frames offered / rate — integer math, same
+                                    // alloc-free path; rsac-522b / rsac-ec25).
+                                    user_data.producer.push_samples_guarded_stamped(
                                         samples,
                                         channels,
                                         sample_rate,
@@ -1923,31 +2211,42 @@ fn pw_thread_main(
                                 // sample is lost regardless of the start offset. Only a
                                 // genuinely truncated trailing partial sample (byte
                                 // length not a multiple of 4) is unrecoverable.
-                                debug_assert!(
-                                    head.len() < std::mem::size_of::<f32>()
-                                        && tail.len() < std::mem::size_of::<f32>(),
-                                    "align_to head/tail must each be a sub-sample edge"
-                                );
+                                //
+                                // NOTE (rsac-9096): a `debug_assert!` on the head/tail
+                                // sizes used to live here, but (a) `align_to`'s
+                                // documented contract does NOT guarantee a maximal
+                                // middle slice (only that the middle is aligned), so
+                                // the assert leaned on an implementation detail, and
+                                // (b) it was a panic site inside this C callback in
+                                // debug builds, OUTSIDE any unwind guard — a firing
+                                // assert would unwind into PipeWire's C frames (UB).
+                                // Correctness never depended on it: the decode below
+                                // reads the raw bytes directly, however align_to
+                                // split them.
                                 let truncated_bytes =
                                     decode_unaligned_f32_le(valid, &mut user_data.realign_scratch);
-                                // Surface the otherwise-invisible realignment ONCE so
-                                // a recurring misalignment (or a truncated tail) is
-                                // diagnosable, without flooding the RT log.
-                                if !user_data.misaligned_logged {
-                                    user_data.misaligned_logged = true;
-                                    log::warn!(
-                                        "PipeWire delivered a non-word-aligned audio chunk \
-                                         (offset {offset}, {} bytes); realigning via copy. \
-                                         {truncated_bytes} trailing byte(s) form a truncated \
-                                         partial sample and were not recoverable.",
-                                        valid.len()
-                                    );
-                                }
+                                // rsac-9096: NO logging here — this closure runs
+                                // inside PipeWire's C `.process` callback (real-time
+                                // path, outside any panic guard), where `log::warn!`
+                                // would format (allocate) and a typical logger backend
+                                // would lock + syscall. Record the occurrence in the
+                                // plain per-session counters instead (exclusive `&mut`
+                                // access; saturating adds — RT-safe) and let the
+                                // non-RT `CaptureStreamData::drop` teardown emit the
+                                // one-shot summary.
+                                user_data.misaligned_chunks =
+                                    user_data.misaligned_chunks.saturating_add(1);
+                                user_data.misaligned_truncated_bytes = user_data
+                                    .misaligned_truncated_bytes
+                                    .saturating_add(truncated_bytes as u64);
                                 if !user_data.realign_scratch.is_empty() {
                                     // Disjoint field borrows: `realign_scratch` is read
                                     // immutably while `producer` is used — allowed.
+                                    // Same stamped push as the aligned fast path so
+                                    // the stream-position timeline stays contiguous
+                                    // across a realigned chunk.
                                     let realigned = user_data.realign_scratch.as_slice();
-                                    user_data.producer.push_samples_guarded(
+                                    user_data.producer.push_samples_guarded_stamped(
                                         realigned,
                                         channels,
                                         sample_rate,
@@ -2130,6 +2429,34 @@ fn pw_thread_main(
                 );
                 // Only owned Vecs cross the channel.
                 let _ = response_tx.send(Ok(apps));
+            }
+
+            Ok(PipeWireCommand::ResolveTarget { query, response_tx }) => {
+                log::debug!("PipeWire thread: ResolveTarget received ({:?})", query);
+                // Settle the registry dump before matching (else we race an
+                // empty registry and report "no match" on a healthy system).
+                run_snapshot_roundtrip(&mut default_metadata);
+                // Build owned, PID-deduplicated snapshots exactly as the
+                // SnapshotDevices / SnapshotApplications arms do, then match
+                // natively (pure function, no subprocess).
+                let devices: Vec<PwDeviceSnapshot> =
+                    snapshot.borrow().devices.values().cloned().collect();
+                let mut seen_pids: std::collections::BTreeSet<u32> =
+                    std::collections::BTreeSet::new();
+                let mut apps: Vec<PwAppSnapshot> = Vec::new();
+                for app in snapshot.borrow().applications.values() {
+                    if seen_pids.insert(app.pid) {
+                        apps.push(app.clone());
+                    }
+                }
+                let matched = resolve_target_from_snapshot(&query, &devices, &apps);
+                log::debug!(
+                    "PipeWire thread: ResolveTarget → {:?} (from {} device(s), {} app(s))",
+                    matched,
+                    devices.len(),
+                    apps.len()
+                );
+                let _ = response_tx.send(Ok(matched));
             }
 
             Ok(PipeWireCommand::EnumNodeFormats {
@@ -3093,6 +3420,173 @@ mod tests {
             }
             other => panic!("Expected DeviceNotFound or BackendError, got {:?}", other),
         }
+    }
+
+    // ── Native registry resolution (H4 part 3 / rsac-nat1) ───────────
+    //
+    // These exercise the PURE matching helpers against synthetic snapshots, so
+    // they run without a live PipeWire daemon and without `pw-dump`/`PATH` —
+    // proving the capture path can resolve every non-default target natively.
+
+    fn dev(id: &str, node_name: &str, name: &str, class: &str) -> PwDeviceSnapshot {
+        PwDeviceSnapshot {
+            id: id.to_string(),
+            name: name.to_string(),
+            node_name: node_name.to_string(),
+            media_class: class.to_string(),
+        }
+    }
+
+    fn app_snap(pid: u32, app_name: &str, node_serial: &str) -> PwAppSnapshot {
+        PwAppSnapshot {
+            pid,
+            app_name: app_name.to_string(),
+            node_serial: node_serial.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_app_name_matches_exact_case_insensitive() {
+        assert!(app_name_matches("Firefox", "firefox"));
+        assert!(app_name_matches("firefox", "FIREFOX"));
+        assert!(app_name_matches("VLC media player", "vlc media player"));
+    }
+
+    #[test]
+    fn test_app_name_matches_basename_and_exe_stripped() {
+        // A full binary path resolves against a bare program name.
+        assert!(app_name_matches("/usr/lib/firefox/firefox", "firefox"));
+        assert!(app_name_matches("C:\\Program Files\\VLC\\vlc.exe", "vlc"));
+        assert!(app_name_matches("spotify.exe", "spotify"));
+    }
+
+    #[test]
+    fn test_app_name_matches_rejects_substring() {
+        // The tightened contract: NO arbitrary substring containment. "Fire"
+        // must not bind to "Firefox" (that could attach to the wrong app).
+        assert!(!app_name_matches("Firefox", "Fire"));
+        assert!(!app_name_matches("Firefox", "fox"));
+        assert!(!app_name_matches("Spotify", "Spot"));
+    }
+
+    #[test]
+    fn test_app_name_matches_empty_query_is_no_match() {
+        assert!(!app_name_matches("Firefox", ""));
+        assert!(!app_name_matches("Firefox", "   "));
+    }
+
+    #[test]
+    fn test_resolve_target_from_snapshot_device_by_serial_and_name() {
+        let devices = vec![
+            dev(
+                "55",
+                "alsa_output.pci-0000_00_1f.3",
+                "Built-in Audio",
+                "Audio/Sink",
+            ),
+            dev(
+                "56",
+                "alsa_input.pci-0000_00_1f.3",
+                "Built-in Mic",
+                "Audio/Source",
+            ),
+        ];
+        // Match by object.serial (id).
+        assert_eq!(
+            resolve_target_from_snapshot(&TargetQuery::Device("55".to_string()), &devices, &[]),
+            Some("55".to_string())
+        );
+        // Match by node.name → returns the node's serial (round-trippable).
+        assert_eq!(
+            resolve_target_from_snapshot(
+                &TargetQuery::Device("alsa_input.pci-0000_00_1f.3".to_string()),
+                &devices,
+                &[]
+            ),
+            Some("56".to_string())
+        );
+        // Match by display name.
+        assert_eq!(
+            resolve_target_from_snapshot(
+                &TargetQuery::Device("Built-in Audio".to_string()),
+                &devices,
+                &[]
+            ),
+            Some("55".to_string())
+        );
+        // No match.
+        assert_eq!(
+            resolve_target_from_snapshot(
+                &TargetQuery::Device("no-such".to_string()),
+                &devices,
+                &[]
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_resolve_target_from_snapshot_by_pid() {
+        let apps = vec![
+            app_snap(1234, "Firefox", "9001"),
+            app_snap(5678, "Spotify", "9002"),
+        ];
+        assert_eq!(
+            resolve_target_from_snapshot(&TargetQuery::ByPid(5678), &[], &apps),
+            Some("9002".to_string())
+        );
+        // A PID with no stream node does not match.
+        assert_eq!(
+            resolve_target_from_snapshot(&TargetQuery::ByPid(4242), &[], &apps),
+            None
+        );
+    }
+
+    #[test]
+    fn test_resolve_target_from_snapshot_by_app_name_uses_tight_contract() {
+        let apps = vec![
+            app_snap(1234, "Firefox", "9001"),
+            app_snap(5678, "/usr/bin/spotify", "9002"),
+        ];
+        assert_eq!(
+            resolve_target_from_snapshot(
+                &TargetQuery::ByAppName("firefox".to_string()),
+                &[],
+                &apps
+            ),
+            Some("9001".to_string())
+        );
+        // Basename match against a full path.
+        assert_eq!(
+            resolve_target_from_snapshot(
+                &TargetQuery::ByAppName("spotify".to_string()),
+                &[],
+                &apps
+            ),
+            Some("9002".to_string())
+        );
+        // Substring must NOT match (tightened contract).
+        assert_eq!(
+            resolve_target_from_snapshot(&TargetQuery::ByAppName("Fire".to_string()), &[], &apps),
+            None
+        );
+    }
+
+    #[test]
+    fn test_resolve_target_from_snapshot_by_pid_set() {
+        let apps = vec![
+            app_snap(1000, "parent", "9001"),
+            app_snap(1002, "child", "9002"),
+        ];
+        // Any tree member's node matches; the first found in the app list wins.
+        let matched =
+            resolve_target_from_snapshot(&TargetQuery::ByPidSet(vec![999, 1002, 1003]), &[], &apps);
+        assert_eq!(matched, Some("9002".to_string()));
+        // A tree with no audio-producing member does not match.
+        assert_eq!(
+            resolve_target_from_snapshot(&TargetQuery::ByPidSet(vec![7, 8, 9]), &[], &apps),
+            None
+        );
     }
 
     // ── parse_default_metadata_name (H4 / rsac-bfd8) ─────────────────

--- a/src/audio/macos/coreaudio.rs
+++ b/src/audio/macos/coreaudio.rs
@@ -837,12 +837,28 @@ const fn device_alive_address() -> AudioObjectPropertyAddress {
 /// [`WatchListenerContext`], it is **intentionally leaked** (`Box::into_raw`,
 /// never reclaimed on the success path) because CoreAudio gives no barrier that
 /// an in-flight proc has finished when its listener is removed — so a late deref
-/// must stay sound. The leak is one tiny struct (an `AudioObjectID` + an
-/// `Arc<BridgeShared>` clone) per capture stream, reclaimed only on the
-/// registration-failure path where no proc can be in flight.
+/// must stay sound. The leak is one tiny struct (an `AudioObjectID`, an
+/// `Arc<BridgeShared>` clone, and an `AtomicBool`) per capture stream, reclaimed
+/// only on the registration-failure path where no proc can be in flight.
+///
+/// # Teardown race guard (rsac-ead3-teardown)
+///
+/// The `tearing_down` flag closes a race between an app-driven teardown and the
+/// death-watch proc. Without it, if the captured device dies *exactly* as the
+/// stream is being stopped/dropped, an in-flight or late proc could
+/// `force_set(Error)` on the shared bridge state — and because terminal `Error`
+/// is sticky and outranks the graceful `Stopping` that `stop_audio_unit` sets,
+/// an *intentional* teardown would be misreported to a reader as a Fatal
+/// `StreamEnded` (device death) rather than a clean stop. Teardown sets
+/// `tearing_down = true` (Release) **before** removing the listener; the proc
+/// checks it (Acquire) and no-ops when set, so a spontaneous death that races an
+/// explicit stop resolves in favor of the explicit stop.
 pub(crate) struct DeviceAliveContext {
     device_id: AudioObjectID,
     terminal: std::sync::Arc<crate::bridge::ring_buffer::BridgeShared>,
+    /// Set true by teardown before listener removal; the proc no-ops when set so
+    /// an intentional stop/Drop is not misreported as a spontaneous device death.
+    tearing_down: std::sync::atomic::AtomicBool,
 }
 
 /// CoreAudio listener proc for `kAudioDevicePropertyDeviceIsAlive`. Runs on a
@@ -863,6 +879,18 @@ unsafe extern "C" fn device_alive_listener_proc(
         return 0;
     }
     let context = unsafe { &*(client_data as *const DeviceAliveContext) };
+
+    // Teardown race guard (rsac-ead3-teardown): if an explicit stop/Drop is in
+    // progress, do NOT poison the stream to the Fatal Error state — the
+    // graceful `stop_audio_unit` transition owns the teardown. A device death
+    // that races an intentional stop should resolve as a clean stop, not a
+    // spontaneous-death StreamEnded.
+    if context
+        .tearing_down
+        .load(std::sync::atomic::Ordering::Acquire)
+    {
+        return 0;
+    }
 
     // Read the current IsAlive value. If the device is gone the read may fail;
     // a failed read on a death notification is itself treated as "dead".
@@ -912,6 +940,7 @@ pub(crate) fn register_device_alive_listener(
     let context_ptr: *mut DeviceAliveContext = Box::into_raw(Box::new(DeviceAliveContext {
         device_id,
         terminal,
+        tearing_down: std::sync::atomic::AtomicBool::new(false),
     }));
     let address = device_alive_address();
     let status = unsafe {
@@ -944,13 +973,33 @@ pub(crate) fn register_device_alive_listener(
 /// NOT freed** (it was leaked at registration for exactly this reason). Called
 /// at stream teardown.
 ///
+/// Teardown race guard (rsac-ead3-teardown): this sets the context's
+/// `tearing_down` flag (Release) **before** calling
+/// `AudioObjectRemovePropertyListener`, so an in-flight or late proc observes
+/// the flag (Acquire) and no-ops instead of poisoning the stream to Fatal
+/// `Error`. This ensures an app-driven stop/Drop that races a spontaneous
+/// device death is reported to a reader as a clean stop, not a device-death
+/// `StreamEnded`.
+///
 /// # Safety
 /// `context_ptr` must be a value returned by [`register_device_alive_listener`]
-/// (i.e. from `Box::into_raw`) for the same `device_id`.
+/// (i.e. from `Box::into_raw`) for the same `device_id`, and must still point at
+/// the intentionally-leaked (never-freed) context.
 pub(crate) unsafe fn remove_device_alive_listener(
     device_id: AudioObjectID,
     context_ptr: *mut DeviceAliveContext,
 ) {
+    // Signal the death-watch proc to stand down BEFORE removing the listener, so
+    // a proc that fires during/after removal (CoreAudio offers no in-flight
+    // barrier) sees the flag and no-ops rather than racing the graceful stop.
+    // SAFETY: `context_ptr` addresses the leaked (never-freed) context, valid
+    // for the process lifetime.
+    if !context_ptr.is_null() {
+        unsafe { &*context_ptr }
+            .tearing_down
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+
     let address = device_alive_address();
     unsafe {
         AudioObjectRemovePropertyListener(
@@ -1183,6 +1232,7 @@ fn try_push_event(context: &WatchListenerContext, event: DeviceEvent) {
 pub struct MacosDeviceEnumerator;
 
 impl MacosDeviceEnumerator {
+    /// Creates a new enumerator. The type is stateless; construction never fails.
     pub fn new() -> Self {
         MacosDeviceEnumerator
     }
@@ -1250,14 +1300,14 @@ impl DeviceEnumerator for MacosDeviceEnumerator {
     /// the helper thread to exit), and joins the helper thread — no leaked
     /// listener, no leaked thread, no hang.
     ///
-    /// The listener-proc context (a [`WatchListenerContext`]) is **intentionally
+    /// The listener-proc context (a `WatchListenerContext`) is **intentionally
     /// leaked** (`Box::into_raw`, never reclaimed on the success/spawn-failure
     /// paths), because CoreAudio gives no barrier that an in-flight proc has
     /// finished when the listener is removed; never freeing it makes a late proc
     /// deref always sound. Delivery is stopped by disconnecting the channel, not
     /// by freeing the context. The residual cost is a bounded, intentional
     /// per-cycle context leak (tens of bytes); the proper race-free fix is
-    /// deferred — see [`WatchListenerContext`] and ADR-0005 §5/§6.
+    /// deferred — see `WatchListenerContext` and ADR-0005 §5/§6.
     fn watch(&self, on_event: DeviceEventHandler) -> AudioResult<DeviceWatcher> {
         // Bounded channel: the CoreAudio proc is the producer, the helper thread
         // the consumer. A bound avoids unbounded growth if events ever burst; on
@@ -2429,6 +2479,87 @@ mod tests {
         let ok: OSStatus = 0;
         assert_eq!(ok, 0i32);
         assert_eq!(std::mem::size_of::<OSStatus>(), 4);
+    }
+
+    /// rsac-ead3-teardown: when the context's `tearing_down` flag is set, the
+    /// device-is-alive listener proc must NOT poison the bridge to the terminal
+    /// `Error` state — an app-driven stop/Drop owns the teardown and a racing
+    /// device-death notification should resolve as a clean stop. Device-free:
+    /// with the guard set, the proc returns before touching any device, so we
+    /// can drive it with a sentinel id and assert the shared state is untouched.
+    #[test]
+    fn device_alive_proc_noops_during_teardown() {
+        use crate::bridge::create_bridge;
+        use crate::bridge::state::StreamState;
+        use crate::core::config::AudioFormat;
+        use std::sync::atomic::AtomicBool;
+
+        let (_producer, consumer) = create_bridge(16, AudioFormat::default());
+        let shared = std::sync::Arc::clone(consumer.shared());
+        shared.state.force_set(StreamState::Running);
+
+        // Context with teardown IN PROGRESS. u32::MAX is not a real device id,
+        // but the guard makes the proc return before any device read.
+        let ctx = DeviceAliveContext {
+            device_id: u32::MAX,
+            terminal: std::sync::Arc::clone(&shared),
+            tearing_down: AtomicBool::new(true),
+        };
+
+        // Invoke the proc exactly as CoreAudio would (cookie = &ctx).
+        let status = unsafe {
+            device_alive_listener_proc(
+                u32::MAX,
+                0,
+                std::ptr::null(),
+                &ctx as *const DeviceAliveContext as *mut std::ffi::c_void,
+            )
+        };
+        assert_eq!(status, 0, "proc must return noErr");
+
+        // The stream MUST still be Running — the death watch stood down, so the
+        // graceful teardown transition (elsewhere) is not overridden by Error.
+        assert_eq!(
+            shared.state.get(),
+            StreamState::Running,
+            "tearing_down guard must prevent the proc from poisoning the stream to Error"
+        );
+    }
+
+    /// rsac-ead3-teardown: `remove_device_alive_listener` sets the `tearing_down`
+    /// flag before removing the listener. We can't unregister a real listener
+    /// device-free, but we can assert the flag-setting contract by constructing a
+    /// context, leaking it, and confirming the flag flips (the subsequent
+    /// `AudioObjectRemovePropertyListener` on a sentinel id is a harmless no-op).
+    #[test]
+    fn remove_device_alive_listener_sets_teardown_flag() {
+        use crate::bridge::create_bridge;
+        use crate::core::config::AudioFormat;
+        use std::sync::atomic::Ordering;
+
+        let (_producer, consumer) = create_bridge(16, AudioFormat::default());
+        let shared = std::sync::Arc::clone(consumer.shared());
+
+        // Leak a context exactly like registration does, so the pointer stays
+        // valid for the (best-effort) removal call.
+        let ctx_ptr: *mut DeviceAliveContext = Box::into_raw(Box::new(DeviceAliveContext {
+            device_id: u32::MAX,
+            terminal: shared,
+            tearing_down: std::sync::atomic::AtomicBool::new(false),
+        }));
+
+        // SAFETY: ctx_ptr came from Box::into_raw for a sentinel device id; the
+        // removal call is a no-op for a never-registered listener.
+        unsafe {
+            remove_device_alive_listener(u32::MAX, ctx_ptr);
+            assert!(
+                (*ctx_ptr).tearing_down.load(Ordering::Acquire),
+                "remove must set tearing_down before removing the listener"
+            );
+            // Reclaim the leaked context in the test (no listener was ever
+            // registered against it, so no proc can be in flight).
+            drop(Box::from_raw(ctx_ptr));
+        }
     }
 
     /// `emit_device_list_diff` emits one `DeviceRemoved` per id that disappears

--- a/src/audio/macos/mod.rs
+++ b/src/audio/macos/mod.rs
@@ -23,6 +23,10 @@ pub mod coreaudio;
 pub mod tap;
 #[cfg(target_os = "macos")]
 pub(crate) mod thread;
+// ADR-0015: private-SPI TCC preflight for the system-audio-capture permission.
+// Compiled only under the opt-in `macos-tcc-spi` feature.
+#[cfg(all(target_os = "macos", feature = "macos-tcc-spi"))]
+pub(crate) mod permission;
 
 // Re-export public types for convenience
 #[cfg(target_os = "macos")]

--- a/src/audio/macos/permission.rs
+++ b/src/audio/macos/permission.rs
@@ -1,0 +1,116 @@
+//! macOS system-audio-capture (Process Tap) TCC permission preflight.
+//!
+//! **This module is compiled only under the opt-in `macos-tcc-spi` feature**
+//! (see [ADR-0015](../../../docs/designs/0015-macos-tcc-audiocapture-preflight.md)).
+//! It exists because there is **no public API** to query the
+//! `kTCCServiceAudioCapture` authorization status before attempting a Process
+//! Tap — `AVCaptureDevice.authorizationStatus(for: .audio)` covers the
+//! *microphone* service, not the tap. The only working preflight is the
+//! **private, undocumented** `TCCAccessPreflight` SPI in
+//! `/System/Library/PrivateFrameworks/TCC.framework`, the same mechanism the
+//! reference implementation `insidegui/AudioCap` uses (behind its own
+//! `ENABLE_TCC_SPI` build flag).
+//!
+//! Because the symbol is private it is `dlopen`/`dlsym`'d at runtime, never
+//! linked. Any failure (framework missing, symbol absent) degrades to
+//! [`PermissionStatus::NotDetermined`] — this module never panics and never
+//! claims an authorization answer it cannot actually obtain.
+
+use std::ffi::c_void;
+use std::os::raw::c_long;
+
+use core_foundation::base::TCFType;
+use core_foundation::string::CFString;
+use core_foundation_sys::dictionary::CFDictionaryRef;
+use core_foundation_sys::string::CFStringRef;
+
+use crate::core::introspection::PermissionStatus;
+
+/// The TCC service name for system-audio capture (Process Tap), as an ASCII
+/// C-string literal. This is a *different* service from `kTCCServiceMicrophone`
+/// (the microphone) and `kTCCServiceScreenCapture` (screen recording).
+const TCC_SERVICE_AUDIO_CAPTURE: &str = "kTCCServiceAudioCapture";
+
+/// Path to the private framework that exports `TCCAccessPreflight`.
+const TCC_FRAMEWORK_PATH: &[u8] = b"/System/Library/PrivateFrameworks/TCC.framework/TCC\0";
+
+/// `TCCAccessPreflight`'s exported symbol name.
+const TCC_PREFLIGHT_SYMBOL: &[u8] = b"TCCAccessPreflight\0";
+
+/// Signature of the private `TCCAccessPreflight` SPI.
+///
+/// ```objc
+/// long TCCAccessPreflight(CFStringRef service, CFDictionaryRef options);
+/// ```
+///
+/// Return values (empirically, per AudioCap): `0` = authorized, `1` = denied,
+/// `2` (and anything else) = not-yet-determined / unknown.
+type TccAccessPreflightFn =
+    unsafe extern "C" fn(service: CFStringRef, options: CFDictionaryRef) -> c_long;
+
+/// Queries the macOS system-audio-capture (Process Tap) TCC authorization
+/// status via the private `TCCAccessPreflight` SPI, without triggering a
+/// consent prompt.
+///
+/// Returns [`PermissionStatus::NotDetermined`] on any failure to reach the SPI,
+/// so the caller always gets an honest, non-panicking answer.
+pub(crate) fn audio_capture_permission() -> PermissionStatus {
+    // SAFETY: dlopen/dlsym of a system framework. We validate every pointer
+    // before use and only call the resolved symbol with a valid CFString and a
+    // null options dictionary (which the SPI accepts).
+    unsafe {
+        let handle = libc::dlopen(TCC_FRAMEWORK_PATH.as_ptr() as *const _, libc::RTLD_LAZY);
+        if handle.is_null() {
+            log::debug!("macos-tcc-spi: dlopen(TCC.framework) failed; reporting NotDetermined");
+            return PermissionStatus::NotDetermined;
+        }
+
+        // Resolve the symbol. Note we intentionally do NOT dlclose(handle):
+        // the framework stays mapped for the process lifetime (cheap, and a
+        // second call re-dlopens the already-resident image), which avoids any
+        // window where a resolved fn pointer could dangle.
+        let sym = libc::dlsym(handle, TCC_PREFLIGHT_SYMBOL.as_ptr() as *const _);
+        if sym.is_null() {
+            log::debug!(
+                "macos-tcc-spi: TCCAccessPreflight symbol not found; reporting NotDetermined"
+            );
+            return PermissionStatus::NotDetermined;
+        }
+
+        // Transmute the resolved address to the function signature. This is the
+        // load-bearing unsafe step; the signature is fixed by the ABI above.
+        let preflight: TccAccessPreflightFn =
+            std::mem::transmute::<*mut c_void, TccAccessPreflightFn>(sym);
+
+        let service = CFString::new(TCC_SERVICE_AUDIO_CAPTURE);
+        let result = preflight(service.as_concrete_TypeRef(), std::ptr::null());
+
+        match result {
+            0 => PermissionStatus::Granted,
+            1 => PermissionStatus::Denied,
+            // 2 = not-yet-determined; any other value is undocumented, so we
+            // treat it conservatively as "we don't know" rather than guessing.
+            _ => PermissionStatus::NotDetermined,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The preflight must always return a well-formed `PermissionStatus` and
+    /// never panic, regardless of the host's actual TCC state or whether the
+    /// SPI resolves. (On CI the process is unbundled/terminal-attributed, so
+    /// this typically observes `NotDetermined`/`Denied`; on a granted dev box
+    /// it may observe `Granted`. All three are valid — we only assert liveness
+    /// and non-panic here.)
+    #[test]
+    fn preflight_returns_a_status_without_panicking() {
+        let status = audio_capture_permission();
+        assert!(matches!(
+            status,
+            PermissionStatus::Granted | PermissionStatus::Denied | PermissionStatus::NotDetermined
+        ));
+    }
+}

--- a/src/audio/macos/tap.rs
+++ b/src/audio/macos/tap.rs
@@ -37,6 +37,7 @@ use objc2::runtime::{AnyClass, AnyObject, Sel};
 use objc2::{msg_send, sel};
 use objc2_foundation::{NSArray, NSAutoreleasePool, NSNumber, NSString, NSUUID};
 use std::ffi::c_void;
+use std::panic::AssertUnwindSafe;
 
 // ── Aggregate device dictionary keys (from CoreAudio/AudioHardware.h) ────
 
@@ -146,24 +147,10 @@ impl CoreAudioProcessTap {
                 "process_tap",
             )?;
 
-            // 3. Set name
-            let tap_name_nsstring = NSString::from_str(tap_name_str);
-            let _: () = msg_send![tap_desc_obj, setName: &*tap_name_nsstring];
-
-            // 4. Set UUID on tap description (REQUIRED for aggregate device)
-            let tap_uuid: Retained<NSUUID> = NSUUID::UUID();
-            let _: () = msg_send![tap_desc_obj, setUUID: &*tap_uuid];
-
-            // 5. Set mute behavior to unmuted (CATapUnmuted = 0)
-            let _: () = msg_send![tap_desc_obj, setMuteBehavior: 0i64];
-
-            // 6. Set privateTap if available (guard for macOS 26+ where it may be removed)
-            if msg_send_responds_to(tap_desc_obj, sel!(setPrivateTap:)) {
-                let _: () = msg_send![tap_desc_obj, setPrivateTap: true];
-            }
-
-            // 7. Set mixdown = true (already configured by initStereoMixdown, but safe to set explicitly)
-            let _: () = msg_send![tap_desc_obj, setMixdown: true];
+            // 3–7. Configure shared tap-description properties (name, UUID,
+            // mute behavior, private, mixdown) via the centralized,
+            // exception-guarded helper.
+            let tap_uuid = configure_tap_description(tap_desc_obj, tap_name_str)?;
 
             // 8. Call AudioHardwareCreateProcessTap
             let mut tap_id: sys::AudioObjectID = 0;
@@ -230,12 +217,23 @@ impl CoreAudioProcessTap {
     }
 
     /// Creates and configures a new Core Audio Tap + aggregate device that
-    /// captures audio from a process tree (parent + all direct children).
+    /// captures audio from a process tree (parent + **all transitive
+    /// descendants**, not just direct children).
     ///
-    /// Uses `sysinfo` to enumerate child processes of `parent_pid`, then
-    /// creates a `CATapDescription` targeting all discovered PIDs.
+    /// Uses `sysinfo` to snapshot the process table once, then walks the
+    /// `parent → child` relation breadth-first from `parent_pid` to collect the
+    /// full descendant closure (children, grandchildren, …). This matters for
+    /// real targets: browsers, Electron apps, and shells spawn audio-producing
+    /// work in **grandchild** helper processes (e.g. a browser's GPU/audio
+    /// service under a content process), which a direct-children-only tap would
+    /// miss. Discovery is snapshot-based and best-effort — a process that
+    /// forks after the snapshot is not captured (a documented limitation;
+    /// re-enumeration on process-tree change is future work, see the module doc
+    /// and REFERENCE_ANALYSIS "ProcessTree re-enumeration").
     ///
-    /// If no child processes are found, the tap is created with just the
+    /// Cycles in the reported parent relation (which can occur transiently after
+    /// PID reuse) cannot cause an infinite loop: each PID is visited at most
+    /// once. If no descendants are found, the tap is created with just the
     /// parent PID (graceful degradation to single-process capture).
     ///
     /// Process targeting uses (in order of preference):
@@ -245,28 +243,31 @@ impl CoreAudioProcessTap {
     ///
     /// **Important:** Requires macOS 14.4+ and the `CATapDescription` class.
     pub fn new_tree(parent_pid: u32) -> AudioResult<Self> {
-        // ── Step 1: Discover child processes via sysinfo ──
+        // ── Step 1: Discover the full descendant closure via sysinfo ──
         use sysinfo::{ProcessRefreshKind, RefreshKind, System};
 
         let refresh_kind = RefreshKind::nothing().with_processes(ProcessRefreshKind::everything());
         let sys = System::new_with_specifics(refresh_kind);
 
-        let parent_sysinfo_pid = sysinfo::Pid::from_u32(parent_pid);
-
-        // Collect parent + direct children
-        let mut all_pids: Vec<u32> = vec![parent_pid];
+        // Build a parent → children adjacency map from the single snapshot, then
+        // walk it breadth-first (see `collect_process_tree_pids`). This captures
+        // grandchildren+ (e.g. a browser's audio helper under a content
+        // process), which a direct-children-only scan would miss.
+        let mut children_of: std::collections::HashMap<u32, Vec<u32>> =
+            std::collections::HashMap::new();
         for (pid, process) in sys.processes() {
             if let Some(ppid) = process.parent() {
-                if ppid == parent_sysinfo_pid && *pid != parent_sysinfo_pid {
-                    all_pids.push(pid.as_u32());
-                }
+                children_of
+                    .entry(ppid.as_u32())
+                    .or_default()
+                    .push(pid.as_u32());
             }
         }
-        all_pids.sort();
-        all_pids.dedup();
+
+        let all_pids = collect_process_tree_pids(parent_pid, &children_of);
 
         log::info!(
-            "ProcessTree capture: parent_pid={}, discovered {} total PIDs: {:?}",
+            "ProcessTree capture: parent_pid={}, discovered {} total PIDs (full descendant closure): {:?}",
             parent_pid,
             all_pids.len(),
             all_pids
@@ -295,25 +296,11 @@ impl CoreAudioProcessTap {
                 "process_tap_tree",
             )?;
 
-            // Set name
+            // Configure shared tap-description properties (name, UUID, mute
+            // behavior, private, mixdown) via the centralized, exception-guarded
+            // helper.
             let tap_name_str = format!("rsac-tap-tree-{}", parent_pid);
-            let tap_name_nsstring = NSString::from_str(&tap_name_str);
-            let _: () = msg_send![tap_desc_obj, setName: &*tap_name_nsstring];
-
-            // Set UUID on tap description
-            let tap_uuid: Retained<NSUUID> = NSUUID::UUID();
-            let _: () = msg_send![tap_desc_obj, setUUID: &*tap_uuid];
-
-            // Set mute behavior to unmuted (CATapUnmuted = 0)
-            let _: () = msg_send![tap_desc_obj, setMuteBehavior: 0i64];
-
-            // Set privateTap if available (guard for macOS 26+ where it may be removed)
-            if msg_send_responds_to(tap_desc_obj, sel!(setPrivateTap:)) {
-                let _: () = msg_send![tap_desc_obj, setPrivateTap: true];
-            }
-
-            // Set mixdown = true (already configured by initStereoMixdown, but safe to set explicitly)
-            let _: () = msg_send![tap_desc_obj, setMixdown: true];
+            let tap_uuid = configure_tap_description(tap_desc_obj, &tap_name_str)?;
 
             // Call AudioHardwareCreateProcessTap
             let mut tap_id: sys::AudioObjectID = 0;
@@ -418,6 +405,9 @@ impl CoreAudioProcessTap {
             // Check that the selector is available before calling
             let sel_global_tap = sel!(initStereoGlobalTapButExcludeProcesses:);
             if !msg_send_responds_to(tap_desc_obj, sel_global_tap) {
+                // alloc_obj is uninitialized (init never ran) — release it so we
+                // don't leak the +1 from `alloc`.
+                let _: () = msg_send![tap_desc_obj, release];
                 return Err(AudioError::BackendError {
                     backend: "CoreAudio".into(),
                     operation: "system_tap".into(),
@@ -426,10 +416,22 @@ impl CoreAudioProcessTap {
                 });
             }
 
-            let tap_desc_obj: *mut AnyObject =
-                msg_send![tap_desc_obj, initStereoGlobalTapButExcludeProcesses: &*empty_array];
+            // Exception-guard the init: an undocumented initializer that raises
+            // on this macOS version must degrade to an AudioError, not abort the
+            // process. On a thrown exception `init` has already consumed (and
+            // released) the alloc'd receiver per the ObjC "init consumes self"
+            // rule, so there is nothing to release here. (No inner `unsafe`:
+            // unsafety contexts are lexical, and this closure is defined inside
+            // the enclosing `unsafe` block above — rustc flags a nested block as
+            // unused_unsafe under -D warnings.)
+            let tap_desc_obj: *mut AnyObject = guard_objc(
+                "initStereoGlobalTapButExcludeProcesses:",
+                || msg_send![tap_desc_obj, initStereoGlobalTapButExcludeProcesses: &*empty_array],
+            )?;
 
             if tap_desc_obj.is_null() {
+                // init returned nil: it already released the receiver (init
+                // consumes self), so we must NOT release again.
                 return Err(AudioError::BackendError {
                     backend: "CoreAudio".into(),
                     operation: "system_tap".into(),
@@ -438,25 +440,10 @@ impl CoreAudioProcessTap {
                 });
             }
 
-            // Set name
-            let tap_name_str = "rsac-tap-system";
-            let tap_name_nsstring = NSString::from_str(tap_name_str);
-            let _: () = msg_send![tap_desc_obj, setName: &*tap_name_nsstring];
-
-            // Set UUID on tap description (REQUIRED for aggregate device)
-            let tap_uuid: Retained<NSUUID> = NSUUID::UUID();
-            let _: () = msg_send![tap_desc_obj, setUUID: &*tap_uuid];
-
-            // Set mute behavior to unmuted (CATapUnmuted = 0)
-            let _: () = msg_send![tap_desc_obj, setMuteBehavior: 0i64];
-
-            // Set privateTap if available (removed in macOS 26+)
-            if msg_send_responds_to(tap_desc_obj, sel!(setPrivateTap:)) {
-                let _: () = msg_send![tap_desc_obj, setPrivateTap: true];
-            }
-
-            // Mixdown already configured by initStereoGlobalTap, but set explicitly for safety
-            let _: () = msg_send![tap_desc_obj, setMixdown: true];
+            // Configure shared tap-description properties (name, UUID, mute
+            // behavior, private, mixdown) via the centralized, exception-guarded
+            // helper.
+            let tap_uuid = configure_tap_description(tap_desc_obj, "rsac-tap-system")?;
 
             // Call AudioHardwareCreateProcessTap
             let mut tap_id: sys::AudioObjectID = 0;
@@ -635,6 +622,48 @@ extern "C" {
 
 // ── Helper functions ─────────────────────────────────────────────────────
 
+/// Collect the full process-tree PID set (the given `root` plus all transitive
+/// descendants) from a `parent → children` adjacency map.
+///
+/// Pure and OS-independent so it can be unit-tested without a live process
+/// table (rsac-ptree). Walks breadth-first, visiting each PID at most once, so
+/// a cyclic `children_of` map (possible transiently after PID reuse) cannot
+/// cause an infinite loop. The returned vec always contains `root` first-ish
+/// but is sorted + de-duplicated for a stable, comparable result.
+///
+/// This is the semantic upgrade over the old direct-children-only scan:
+/// grandchildren and deeper descendants (e.g. a browser's audio-service helper
+/// under a content process) are now included in the tap's target set.
+fn collect_process_tree_pids(
+    root: u32,
+    children_of: &std::collections::HashMap<u32, Vec<u32>>,
+) -> Vec<u32> {
+    use std::collections::{HashSet, VecDeque};
+
+    let mut seen: HashSet<u32> = HashSet::new();
+    let mut queue: VecDeque<u32> = VecDeque::new();
+
+    seen.insert(root);
+    queue.push_back(root);
+
+    while let Some(pid) = queue.pop_front() {
+        if let Some(children) = children_of.get(&pid) {
+            for &child in children {
+                // `insert` returns false if already present → natural cycle /
+                // diamond guard; never enqueue a PID twice.
+                if seen.insert(child) {
+                    queue.push_back(child);
+                }
+            }
+        }
+    }
+
+    let mut pids: Vec<u32> = seen.into_iter().collect();
+    pids.sort_unstable();
+    pids.dedup();
+    pids
+}
+
 /// Translate a process PID to its CoreAudio `AudioObjectID` using
 /// `kAudioHardwarePropertyTranslatePIDToProcessObject`.
 ///
@@ -693,6 +722,26 @@ unsafe fn translate_pid_to_audio_object_id(pid: u32) -> Option<sys::AudioObjectI
 ///    when PID→AudioObjectID translation failed)
 ///
 /// Returns the initialized CATapDescription ObjC object or an error.
+///
+/// # ObjC ownership contract (audited — rsac-catap-safety)
+///
+/// `CATapDescription` is a standard `NSObject` subclass, so its `init…` family
+/// follows normal ObjC retain semantics: the caller receives a **+1-retained**
+/// object it owns (adopted by `AudioHardwareCreateProcessTap`'s caller flow and
+/// released via `Drop`). The two failure modes each have a distinct cleanup
+/// rule, applied consistently below:
+///
+/// * **`init…` returns nil OR throws** — per the ObjC "init consumes self" rule
+///   the initializer has already released the alloc'd receiver, so the caller
+///   must **NOT** release it again. We simply fall through to the next path with
+///   a *fresh* `alloc` (never re-touching the consumed pointer).
+/// * **`init…` was never called** (selector unavailable, or no PIDs to pass) —
+///   the `alloc`'d receiver is still uninitialized and owns a +1 the caller must
+///   `release` before falling through.
+///
+/// Every may-throw private selector goes through [`guard_objc`] so a
+/// version-shape mismatch degrades to an [`AudioError`] rather than aborting the
+/// host process.
 unsafe fn create_process_tap_description(
     ca_tap_class: &AnyClass,
     pids: &[u32],
@@ -728,25 +777,44 @@ unsafe fn create_process_tap_description(
 
             let processes_array = NSArray::from_retained_slice(&nsnumbers);
 
-            let result: *mut AnyObject =
-                msg_send![alloc_obj, initStereoMixdownOfProcesses: &*processes_array];
-            if !result.is_null() {
-                log::info!(
-                    "Using initStereoMixdownOfProcesses: for PIDs {:?} → AudioObjectIDs {:?}",
-                    pids,
-                    audio_obj_ids
-                );
-                return Ok(result);
+            // Exception-guarded init. On a thrown NSException OR a nil return,
+            // `init` has consumed (released) `alloc_obj` — we must NOT release it,
+            // and fall through to Path 2 with a fresh alloc.
+            let init_result = guard_objc("initStereoMixdownOfProcesses:", || unsafe {
+                let result: *mut AnyObject =
+                    msg_send![alloc_obj, initStereoMixdownOfProcesses: &*processes_array];
+                result
+            });
+            match init_result {
+                Ok(result) if !result.is_null() => {
+                    log::info!(
+                        "Using initStereoMixdownOfProcesses: for PIDs {:?} → AudioObjectIDs {:?}",
+                        pids,
+                        audio_obj_ids
+                    );
+                    return Ok(result);
+                }
+                Ok(_) => {
+                    // nil — alloc_obj consumed by init; fall through with a fresh alloc.
+                    log::warn!(
+                        "initStereoMixdownOfProcesses: returned nil for AudioObjectIDs {:?}, trying fallback",
+                        audio_obj_ids
+                    );
+                }
+                Err(e) => {
+                    // Thrown NSException: init consumed the receiver, so no release.
+                    // Fall through to the PID-based paths rather than failing hard —
+                    // a throw here usually means this initializer's shape differs on
+                    // this macOS version, which Path 2/3 may handle.
+                    log::warn!(
+                        "initStereoMixdownOfProcesses: raised ({e:?}) for AudioObjectIDs {:?}, trying fallback",
+                        audio_obj_ids
+                    );
+                }
             }
-            // initStereoMixdownOfProcesses: returned nil — alloc_obj consumed by init.
-            // Fall through to Path 2 with a fresh alloc.
-            log::warn!(
-                "initStereoMixdownOfProcesses: returned nil for AudioObjectIDs {:?}, trying fallback",
-                audio_obj_ids
-            );
         } else {
             // No PIDs could be translated to AudioObjectIDs.
-            // alloc_obj is still uninitialized — release it.
+            // alloc_obj is still uninitialized (init never ran) — release it.
             log::debug!(
                 "No PIDs translated to AudioObjectIDs for {:?}, trying fallback",
                 pids
@@ -755,7 +823,7 @@ unsafe fn create_process_tap_description(
         }
     } else {
         // initStereoMixdownOfProcesses: is not available on this macOS version.
-        // alloc_obj is still uninitialized — release it.
+        // alloc_obj is still uninitialized (init never ran) — release it.
         log::debug!("initStereoMixdownOfProcesses: not available, trying fallback");
         let _: () = msg_send![alloc_obj, release];
     }
@@ -766,6 +834,7 @@ unsafe fn create_process_tap_description(
     let alloc_obj2: *mut AnyObject = msg_send![ca_tap_class, alloc];
     let init_obj: *mut AnyObject = msg_send![alloc_obj2, init];
     if init_obj.is_null() {
+        // init returned nil: it already released the receiver; nothing to release.
         return Err(AudioError::BackendError {
             backend: "CoreAudio".into(),
             operation: operation.into(),
@@ -773,6 +842,15 @@ unsafe fn create_process_tap_description(
             context: None,
         });
     }
+
+    // From here on `init_obj` is a live +1-owned object. Any early return on a
+    // configuration error MUST release it first to avoid leaking it (a thrown
+    // setter would otherwise skip the manual release). `release_on_err` centralizes
+    // that: it releases `init_obj` and returns the error.
+    let release_on_err = |init_obj: *mut AnyObject, e: AudioError| -> AudioError {
+        let _: () = unsafe { msg_send![init_obj, release] };
+        e
+    };
 
     // Create NSArray of PIDs as NSNumber(int:)
     let pid_nsnumbers: Vec<Retained<NSNumber>> = pids
@@ -785,9 +863,16 @@ unsafe fn create_process_tap_description(
     // Path 2: Try combined setProcesses:exclusive: (macOS 14.4–15)
     let sel_set_processes_exclusive = sel!(setProcesses:exclusive:);
     if msg_send_responds_to(init_obj, sel_set_processes_exclusive) {
-        let _: () = msg_send![init_obj, setProcesses: &*pids_nsarray, exclusive: false];
-        log::info!("Using setProcesses:exclusive: for PIDs {:?}", pids);
-        return Ok(init_obj);
+        match guard_objc("setProcesses:exclusive:", || unsafe {
+            let _: () = msg_send![init_obj, setProcesses: &*pids_nsarray, exclusive: false];
+        }) {
+            Ok(()) => {
+                log::info!("Using setProcesses:exclusive: for PIDs {:?}", pids);
+                return Ok(init_obj);
+            }
+            // A thrown setter left `init_obj` live but unconfigured — release it.
+            Err(e) => return Err(release_on_err(init_obj, e)),
+        }
     }
 
     // Path 3: Try separate setProcesses: + setExclusive: (macOS 26 fallback)
@@ -796,27 +881,36 @@ unsafe fn create_process_tap_description(
     if msg_send_responds_to(init_obj, sel_set_processes)
         && msg_send_responds_to(init_obj, sel_set_exclusive)
     {
-        let _: () = msg_send![init_obj, setProcesses: &*pids_nsarray];
-        let _: () = msg_send![init_obj, setExclusive: false];
-        log::info!(
-            "Using separate setProcesses: + setExclusive: for PIDs {:?}",
-            pids
-        );
-        return Ok(init_obj);
+        match guard_objc("setProcesses:/setExclusive:", || unsafe {
+            let _: () = msg_send![init_obj, setProcesses: &*pids_nsarray];
+            let _: () = msg_send![init_obj, setExclusive: false];
+        }) {
+            Ok(()) => {
+                log::info!(
+                    "Using separate setProcesses: + setExclusive: for PIDs {:?}",
+                    pids
+                );
+                return Ok(init_obj);
+            }
+            Err(e) => return Err(release_on_err(init_obj, e)),
+        }
     }
 
-    // No supported method found
-    Err(AudioError::BackendError {
-        backend: "CoreAudio".into(),
-        operation: operation.into(),
-        message: format!(
-            "No supported method found for setting processes on CATapDescription. \
-             Tried initStereoMixdownOfProcesses:, setProcesses:exclusive:, and \
-             separate setProcesses:/setExclusive:. PIDs: {:?}. Ensure macOS 14.4+.",
-            pids
-        ),
-        context: None,
-    })
+    // No supported method found — release the live init_obj before failing.
+    Err(release_on_err(
+        init_obj,
+        AudioError::BackendError {
+            backend: "CoreAudio".into(),
+            operation: operation.into(),
+            message: format!(
+                "No supported method found for setting processes on CATapDescription. \
+                 Tried initStereoMixdownOfProcesses:, setProcesses:exclusive:, and \
+                 separate setProcesses:/setExclusive:. PIDs: {:?}. Ensure macOS 14.4+.",
+                pids
+            ),
+            context: None,
+        },
+    ))
 }
 
 /// Enumerates all audio process AudioObjectIDs from CoreAudio's
@@ -1147,6 +1241,174 @@ unsafe fn msg_send_responds_to(obj: *mut AnyObject, sel: Sel) -> bool {
     msg_send![obj, respondsToSelector: sel]
 }
 
+// ── ObjC exception safety (rsac-catap-safety) ─────────────────────────────
+//
+// `CATapDescription` is a private/undocumented CoreAudio class driven entirely
+// through raw `objc2::msg_send!`. Several of its selectors
+// (`initStereoMixdownOfProcesses:`, `initStereoGlobalTapButExcludeProcesses:`,
+// `setProcesses:exclusive:`, `setMuteBehavior:`, `setPrivateTap:`, …) are
+// undocumented and their argument shapes have shifted across macOS 14.4–26. If
+// one of them raises an `NSException`, the exception unwinds out of the C frame
+// into Rust. With objc2's default `msg_send!` (this crate enables the
+// `"exception"` feature but NOT `"catch-all"`), that unwind is a *foreign*
+// exception that Rust cannot catch with `std::panic::catch_unwind` — it will
+// typically **abort the process**.
+//
+// `objc2::exception::catch` (feature `"exception"`, already enabled in
+// Cargo.toml) is the correct primitive: it wraps the closure in a real ObjC
+// `@try/@catch` and returns `Err(Some(Retained<Exception>))` on a caught
+// `NSException` instead of aborting. We funnel every may-throw `CATapDescription`
+// message send through [`guard_objc`] so a version-shape mismatch degrades to a
+// categorized [`AudioError`] the caller can handle, rather than killing the host
+// process.
+
+/// Runs an ObjC message-send closure, converting any thrown `NSException` into
+/// an [`AudioError::BackendError`] instead of aborting the process.
+///
+/// Backed by [`objc2::exception::catch`] (gated by the `objc2` `"exception"`
+/// cargo feature, enabled for this crate). `operation` is a short label
+/// (usually the selector name) surfaced in the error message and log line.
+///
+/// # Safety / panics
+/// The closure runs inside an ObjC `@try`. A *Rust* panic inside the closure is
+/// NOT converted — it propagates as a normal Rust unwind (matching
+/// `objc2::exception::catch`'s contract). Only ObjC `NSException`s are caught.
+fn guard_objc<R>(operation: &str, f: impl FnOnce() -> R) -> AudioResult<R> {
+    // AssertUnwindSafe: the CATapDescription pointers/refs captured by these
+    // closures are `*mut AnyObject`/borrows used only for the duration of the
+    // single message send; there is no cross-unwind shared-mutable state to be
+    // left in a torn state (a thrown selector either mutated the description or
+    // did not — the caller discards it on error).
+    match objc2::exception::catch(AssertUnwindSafe(f)) {
+        Ok(v) => Ok(v),
+        Err(exc) => {
+            let detail = exc
+                .as_deref()
+                .map(describe_nsexception)
+                .unwrap_or_else(|| "nil ObjC exception (@throw nil)".to_string());
+            log::warn!(
+                "CoreAudio: ObjC exception during {operation}: {detail}. \
+                 The CATapDescription API shape may differ on this macOS version."
+            );
+            Err(AudioError::BackendError {
+                backend: "CoreAudio".into(),
+                operation: operation.into(),
+                message: format!("ObjC exception during {operation}: {detail}"),
+                context: None,
+            })
+        }
+    }
+}
+
+/// Extracts `name: reason` from a caught `NSException` for diagnostics.
+///
+/// `objc2::exception::Exception` derefs to an ObjC object that responds to
+/// `-name` / `-reason` (both `NSString`). Best-effort: a missing field yields an
+/// empty component. Never panics.
+fn describe_nsexception(exc: &objc2::exception::Exception) -> String {
+    unsafe {
+        // `objc2::exception::Exception` is a transparent wrapper over the thrown
+        // ObjC object; reinterpret it as `AnyObject` to read `-name` / `-reason`
+        // (both `NSString`) when the thrown value is an NSException. Best-effort
+        // diagnostics only — a non-NSException or a nil field yields an empty
+        // component and never panics.
+        let obj: *const AnyObject = (exc as *const objc2::exception::Exception).cast();
+        let name: Option<Retained<NSString>> = msg_send![obj, name];
+        let reason: Option<Retained<NSString>> = msg_send![obj, reason];
+        let name = name.map(|s| s.to_string()).unwrap_or_default();
+        let reason = reason.map(|s| s.to_string()).unwrap_or_default();
+        format!("{name}: {reason}")
+    }
+}
+
+/// Centralized, exception-guarded configuration of the shared `CATapDescription`
+/// properties common to all three tap flavours (per-process, process-tree, and
+/// system-wide).
+///
+/// This is the single place that issues the may-throw private selectors
+/// `setName:`, `setUUID:`, `setMuteBehavior:`, `setPrivateTap:`, and
+/// `setMixdown:`, so exception handling, macOS-version guards
+/// (`respondsToSelector:` for the removed-in-26 `setPrivateTap:`), and the
+/// `setMuteBehavior:` `i64` argument-type fix all live in one auditable spot
+/// rather than being copy-pasted across `new`, `new_tree`, and `new_system`.
+///
+/// Returns the tap's freshly-generated UUID (already set on the description) so
+/// the caller can key the aggregate device off it.
+///
+/// # Leak safety on error
+///
+/// `tap_desc_obj` is a live, +1-owned `CATapDescription` the caller no longer
+/// uses if this returns `Err`. To keep every error path leak-free, this helper
+/// **releases `tap_desc_obj` before returning any `Err`** (a thrown setter would
+/// otherwise leave it dangling with no `Drop` to reclaim it, since it is a raw
+/// `*mut AnyObject`, not a `Retained`). Callers therefore must NOT release it on
+/// error, and must NOT use it after an `Err` return.
+///
+/// # Safety
+/// `tap_desc_obj` must be a valid, initialized `CATapDescription` instance
+/// (non-null). The autorelease pool must be active for the current scope.
+unsafe fn configure_tap_description(
+    tap_desc_obj: *mut AnyObject,
+    tap_name: &str,
+) -> AudioResult<Retained<NSUUID>> {
+    // Run the may-throw setters; on the first error release the description so
+    // no path leaks it.
+    match configure_tap_description_inner(tap_desc_obj, tap_name) {
+        Ok(uuid) => Ok(uuid),
+        Err(e) => {
+            let _: () = msg_send![tap_desc_obj, release];
+            Err(e)
+        }
+    }
+}
+
+/// Inner body of [`configure_tap_description`]: issues the guarded setters and
+/// returns the generated UUID, WITHOUT any release-on-error cleanup (the outer
+/// wrapper owns that so there is exactly one release site).
+///
+/// # Safety
+/// Same contract as [`configure_tap_description`].
+unsafe fn configure_tap_description_inner(
+    tap_desc_obj: *mut AnyObject,
+    tap_name: &str,
+) -> AudioResult<Retained<NSUUID>> {
+    // Name.
+    let tap_name_nsstring = NSString::from_str(tap_name);
+    guard_objc("setName:", || unsafe {
+        let _: () = msg_send![tap_desc_obj, setName: &*tap_name_nsstring];
+    })?;
+
+    // UUID (REQUIRED for aggregate device — keyed off this value).
+    let tap_uuid: Retained<NSUUID> = NSUUID::UUID();
+    guard_objc("setUUID:", || unsafe {
+        let _: () = msg_send![tap_desc_obj, setUUID: &*tap_uuid];
+    })?;
+
+    // Mute behavior = CATapUnmuted (0). CATapMuteBehavior is NSInteger-backed
+    // (ObjC type code 'q'), so the argument MUST be i64 — objc2 validates the
+    // argument encoding at runtime and rejects an i32 (a bug the old `objc`
+    // crate silently accepted). See §9.1 of AGENTS.md.
+    guard_objc("setMuteBehavior:", || unsafe {
+        let _: () = msg_send![tap_desc_obj, setMuteBehavior: 0i64];
+    })?;
+
+    // setPrivateTap: — present on macOS 14.4–15, removed on macOS 26+. Guard
+    // with respondsToSelector: so we never send a removed selector.
+    if msg_send_responds_to(tap_desc_obj, sel!(setPrivateTap:)) {
+        guard_objc("setPrivateTap:", || unsafe {
+            let _: () = msg_send![tap_desc_obj, setPrivateTap: true];
+        })?;
+    }
+
+    // Mixdown = true. Already implied by the stereo-mixdown/global initializers,
+    // but set explicitly for safety. Guarded like the rest.
+    guard_objc("setMixdown:", || unsafe {
+        let _: () = msg_send![tap_desc_obj, setMixdown: true];
+    })?;
+
+    Ok(tap_uuid)
+}
+
 /// Build a [`BackendContext`] for a CoreAudio `OSStatus` (M6).
 ///
 /// `OSStatus` is an `i32`; it is sign-extended into the `i64`
@@ -1190,6 +1452,102 @@ mod tests {
         assert_eq!(ctx.backend_name, "CoreAudio");
         assert_eq!(ctx.os_error_code, Some(-50i64));
         assert!(ctx.os_error_message.is_some());
+    }
+
+    /// rsac-catap-safety: `guard_objc` returns `Ok` and forwards the closure's
+    /// value when no ObjC exception is thrown (no CoreAudio hardware needed).
+    #[test]
+    fn guard_objc_returns_ok_for_non_throwing_closure() {
+        let result = guard_objc("noop", || 42u32);
+        assert_eq!(result.expect("non-throwing closure should be Ok"), 42);
+    }
+
+    /// rsac-ptree: `collect_process_tree_pids` gathers the FULL descendant
+    /// closure (grandchildren+), not just direct children. Pure — no live
+    /// process table needed.
+    #[test]
+    fn collect_process_tree_pids_includes_grandchildren() {
+        use std::collections::HashMap;
+        // 1 → {2, 3}; 2 → {4}; 4 → {5}; 3 has no children. Sibling 99 unrelated.
+        let mut m: HashMap<u32, Vec<u32>> = HashMap::new();
+        m.insert(1, vec![2, 3]);
+        m.insert(2, vec![4]);
+        m.insert(4, vec![5]);
+        m.insert(99, vec![100]);
+
+        let pids = collect_process_tree_pids(1, &m);
+        assert_eq!(pids, vec![1, 2, 3, 4, 5], "full closure, sorted, deduped");
+        // Unrelated subtree must NOT be included.
+        assert!(!pids.contains(&99));
+        assert!(!pids.contains(&100));
+    }
+
+    /// rsac-ptree: a leaf root (no children entry) yields just itself.
+    #[test]
+    fn collect_process_tree_pids_leaf_is_just_root() {
+        use std::collections::HashMap;
+        let m: HashMap<u32, Vec<u32>> = HashMap::new();
+        assert_eq!(collect_process_tree_pids(42, &m), vec![42]);
+    }
+
+    /// rsac-ptree: a cyclic parent relation (possible after PID reuse) must not
+    /// hang and must visit each PID once.
+    #[test]
+    fn collect_process_tree_pids_tolerates_cycles() {
+        use std::collections::HashMap;
+        // 1 → 2 → 3 → 1 (cycle), plus 2 → 4.
+        let mut m: HashMap<u32, Vec<u32>> = HashMap::new();
+        m.insert(1, vec![2]);
+        m.insert(2, vec![3, 4]);
+        m.insert(3, vec![1]); // back-edge
+        let pids = collect_process_tree_pids(1, &m);
+        assert_eq!(pids, vec![1, 2, 3, 4]);
+    }
+
+    /// rsac-catap-safety: `guard_objc` converts a thrown `NSException` into an
+    /// `AudioError::BackendError` (labelled with the operation) instead of
+    /// aborting the process. Uses `objc2::exception::throw` to raise a real
+    /// NSException and asserts the caught error carries the operation label.
+    #[test]
+    fn guard_objc_converts_thrown_nsexception_to_backend_error() {
+        // Build a minimal NSException and throw it inside the guarded closure.
+        // We only need *an* ObjC exception object; NSException is the canonical
+        // one. Construct via the runtime so we don't depend on objc2-foundation
+        // exposing a typed NSException builder.
+        let err = guard_objc("throwing_op", || unsafe {
+            // Build an NSException and throw it. Let `msg_send!` perform the
+            // correct autoreleased-return retain directly into a
+            // `Retained<Exception>` (the pointer from
+            // `+exceptionWithName:reason:userInfo:` is +0 autoreleased).
+            let cls = AnyClass::get(c"NSException").expect("NSException class must exist");
+            let name = NSString::from_str("rsacTestException");
+            let reason = NSString::from_str("intentional test throw");
+            let exc: Retained<objc2::exception::Exception> = msg_send![
+                cls,
+                exceptionWithName: &*name,
+                reason: &*reason,
+                userInfo: std::ptr::null::<AnyObject>(),
+            ];
+            objc2::exception::throw(exc);
+        });
+
+        match err {
+            Err(AudioError::BackendError {
+                operation, message, ..
+            }) => {
+                assert_eq!(operation, "throwing_op");
+                assert!(
+                    message.contains("ObjC exception during throwing_op"),
+                    "message should note the ObjC exception, got: {message}"
+                );
+                // The reason should be surfaced for diagnostics.
+                assert!(
+                    message.contains("intentional test throw"),
+                    "message should include the NSException reason, got: {message}"
+                );
+            }
+            other => panic!("Expected BackendError from a thrown NSException, got: {other:?}"),
+        }
     }
 
     /// M6: aggregate-device failures carry the OSStatus machine-readably.
@@ -1346,8 +1704,18 @@ mod tests {
     }
 
     /// Test that new_system() creates a valid system-wide tap.
-    /// Uses std::panic::catch_unwind to catch ObjC exceptions (now that
-    /// the objc crate's "exception" feature is enabled).
+    ///
+    /// ObjC exceptions from the private `CATapDescription` selectors are now
+    /// converted to an `AudioError::BackendError` internally (via `guard_objc`
+    /// → `objc2::exception::catch`), so a version-shape mismatch surfaces as a
+    /// handled `Err`, NOT a Rust panic. We still wrap the call in
+    /// `std::panic::catch_unwind` as a defensive net for a *genuine* Rust panic
+    /// (e.g. a `.unwrap()` regression), which the test then reports.
+    ///
+    /// Note: `std::panic::catch_unwind` does NOT reliably catch foreign ObjC
+    /// exceptions (that would require the objc2 `"catch-all"` feature and would
+    /// otherwise abort); relying on it for that purpose was the bug this change
+    /// fixes. ObjC exceptions are handled inside `new_system` now.
     ///
     /// Ignored by default: `AudioHardwareCreateProcessTap` requires audio
     /// hardware + Screen-Recording (TCC) permission and can BLOCK indefinitely
@@ -1373,16 +1741,19 @@ mod tests {
                 // Drop will clean up the tap and aggregate device
             }
             Ok(Err(audio_err)) => {
-                // AudioError returned — not a panic, just a handled error
+                // AudioError returned — the expected path for a failure. A
+                // caught ObjC exception now arrives here as
+                // AudioError::BackendError (via guard_objc), alongside ordinary
+                // OSStatus/permission failures. All are acceptable on hosts
+                // lacking hardware/TCC or with a differing API shape.
                 eprintln!(
                     "new_system() returned AudioError (not a panic): {:?}",
                     audio_err
                 );
-                // This is acceptable — the test documents what error occurred
-                // On some systems, this may fail due to permissions or API changes
             }
             Err(panic_info) => {
-                // ObjC exception was caught as a Rust panic
+                // A genuine Rust panic (NOT an ObjC exception, which is now
+                // converted to Err above). This indicates a Rust-side bug.
                 let panic_msg = if let Some(s) = panic_info.downcast_ref::<String>() {
                     s.clone()
                 } else if let Some(s) = panic_info.downcast_ref::<&str>() {
@@ -1390,13 +1761,11 @@ mod tests {
                 } else {
                     format!("{:?}", panic_info)
                 };
-                eprintln!(
-                    "new_system() panicked (likely ObjC exception): {}",
-                    panic_msg
-                );
+                eprintln!("new_system() panicked (Rust panic): {}", panic_msg);
                 panic!(
-                    "new_system() threw an ObjC exception: {}. \
-                     This indicates the CATapDescription API needs adjustment for this macOS version.",
+                    "new_system() triggered a Rust panic: {}. \
+                     ObjC exceptions are converted to AudioError now, so this is a \
+                     Rust-side bug, not a CATapDescription API mismatch.",
                     panic_msg
                 );
             }

--- a/src/audio/macos/thread.rs
+++ b/src/audio/macos/thread.rs
@@ -47,6 +47,17 @@ use coreaudio_sys::{
 /// Same as CoreAudio's AudioObjectID = u32.
 type AudioDeviceID = u32;
 
+/// Grace window for the silent-zeros diagnostic (ADR-0016): how long a
+/// Process-Tap capture may deliver only zeroed samples before we warn that the
+/// most likely cause is a missing/denied `kTCCServiceAudioCapture` permission.
+/// Generous enough to clear cold-start latency on a busy machine while still
+/// surfacing the diagnostic promptly.
+const SILENCE_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Poll increment for the watchdog's sleep, so it reacts to the teardown stop
+/// flag within one tick instead of blocking the full grace window.
+const SILENCE_POLL: std::time::Duration = std::time::Duration::from_millis(100);
+
 // ── MacosCaptureConfig ───────────────────────────────────────────────────
 
 /// Resolved capture parameters passed to the CoreAudio capture setup.
@@ -135,6 +146,12 @@ pub(crate) struct MacosPlatformStream {
     /// `Arc<BridgeShared>`) are `Send`/`Sync`, so it does not change the existing
     /// thread-safety story.
     device_alive_ctx: Option<*mut super::coreaudio::DeviceAliveContext>,
+    /// Stop flag for the silent-zeros diagnostic watchdog (ADR-0016). Set at
+    /// teardown so the watchdog exits promptly and does not emit a spurious
+    /// "silent capture" warning when the user stops within the grace window.
+    /// `None` for non-Process-Tap captures (the watchdog only runs for tap
+    /// tiers, where the denied-permission silent-zeros trap exists).
+    silence_watchdog_stop: Option<Arc<AtomicBool>>,
 }
 
 // SAFETY: `MacosPlatformStream` carries a raw `*mut DeviceAliveContext` (the
@@ -160,6 +177,14 @@ impl MacosPlatformStream {
     /// Marked private; `stop_capture` is the public (trait) entry point and
     /// `drop` reuses the same logic.
     fn stop_audio_unit(&self) -> AudioResult<()> {
+        // Silence-watchdog stop (ADR-0016): signal first so a stop within the
+        // grace window suppresses a spurious "silent capture" warning. Cheap,
+        // idempotent relaxed store; no-op when the watchdog wasn't spawned
+        // (non-tap tiers) or already exited.
+        if let Some(stop) = &self.silence_watchdog_stop {
+            stop.store(true, Ordering::Relaxed);
+        }
+
         // `stop()` requires `&mut self` on the AudioUnit, so the lock guard must
         // be `mut`. `AudioOutputUnitStop` is synchronous — on return the IO proc
         // has stopped and no further input callbacks will fire.
@@ -219,7 +244,11 @@ impl Drop for MacosPlatformStream {
     /// own `Drop` tears down the aggregate device and the tap.
     fn drop(&mut self) {
         // rsac-ead3: remove the device-is-alive listener FIRST, so an app-driven
-        // teardown does not race the death-watch proc. Best-effort + the context
+        // teardown does not race the death-watch proc. `remove_device_alive_listener`
+        // sets the context's `tearing_down` guard (Release) BEFORE removing the
+        // listener, so an in-flight/late proc no-ops instead of poisoning the
+        // stream to Fatal Error (rsac-ead3-teardown) — an intentional stop wins
+        // over a racing spontaneous-death notification. Best-effort + the context
         // is intentionally NOT freed (CoreAudio gives no in-flight-proc barrier);
         // see `remove_device_alive_listener`. A normal stop signals the terminal
         // via `stop_audio_unit` below — the death watch is only for the
@@ -351,6 +380,15 @@ pub(crate) fn create_macos_capture(
     let channels = config.channels;
     let sample_rate = config.sample_rate;
 
+    // Silent-zeros diagnostic (ADR-0016): only for Process-Tap tiers, where a
+    // missing/denied kTCCServiceAudioCapture permission makes every setup call
+    // return noErr and then stream all-zero buffers with no error code. The RT
+    // callback flips `non_silence_seen` the first time any non-zero sample
+    // arrives; a non-RT watchdog (spawned after start) warns if it stays unset.
+    let is_tap_tier = process_tap.is_some();
+    let non_silence_seen = Arc::new(AtomicBool::new(false));
+    let rt_non_silence_seen = non_silence_seen.clone();
+
     audio_unit
         .set_input_callback(
             move |args: coreaudio::audio_unit::render_callback::Args<
@@ -381,7 +419,21 @@ pub(crate) fn create_macos_capture(
                 let data: &[f32] = args.data.buffer;
 
                 if !data.is_empty() {
-                    producer.push_samples_guarded(data, channels, sample_rate);
+                    // Silent-zeros diagnostic (ADR-0016): alloc-free, lock-free,
+                    // RT-safe. Once we've seen non-silence, a single relaxed load
+                    // short-circuits the scan; before that, `any(|&s| s != 0.0)`
+                    // stops at the first non-zero sample. No effect on the push.
+                    if is_tap_tier
+                        && !rt_non_silence_seen.load(Ordering::Relaxed)
+                        && data.iter().any(|&s| s != 0.0)
+                    {
+                        rt_non_silence_seen.store(true, Ordering::Relaxed);
+                    }
+
+                    // `_stamped`: stream-position timestamps (frames offered /
+                    // rate — integer math, same guarded alloc-free path;
+                    // rsac-522b / rsac-ec25).
+                    producer.push_samples_guarded_stamped(data, channels, sample_rate);
                 }
 
                 Ok(())
@@ -409,6 +461,55 @@ pub(crate) fn create_macos_capture(
     let device_alive_ctx =
         super::coreaudio::register_device_alive_listener(device_id, terminal.clone());
 
+    // ── Step 6b: Spawn the silent-zeros diagnostic watchdog (ADR-0016) ──
+    // Process-Tap tiers only: a missing/denied kTCCServiceAudioCapture permission
+    // streams all-zero buffers with NO error code. If nothing non-silent arrives
+    // within the grace window while the stream is still healthy, warn once — a
+    // diagnostic, never an error (silence is a legitimate state). Non-RT thread;
+    // exits on the stop flag (set at teardown) or the grace deadline.
+    let silence_watchdog_stop = if is_tap_tier {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_for_thread = stop.clone();
+        let wd_terminal = terminal.clone();
+        let target_desc = format!("{:?}", config.target);
+        // Detached: it self-terminates within one SILENCE_POLL of the stop flag
+        // or the grace deadline, so it never blocks the struct's drop-order
+        // contract and needs no JoinHandle stored.
+        std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + SILENCE_GRACE;
+            loop {
+                if stop_for_thread.load(Ordering::Relaxed) {
+                    return; // stopped within the grace window — no warning
+                }
+                if non_silence_seen.load(Ordering::Relaxed) {
+                    return; // real audio flowed — all good
+                }
+                if wd_terminal.state.is_terminal() {
+                    return; // stream ended/errored on its own — not our concern
+                }
+                if std::time::Instant::now() >= deadline {
+                    break;
+                }
+                std::thread::sleep(SILENCE_POLL);
+            }
+            // Grace elapsed with only zeros on a still-running Process-Tap stream.
+            log::warn!(
+                "CoreAudio: capture target {target_desc} has streamed only silence for \
+                 {}s. If audio is expected, this usually means the system-audio-capture \
+                 permission (TCC kTCCServiceAudioCapture) is missing or denied — the tap \
+                 succeeds but delivers zeroed samples. Ensure the host app bundle declares \
+                 NSAudioCaptureUsageDescription and is granted under System Settings > \
+                 Privacy & Security > Screen & System Audio Recording (a terminal-launched \
+                 or unsigned binary is denied regardless). See ADR-0016. (This is only a \
+                 diagnostic — a genuinely paused/muted source is also silent and fine.)",
+                SILENCE_GRACE.as_secs()
+            );
+        });
+        Some(stop)
+    } else {
+        None
+    };
+
     // ── Step 7: Return the platform stream handle ──
 
     Ok(MacosPlatformStream {
@@ -418,6 +519,7 @@ pub(crate) fn create_macos_capture(
         terminal,
         device_id,
         device_alive_ctx,
+        silence_watchdog_stop,
     })
 }
 
@@ -432,7 +534,7 @@ pub(crate) fn create_macos_capture(
 /// | `Device(id)`           | Parse `DeviceId.0` as `u32`; require INPUT streams (M8)     |
 /// | `Application(pid)`     | `CoreAudioProcessTap::new(pid)` → tap's AudioObjectID      |
 /// | `ApplicationByName(n)` | `enumerate_audio_applications()` → find PID → tap           |
-/// | `ProcessTree(pid)`     | `CoreAudioProcessTap::new_tree(pid)` → multi-PID tap       |
+/// | `ProcessTree(pid)`     | `CoreAudioProcessTap::new_tree(pid)` → parent + full descendant closure |
 fn resolve_capture_target(
     config: &MacosCaptureConfig,
 ) -> AudioResult<(AudioDeviceID, Option<CoreAudioProcessTap>)> {
@@ -557,7 +659,9 @@ fn resolve_capture_target(
         }
 
         CaptureTarget::ProcessTree(pid) => {
-            // Multi-PID tap: captures parent process + all direct child processes
+            // Multi-PID tap: captures the parent process + its full descendant
+            // closure (children, grandchildren, …) — see
+            // `CoreAudioProcessTap::new_tree` / `collect_process_tree_pids`.
             let tap = CoreAudioProcessTap::new_tree(pid.0)?;
             let tap_device_id = tap.id();
             log::debug!(
@@ -641,6 +745,54 @@ mod tests {
     use super::*;
     use crate::core::config::{ApplicationId, CaptureTarget, DeviceId};
     use coreaudio_sys::kAudioFormatFlagIsNonInterleaved;
+
+    // ── silent-zeros diagnostic (ADR-0016) ───────────────────────────
+
+    /// The RT-side detection is `any(|&s| s != 0.0)`: an all-zero buffer must
+    /// NOT flip the flag (the denied-permission silent case), and the first
+    /// non-zero sample must flip it (real audio → watchdog stays quiet). This
+    /// mirrors exactly what the input callback does.
+    #[test]
+    fn non_silence_detection_matches_callback_predicate() {
+        let all_zero = [0.0f32; 256];
+        assert!(
+            !all_zero.iter().any(|&s| s != 0.0),
+            "all-zero buffer must read as silent (would warn)"
+        );
+
+        let mut with_signal = [0.0f32; 256];
+        with_signal[200] = -0.0001; // a single tiny non-zero sample is enough
+        assert!(
+            with_signal.iter().any(|&s| s != 0.0),
+            "any non-zero sample must read as non-silent (suppresses the warn)"
+        );
+    }
+
+    /// The watchdog's warn-guard is: warn only if `!non_silence_seen && !stopped
+    /// && !terminal`. Once the flag is set (real audio flowed), it must be
+    /// suppressed regardless of the other conditions — this is the false-positive
+    /// guard for a correctly-permissioned capture.
+    #[test]
+    fn watchdog_suppressed_once_non_silence_seen() {
+        let seen = Arc::new(AtomicBool::new(false));
+        let stop = Arc::new(AtomicBool::new(false));
+        let would_warn = |seen: &AtomicBool, stop: &AtomicBool| {
+            !stop.load(Ordering::Relaxed) && !seen.load(Ordering::Relaxed)
+        };
+
+        assert!(would_warn(&seen, &stop), "silent + running ⇒ would warn");
+        seen.store(true, Ordering::Relaxed);
+        assert!(
+            !would_warn(&seen, &stop),
+            "non-silence observed ⇒ must NOT warn (false-positive guard)"
+        );
+        seen.store(false, Ordering::Relaxed);
+        stop.store(true, Ordering::Relaxed);
+        assert!(
+            !would_warn(&seen, &stop),
+            "stopped within grace window ⇒ must NOT warn"
+        );
+    }
 
     // ── build_f32_asbd tests ─────────────────────────────────────────
 

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -10,6 +10,10 @@
 //! obtaining a `DeviceEnumerator` through the `get_device_enumerator()` function.
 
 // Conditional module declarations
+#[cfg(all(target_os = "android", feature = "feat_android"))]
+pub mod android;
+#[cfg(all(target_os = "ios", feature = "feat_ios"))]
+pub mod ios;
 #[cfg(all(target_os = "linux", feature = "feat_linux"))]
 pub mod linux;
 #[cfg(all(target_os = "macos", feature = "feat_macos"))]
@@ -20,6 +24,10 @@ pub mod windows;
 // --- Trait-Based API Exports ---
 
 // Re-export platform-specific DeviceEnumerators
+#[cfg(all(target_os = "android", feature = "feat_android"))]
+pub use android::AndroidDeviceEnumerator;
+#[cfg(all(target_os = "ios", feature = "feat_ios"))]
+pub use ios::IosDeviceEnumerator;
 #[cfg(all(target_os = "linux", feature = "feat_linux"))]
 pub use linux::LinuxDeviceEnumerator;
 #[cfg(all(target_os = "macos", feature = "feat_macos"))]
@@ -43,20 +51,33 @@ use crate::core::error::AudioError;
 #[cfg(any(
     all(target_os = "windows", feature = "feat_windows"),
     all(target_os = "linux", feature = "feat_linux"),
-    all(target_os = "macos", feature = "feat_macos")
+    all(target_os = "macos", feature = "feat_macos"),
+    all(target_os = "android", feature = "feat_android"),
+    all(target_os = "ios", feature = "feat_ios")
 ))]
 use crate::core::interface::DeviceEnumerator;
 
 /// Cross-platform device enumerator that wraps platform-specific implementations.
 pub enum CrossPlatformDeviceEnumerator {
+    /// WASAPI-backed enumerator (Windows).
     #[cfg(all(target_os = "windows", feature = "feat_windows"))]
     Windows(windows::WindowsDeviceEnumerator),
 
+    /// PipeWire-backed enumerator (Linux).
     #[cfg(all(target_os = "linux", feature = "feat_linux"))]
     Linux(linux::LinuxDeviceEnumerator),
 
+    /// CoreAudio-backed enumerator (macOS).
     #[cfg(all(target_os = "macos", feature = "feat_macos"))]
     MacOS(macos::MacosDeviceEnumerator),
+
+    /// AAudio-backed enumerator (Android; mic slice — rsac-20cd).
+    #[cfg(all(target_os = "android", feature = "feat_android"))]
+    Android(android::AndroidDeviceEnumerator),
+
+    /// AVAudioEngine-backed enumerator (iOS; mic slice — rsac-9e02).
+    #[cfg(all(target_os = "ios", feature = "feat_ios"))]
+    Ios(ios::IosDeviceEnumerator),
 }
 
 impl CrossPlatformDeviceEnumerator {
@@ -77,10 +98,20 @@ impl CrossPlatformDeviceEnumerator {
             CrossPlatformDeviceEnumerator::MacOS(enumerator) => {
                 DeviceEnumerator::enumerate_devices(enumerator)
             }
+            #[cfg(all(target_os = "android", feature = "feat_android"))]
+            CrossPlatformDeviceEnumerator::Android(enumerator) => {
+                DeviceEnumerator::enumerate_devices(enumerator)
+            }
+            #[cfg(all(target_os = "ios", feature = "feat_ios"))]
+            CrossPlatformDeviceEnumerator::Ios(enumerator) => {
+                DeviceEnumerator::enumerate_devices(enumerator)
+            }
             #[cfg(not(any(
                 all(target_os = "windows", feature = "feat_windows"),
                 all(target_os = "linux", feature = "feat_linux"),
-                all(target_os = "macos", feature = "feat_macos")
+                all(target_os = "macos", feature = "feat_macos"),
+                all(target_os = "android", feature = "feat_android"),
+                all(target_os = "ios", feature = "feat_ios")
             )))]
             _ => Err(crate::core::error::AudioError::PlatformNotSupported {
                 feature: "audio device enumeration".to_string(),
@@ -118,10 +149,20 @@ impl CrossPlatformDeviceEnumerator {
             CrossPlatformDeviceEnumerator::MacOS(enumerator) => {
                 DeviceEnumerator::default_device(enumerator)
             }
+            #[cfg(all(target_os = "android", feature = "feat_android"))]
+            CrossPlatformDeviceEnumerator::Android(enumerator) => {
+                DeviceEnumerator::default_device(enumerator)
+            }
+            #[cfg(all(target_os = "ios", feature = "feat_ios"))]
+            CrossPlatformDeviceEnumerator::Ios(enumerator) => {
+                DeviceEnumerator::default_device(enumerator)
+            }
             #[cfg(not(any(
                 all(target_os = "windows", feature = "feat_windows"),
                 all(target_os = "linux", feature = "feat_linux"),
-                all(target_os = "macos", feature = "feat_macos")
+                all(target_os = "macos", feature = "feat_macos"),
+                all(target_os = "android", feature = "feat_android"),
+                all(target_os = "ios", feature = "feat_ios")
             )))]
             _ => Err(crate::core::error::AudioError::PlatformNotSupported {
                 feature: "audio device enumeration".to_string(),
@@ -190,10 +231,20 @@ impl CrossPlatformDeviceEnumerator {
             CrossPlatformDeviceEnumerator::MacOS(enumerator) => {
                 DeviceEnumerator::watch(enumerator, on_event)
             }
+            #[cfg(all(target_os = "android", feature = "feat_android"))]
+            CrossPlatformDeviceEnumerator::Android(enumerator) => {
+                DeviceEnumerator::watch(enumerator, on_event)
+            }
+            #[cfg(all(target_os = "ios", feature = "feat_ios"))]
+            CrossPlatformDeviceEnumerator::Ios(enumerator) => {
+                DeviceEnumerator::watch(enumerator, on_event)
+            }
             #[cfg(not(any(
                 all(target_os = "windows", feature = "feat_windows"),
                 all(target_os = "linux", feature = "feat_linux"),
-                all(target_os = "macos", feature = "feat_macos")
+                all(target_os = "macos", feature = "feat_macos"),
+                all(target_os = "android", feature = "feat_android"),
+                all(target_os = "ios", feature = "feat_ios")
             )))]
             _ => {
                 drop(on_event);
@@ -233,10 +284,24 @@ pub fn get_device_enumerator() -> Result<CrossPlatformDeviceEnumerator, AudioErr
             macos::MacosDeviceEnumerator::new(),
         ))
     }
+    #[cfg(all(target_os = "android", feature = "feat_android"))]
+    {
+        Ok(CrossPlatformDeviceEnumerator::Android(
+            android::AndroidDeviceEnumerator::new(),
+        ))
+    }
+    #[cfg(all(target_os = "ios", feature = "feat_ios"))]
+    {
+        Ok(CrossPlatformDeviceEnumerator::Ios(
+            ios::IosDeviceEnumerator::new(),
+        ))
+    }
     #[cfg(not(any(
         all(target_os = "windows", feature = "feat_windows"),
         all(target_os = "linux", feature = "feat_linux"),
-        all(target_os = "macos", feature = "feat_macos")
+        all(target_os = "macos", feature = "feat_macos"),
+        all(target_os = "android", feature = "feat_android"),
+        all(target_os = "ios", feature = "feat_ios")
     )))]
     {
         Err::<CrossPlatformDeviceEnumerator, AudioError>(AudioError::PlatformNotSupported {

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -359,3 +359,136 @@ mod tests {
         }
     }
 }
+
+/// JNI lockstep drift guard (rsac-77f1) — runs on **every** host, not just
+/// Android builds.
+///
+/// The Android playback path registers Rust natives on the Kotlin AAR's
+/// classes via `RegisterNatives` (src/audio/android/jni.rs). The JVM never
+/// checks that contract at build time: a renamed `external fun`, a changed
+/// parameter list, or a moved class fails only at **runtime** on a device.
+/// These tests pin both sides of the contract against the **source text**
+/// (`include_str!` — cfg-independent, so they compile and run on desktop
+/// hosts): each expected name/signature/class must appear verbatim in both
+/// the Kotlin declaration and the Rust registration. Renaming either side
+/// without updating the other (and this table) fails `cargo test --lib`
+/// everywhere.
+///
+/// Packaging note: the Kotlin sources live under `/mobile`, which is
+/// excluded from the crates.io package. That is safe because this module is
+/// `#[cfg(test)]` — the packaged crate never compiles it (`cargo package
+/// --verify` builds, it does not test) — and the guard's job is repo-side
+/// CI, where the files always exist.
+#[cfg(test)]
+mod jni_lockstep {
+    const JNI_RS: &str = include_str!("android/jni.rs");
+    const CAPTURE_BRIDGE_KT: &str =
+        include_str!("../../mobile/android/src/main/kotlin/ai/codeseys/rsac/CaptureBridge.kt");
+    const RSAC_PROJECTION_KT: &str =
+        include_str!("../../mobile/android/src/main/kotlin/ai/codeseys/rsac/RsacProjection.kt");
+
+    /// One registered native: (Kotlin source, `external fun` name, JNI
+    /// signature string registered in jni.rs).
+    const CONTRACT: &[(&str, &str, &str)] = &[
+        (CAPTURE_BRIDGE_KT, "nativePush", "(J[FIII)V"),
+        (CAPTURE_BRIDGE_KT, "nativeSessionEnded", "(J)V"),
+        (
+            RSAC_PROJECTION_KT,
+            "nativeRetainProjection",
+            "(Landroid/media/projection/MediaProjection;)J",
+        ),
+    ];
+
+    #[test]
+    fn every_kotlin_external_fun_is_registered_in_rust() {
+        for (kotlin_src, name, signature) in CONTRACT {
+            assert!(
+                kotlin_src.contains(&format!("external fun {name}(")),
+                "Kotlin side lost `external fun {name}` — update the Rust \
+                 registration (src/audio/android/jni.rs) and this table together"
+            );
+            assert!(
+                JNI_RS.contains(&format!("c\"{name}\"")),
+                "Rust side does not register {name:?} — update \
+                 src/audio/android/jni.rs and this table together"
+            );
+            assert!(
+                JNI_RS.contains(&format!("c\"{signature}\"")),
+                "Rust side does not register the JNI signature {signature:?} \
+                 for {name} — the Kotlin parameter list and the registration \
+                 must move together"
+            );
+        }
+    }
+
+    #[test]
+    fn no_kotlin_external_fun_is_missing_from_the_contract_table() {
+        // Count the `external fun` declarations on the Kotlin side; every
+        // one must be represented in CONTRACT (a new native added in Kotlin
+        // without a Rust registration would otherwise slip through as an
+        // UnsatisfiedLinkError on-device).
+        for (src, file) in [
+            (CAPTURE_BRIDGE_KT, "CaptureBridge.kt"),
+            (RSAC_PROJECTION_KT, "RsacProjection.kt"),
+        ] {
+            let declared = src.matches("external fun ").count();
+            let covered = CONTRACT.iter().filter(|(s, _, _)| *s == src).count();
+            assert_eq!(
+                declared, covered,
+                "{file} declares {declared} `external fun`(s) but the \
+                 lockstep CONTRACT table covers {covered} — extend the table \
+                 and the Rust registration together"
+            );
+        }
+    }
+
+    #[test]
+    fn rust_registers_on_the_kotlin_classes() {
+        // The registration must target the exact binary class names the
+        // Kotlin files define (package ai.codeseys.rsac).
+        for class in [
+            "ai/codeseys/rsac/CaptureBridge",
+            "ai/codeseys/rsac/RsacProjection",
+        ] {
+            assert!(
+                JNI_RS.contains(&format!("c\"{class}\"")),
+                "src/audio/android/jni.rs must resolve {class:?} for \
+                 RegisterNatives"
+            );
+        }
+        for kt in [CAPTURE_BRIDGE_KT, RSAC_PROJECTION_KT] {
+            assert!(
+                kt.contains("package ai.codeseys.rsac"),
+                "the Kotlin sources must stay in the ai.codeseys.rsac package \
+                 the Rust registration resolves"
+            );
+        }
+    }
+
+    #[test]
+    fn frames_per_read_and_uid_sentinel_stay_lockstep() {
+        // Numeric constants that cross the boundary by value: the Kotlin
+        // defaults and the Rust callers must agree.
+        assert!(
+            CAPTURE_BRIDGE_KT.contains("const val DEFAULT_FRAMES_PER_READ: Int = 480"),
+            "Kotlin DEFAULT_FRAMES_PER_READ moved — update playback.rs's \
+             FRAMES_PER_READ and this guard together"
+        );
+        assert!(
+            CAPTURE_BRIDGE_KT.contains("const val NO_UID_FILTER: Int = -1"),
+            "Kotlin NO_UID_FILTER moved — update playback.rs's NO_UID_FILTER \
+             and this guard together"
+        );
+        const PLAYBACK_RS: &str = include_str!("android/playback.rs");
+        assert!(
+            PLAYBACK_RS.contains("const FRAMES_PER_READ: i32 = 480"),
+            "Rust FRAMES_PER_READ moved — keep it lockstep with the Kotlin \
+             default"
+        );
+        assert!(
+            PLAYBACK_RS.contains("const NO_UID_FILTER: i32 = -1"),
+            "Rust NO_UID_FILTER moved — keep it lockstep with the Kotlin \
+             sentinel"
+        );
+    }
+}

--- a/src/audio/windows/thread.rs
+++ b/src/audio/windows/thread.rs
@@ -215,6 +215,16 @@ impl PlatformStream for WindowsPlatformStream {
     fn stop_capture(&self) -> AudioResult<()> {
         // Just set the stop flag — don't join the thread while holding
         // the mutex lock. Drop handles the actual thread join.
+        //
+        // Lifecycle contract: `stop_capture()` is a *signal*, not a *join*. It
+        // returns as soon as the stop flag is set; the capture loop then exits on
+        // its next iteration (bounded by the 100 ms event wait) and the OS thread
+        // is joined only when the last `Arc<Mutex<WindowsCaptureThread>>` is
+        // dropped (see `WindowsCaptureThread::drop`). This keeps `stop()`
+        // non-blocking and, crucially, avoids joining while holding this mutex —
+        // which `is_active()` also locks — so a stop can never deadlock against a
+        // concurrent liveness check. Calling it more than once is harmless: the
+        // flag store is idempotent.
         let thread = self
             .capture_thread
             .lock()
@@ -268,6 +278,19 @@ impl PlatformStream for WindowsPlatformStream {
 ///   device-error exit calls `producer.signal_error()` (terminal `Error`), per
 ///   the ADR-0010 cross-backend terminal contract (rsac-66a6)
 /// - WASAPI/COM objects are dropped via RAII
+///
+/// # Panic containment (rsac-b3a0 / ADR-0010)
+///
+/// The capture loop (everything after init success) runs inside
+/// [`std::panic::catch_unwind`]: a panic anywhere in it is contained and routed
+/// into the FATAL `fatal_error` cleanup path (`signal_error()` → terminal
+/// `Error`), so no unwind can skip the cleanup tail and leave `is_active`
+/// stuck `true` with the bridge in a non-terminal state — which would degrade
+/// a blocked `read_chunk` to an infinite Timeout-retry loop instead of the
+/// contract's fatal `StreamEnded`. A panic *before* init success is already
+/// handled at the `spawn()` level: the init channel drops without a status,
+/// `spawn()` returns `BackendInitializationFailed`, and no stream (hence no
+/// blocked reader) is ever created for this bridge.
 fn wasapi_capture_thread_main(
     config: WindowsCaptureConfig,
     mut producer: BridgeProducer,
@@ -349,12 +372,19 @@ fn wasapi_capture_thread_main(
         // system/device-loopback path keeps autoconvert enabled so WASAPI can
         // resample the endpoint mix format to our requested f32 format.
         //
-        // TODO: When autoconvert is disabled (process loopback), the captured
-        // data is whatever format the loopback endpoint delivers. We currently
-        // request 32-bit float (see `desired_format`), which the process
-        // loopback path accepts; if a future Windows release delivers a
-        // different format here, downstream format handling/resampling will be
-        // needed since we can't query the mix format on a loopback client.
+        // Format invariant (WASAPI-hardening): in BOTH modes the client is
+        // initialized with the explicit 32-bit-float `desired_format` above, and
+        // `IAudioClient::Initialize` FAILS if the client cannot deliver it —
+        // autoconvert resamples to it on the system/device path, and the
+        // process-loopback path accepts f32 directly. So a *successful* init is
+        // the contract that every delivered packet is interleaved f32 with
+        // `channels` samples per frame. We cannot re-query the negotiated format
+        // on a loopback client (`get_mixformat` returns "Not implemented"), so
+        // that init success is the only negotiation signal we have — and the
+        // capture loop additionally validates the per-packet frame invariant via
+        // `bytes_to_f32_frames`, failing loud (throttled diagnostics + partial-
+        // frame drop) rather than silently corrupting channel alignment if a
+        // future Windows release ever delivers a packet that violates it.
         autoconvert: !is_process_loopback,
         buffer_duration_hns: 0, // default buffer duration
     };
@@ -427,45 +457,17 @@ fn wasapi_capture_thread_main(
     let channels = config.channels;
     let sample_rate = config.sample_rate;
 
-    // PU-1/PERF-07 (rsac-2c56): publish the negotiated *delivery* format onto
-    // the bridge so `stream.format()` / `StreamStats.format_description` report
-    // what is actually delivered rather than only what was requested. WASAPI was
-    // opened with the explicit `desired_format` (32-bit float, `sample_rate`,
-    // `channels`): on the system/device-loopback path autoconvert resamples the
-    // endpoint mix format to it, and on the process-loopback path the client
-    // accepts it directly — so in both cases the bridge receives exactly these
-    // `channels`/`sample_rate` as interleaved f32 (the values used by the drain
-    // loop's `push_samples_or_drop`). The bridge normalizes `sample_format` to
-    // F32 internally, so the value passed here is ignored. One-time, off-RT,
-    // lock-free `Release` store on the setup path before the capture loop.
-    producer.set_negotiated_format(&crate::core::config::AudioFormat {
-        sample_rate,
-        channels,
-        sample_format: crate::core::config::SampleFormat::F32,
-    });
-
-    // PU-7 (rsac-7876): bytes per interleaved f32 frame for the negotiated
-    // delivery format. The client is opened with `desired_format` (32-bit float,
-    // `channels`), and both the autoconvert (system/device-loopback) and the
-    // process-loopback paths deliver exactly that — so a frame is `channels`
-    // little-endian f32 samples = `channels * 4` bytes. `channels` is `>= 1`
-    // (validated upstream), so this is non-zero.
-    let bytes_per_frame = channels as usize * std::mem::size_of::<f32>();
-
-    // PU-7: one reusable contiguous byte buffer for the raw WASAPI packet.
-    //
-    // This replaces the previous `VecDeque<u8>` + scalar `from_le_bytes` decode.
-    // `read_from_device` copies a packet's bytes into a `&mut [u8]` in a single
-    // `copy_from_slice` (vs. the deque path's per-byte `push_back`), and because
-    // the destination is already contiguous we drop the O(n) `make_contiguous`
-    // rotation. The bytes are then reinterpreted as `&[f32]` in bulk via
-    // `slice::align_to` (mirroring the Linux/PipeWire path), eliminating the
-    // per-sample scalar loop and the separate `Vec<f32>` staging buffer entirely.
-    //
-    // Pre-sized to ~100ms at 48kHz stereo f32 so steady-state reads never grow
-    // it; a larger packet grows it once (amortized, off the steady-state path).
-    // No allocation happens on the per-packet hot path once warmed.
-    let mut byte_buf: Vec<u8> = Vec::with_capacity(48000 * 4 * 2 / 10);
+    // WASAPI-hardening: throttle the invariant-violation diagnostics so a
+    // pathological stream (a loopback endpoint that starts delivering a format
+    // that violates our interleaved-f32 assumption) cannot flood the log at
+    // audio-callback cadence. We log the FIRST occurrence at `error` unconditionally
+    // (it is always a real problem worth surfacing) and thereafter emit a single
+    // rate-limited summary roughly once per second of wall-clock capture, plus a
+    // final count in the cleanup section. Counted per-thread; no atomics needed
+    // because only this capture thread touches them. Declared OUTSIDE the
+    // panic-guarded closure below so the cleanup tail can report the final
+    // count even if the loop panicked.
+    let mut malformed_packet_count: u64 = 0;
 
     // rsac-66a6 (ADR-0010 cross-backend terminal contract): distinguish a clean
     // stop-flag exit from a FATAL device-error exit. A WASAPI capture-client read
@@ -476,155 +478,283 @@ fn wasapi_capture_thread_main(
     // `Error` state via `signal_error()` (mirroring the Linux `.state_changed`
     // Error/Unconnected path and the macOS spontaneous-death path), instead of the
     // graceful `Stopping` that `signal_done()` produces. A graceful stop-flag exit
-    // leaves this `false` and keeps the `signal_done()` behaviour.
+    // leaves this `false` and keeps the `signal_done()` behaviour. A PANIC caught
+    // by the guard below also lands here as `true` (rsac-b3a0).
     let mut fatal_error = false;
 
-    loop {
-        // Check stop flag before waiting.
-        if stop_flag.load(Ordering::SeqCst) {
-            log::debug!("WASAPI thread: stop flag set, exiting capture loop");
-            break;
-        }
+    // rsac-b3a0 (ADR-0010): contain any unwind out of the capture loop. Without
+    // this, a panic anywhere below would unwind straight past the cleanup tail —
+    // `is_active` would stay `true` and neither `signal_done()` nor
+    // `signal_error()` would ever fire, so a blocked `read_chunk` degrades to an
+    // infinite Timeout-retry instead of the contract's fatal `StreamEnded`.
+    // `AssertUnwindSafe` is sound for the same reason as the bridge's own
+    // `push_samples_guarded`: after a caught panic we immediately poison the
+    // stream to terminal `Error` (via `fatal_error` → `signal_error()`), so a
+    // torn `&mut` capture is moot — nothing pushes afterwards. `catch_unwind`
+    // is near-free on the happy path (no allocation; the closure only borrows
+    // the locals), so the loop's steady-state behavior is unchanged.
+    let loop_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // PU-1/PERF-07 (rsac-2c56): publish the negotiated *delivery* format onto
+        // the bridge so `stream.format()` / `StreamStats.format_description` report
+        // what is actually delivered rather than only what was requested. WASAPI was
+        // opened with the explicit `desired_format` (32-bit float, `sample_rate`,
+        // `channels`): on the system/device-loopback path autoconvert resamples the
+        // endpoint mix format to it, and on the process-loopback path the client
+        // accepts it directly — so in both cases the bridge receives exactly these
+        // `channels`/`sample_rate` as interleaved f32 (the values used by the drain
+        // loop's `push_samples_or_drop`). The bridge normalizes `sample_format` to
+        // F32 internally, so the value passed here is ignored. One-time, off-RT,
+        // lock-free `Release` store on the setup path before the capture loop.
+        producer.set_negotiated_format(&crate::core::config::AudioFormat {
+            sample_rate,
+            channels,
+            sample_format: crate::core::config::SampleFormat::F32,
+        });
 
-        // Wait for audio data event with a short timeout so we can
-        // check the stop flag periodically.
+        // PU-7 (rsac-7876): bytes per interleaved f32 frame for the negotiated
+        // delivery format. The client is opened with `desired_format` (32-bit float,
+        // `channels`), and both the autoconvert (system/device-loopback) and the
+        // process-loopback paths deliver exactly that — so a frame is `channels`
+        // little-endian f32 samples = `channels * 4` bytes. `channels` is `>= 1`
+        // (validated upstream), so this is non-zero.
+        let bytes_per_frame = channels as usize * std::mem::size_of::<f32>();
+
+        let mut last_malformed_log = std::time::Instant::now();
+
+        // PU-7: one reusable contiguous byte buffer for the raw WASAPI packet.
         //
-        // C3 fix: regardless of whether the event fired or the wait timed
-        // out, drain ALL packets currently queued in the capture client.
-        // WASAPI typically has multiple packets ready per event signal;
-        // reading only one packet per event causes the client buffer to grow
-        // unbounded (latency growth) and eventually overrun/underrun. The
-        // drain loop below pulls packets until `get_next_packet_size()`
-        // reports none remaining, then we return to waiting for the next event.
-        if h_event.wait_for_event(100).is_err() {
-            // Timeout or error — check stop flag, then still fall through to
-            // drain any packets that may be queued (timeout doesn't mean
-            // empty), so we don't strand data.
-            if stop_flag.load(Ordering::SeqCst) {
-                log::debug!("WASAPI thread: stop flag set during wait, exiting");
-                break;
-            }
-        }
+        // This replaces the previous `VecDeque<u8>` + scalar `from_le_bytes` decode.
+        // `read_from_device` copies a packet's bytes into a `&mut [u8]` in a single
+        // `copy_from_slice` (vs. the deque path's per-byte `push_back`), and because
+        // the destination is already contiguous we drop the O(n) `make_contiguous`
+        // rotation. The bytes are then reinterpreted as `&[f32]` in bulk via
+        // `slice::align_to` (mirroring the Linux/PipeWire path), eliminating the
+        // per-sample scalar loop and the separate `Vec<f32>` staging buffer entirely.
+        //
+        // Pre-sized to ~100ms at 48kHz stereo f32 so steady-state reads never grow
+        // it; a larger packet grows it once (amortized, off the steady-state path).
+        // No allocation happens on the per-packet hot path once warmed.
+        let mut byte_buf: Vec<u8> = Vec::with_capacity(48000 * 4 * 2 / 10);
 
-        // Drain loop: read every packet currently available, converting each
-        // to f32 and pushing it through the bridge. Remains responsive to the
-        // stop flag so shutdown isn't delayed by a long burst of packets.
         loop {
-            // Stop promptly if requested mid-drain.
+            // Check stop flag before waiting.
             if stop_flag.load(Ordering::SeqCst) {
+                log::debug!("WASAPI thread: stop flag set, exiting capture loop");
                 break;
             }
 
-            // How many frames are in the next packet? 0 (or None) means the
-            // client buffer is drained — go back to waiting for the event.
-            let packet_frames = match capture_client.get_next_packet_size() {
-                Ok(Some(frames)) => frames,
-                Ok(None) => 0,
-                Err(e) => {
-                    // rsac-66a6: a capture-client query failure is treated as
-                    // device loss (fatal). Flag it and break out of the drain
-                    // loop; the outer-loop check below then exits the thread so
-                    // cleanup signals terminal `Error` rather than graceful
-                    // `Stopping`.
-                    log::error!(
+            // Wait for audio data event with a short timeout so we can
+            // check the stop flag periodically.
+            //
+            // C3 fix: regardless of whether the event fired or the wait timed
+            // out, drain ALL packets currently queued in the capture client.
+            // WASAPI typically has multiple packets ready per event signal;
+            // reading only one packet per event causes the client buffer to grow
+            // unbounded (latency growth) and eventually overrun/underrun. The
+            // drain loop below pulls packets until `get_next_packet_size()`
+            // reports none remaining, then we return to waiting for the next event.
+            if h_event.wait_for_event(100).is_err() {
+                // Timeout or error — check stop flag, then still fall through to
+                // drain any packets that may be queued (timeout doesn't mean
+                // empty), so we don't strand data.
+                if stop_flag.load(Ordering::SeqCst) {
+                    log::debug!("WASAPI thread: stop flag set during wait, exiting");
+                    break;
+                }
+            }
+
+            // Drain loop: read every packet currently available, converting each
+            // to f32 and pushing it through the bridge. Remains responsive to the
+            // stop flag so shutdown isn't delayed by a long burst of packets.
+            loop {
+                // Stop promptly if requested mid-drain.
+                if stop_flag.load(Ordering::SeqCst) {
+                    break;
+                }
+
+                // How many frames are in the next packet? 0 (or None) means the
+                // client buffer is drained — go back to waiting for the event.
+                let packet_frames = match capture_client.get_next_packet_size() {
+                    Ok(Some(frames)) => frames,
+                    Ok(None) => 0,
+                    Err(e) => {
+                        // rsac-66a6: a capture-client query failure is treated as
+                        // device loss (fatal). Flag it and break out of the drain
+                        // loop; the outer-loop check below then exits the thread so
+                        // cleanup signals terminal `Error` rather than graceful
+                        // `Stopping`.
+                        log::error!(
                         "WASAPI thread: get_next_packet_size failed (treating as device loss): {}",
                         e
                     );
-                    fatal_error = true;
+                        fatal_error = true;
+                        break;
+                    }
+                };
+                if packet_frames == 0 {
                     break;
                 }
-            };
-            if packet_frames == 0 {
+
+                // PU-7: read this packet's raw bytes into the reused contiguous
+                // buffer. `read_from_device` requires the destination to be large
+                // enough to hold the whole packet (else it errors and releases the
+                // WASAPI buffer), so ensure capacity for the predicted packet size.
+                // `resize` only allocates when a packet exceeds the high-water mark
+                // (off the steady-state path); thereafter it is a no-op length set.
+                let needed = packet_frames as usize * bytes_per_frame;
+                if byte_buf.len() < needed {
+                    byte_buf.resize(needed, 0);
+                }
+
+                // Copy the packet's bytes in a single `copy_from_slice` (inside
+                // wasapi-rs), into a contiguous slice — no per-byte `push_back`, no
+                // `make_contiguous` rotation. `frames_read` is the authoritative
+                // count of frames actually delivered.
+                //
+                // `buffer_info` carries the WASAPI buffer flags (SILENT /
+                // DATA_DISCONTINUITY) we use for diagnostics below.
+                let (frames_read, buffer_info) =
+                    match capture_client.read_from_device(&mut byte_buf[..needed]) {
+                        Ok((frames, info)) => (frames as usize, info),
+                        Err(e) => {
+                            // rsac-66a6: a read failure means the capture endpoint can no
+                            // longer deliver audio (device invalidated / unplugged). Flag
+                            // it as fatal and bail out of the drain loop; the outer-loop
+                            // check below exits the thread so cleanup signals terminal
+                            // `Error` rather than graceful `Stopping`.
+                            log::error!(
+                            "WASAPI thread: read_from_device failed (treating as device loss): {}",
+                            e
+                        );
+                            fatal_error = true;
+                            break;
+                        }
+                    };
+                if frames_read == 0 {
+                    continue;
+                }
+
+                // WASAPI-hardening: log a data-discontinuity flag (a gap in the
+                // captured stream, e.g. the endpoint glitched or a buffer was
+                // dropped by the engine) at `debug`. It is not fatal — audio
+                // continues — but it explains a discontinuity a downstream consumer
+                // might otherwise attribute to rsac. Kept at `debug` so it never
+                // floods a healthy stream's log at `info`+.
+                if buffer_info.flags.data_discontinuity {
+                    log::debug!(
+                        "WASAPI thread: capture reported DATA_DISCONTINUITY at frame index {} \
+                     ({} frames) — a gap in the source stream, not a capture bug",
+                        buffer_info.index,
+                        frames_read
+                    );
+                }
+
+                // The valid region is exactly `frames_read` whole frames. Slicing to
+                // it keeps the conversion exact even if WASAPI delivered fewer frames
+                // than `get_next_packet_size` predicted.
+                let valid = &byte_buf[..frames_read * bytes_per_frame];
+
+                // Reinterpret the F32LE bytes as `&[f32]` in one bulk operation
+                // instead of a per-sample `from_le_bytes` loop, mirroring the
+                // Linux/PipeWire path. WASAPI's GetBuffer region is sample-aligned and
+                // `byte_buf` is a `Vec<u8>` whose data pointer is at least word-
+                // aligned, so `align_to`'s head/tail are normally empty; we consume
+                // the aligned run of whole samples and ignore any unaligned edge.
+                // (`align_to` is used deliberately over `bytemuck::cast_slice`, which
+                // would *panic* on a misaligned slice — see PU-7 blueprint.) On the
+                // little-endian hosts Windows runs on, the in-memory layout equals the
+                // F32LE byte layout, so this reinterpret is a no-op at the bit level.
+                //
+                // SAFETY: every bit pattern is a valid `f32`, and we only read the
+                // `frames_read * bytes_per_frame` bytes that `read_from_device` just
+                // initialized within `valid`.
+                //
+                // WASAPI-hardening: `bytes_to_f32_frames` additionally enforces the
+                // interleaved-f32 delivery contract — the byte run must be a whole
+                // multiple of `bytes_per_frame` (so the sample count is a whole
+                // multiple of `channels`). If a future/edge loopback endpoint ever
+                // delivers a partial frame (the risk called out by the process-
+                // loopback autoconvert TODO), the trailing partial frame is dropped
+                // and the event surfaced via `malformed`, rather than silently
+                // shifting every subsequent sample into the wrong channel.
+                let (samples, malformed) = bytes_to_f32_frames(valid, bytes_per_frame);
+                if malformed {
+                    malformed_packet_count += 1;
+                    // First occurrence is always surfaced; subsequent ones are
+                    // rate-limited to ~1/s so a persistently-wrong stream can't
+                    // flood the log at callback cadence.
+                    if malformed_packet_count == 1
+                        || last_malformed_log.elapsed() >= std::time::Duration::from_secs(1)
+                    {
+                        log::error!(
+                            "WASAPI thread: delivered packet violates the interleaved-f32 \
+                         contract (byte_len={} not a whole multiple of bytes_per_frame={} \
+                         for {} channels); trailing partial frame dropped. \
+                         total malformed packets so far: {}",
+                            valid.len(),
+                            bytes_per_frame,
+                            channels,
+                            malformed_packet_count
+                        );
+                        last_malformed_log = std::time::Instant::now();
+                    }
+                }
+
+                if !samples.is_empty() {
+                    // Push the borrowed sample view directly. The stamped push
+                    // sources its backing buffer from the bridge free-list, so this
+                    // is zero-allocation on the capture thread in steady state — and
+                    // we no longer stage into an intermediate `Vec<f32>` at all.
+                    // `_stamped` additionally tags each buffer with its stream
+                    // position (frames offered / rate; pure integer math), so
+                    // `AudioBuffer::timestamp()` is populated and producer-side
+                    // drops surface as timestamp gaps (rsac-522b / rsac-ec25).
+                    producer.push_samples_or_drop_stamped(samples, channels, sample_rate);
+                    // Wake a consumer parked in a blocking read (PU-5). This is sound
+                    // here even though the producer push path is RT-disciplined: the
+                    // WASAPI capture loop runs on rsac's OWN spawned polling thread
+                    // (NOT an OS audio-callback context), so a Condvar notify is
+                    // allowed (ADR-0001 forbids notify only from the Linux/macOS RT
+                    // callbacks). Without this, a blocking reader only wakes via the
+                    // bounded ≤1ms backstop poll.
+                    producer.notify_consumers();
+                }
+            }
+
+            // rsac-66a6: a fatal capture-client failure during the drain means the
+            // device is gone — exit the capture loop so cleanup signals terminal
+            // `Error`. Checked before the stop flag so a device-loss exit is never
+            // mis-reported as a graceful stop.
+            if fatal_error {
+                log::error!("WASAPI thread: fatal device error, exiting capture loop");
                 break;
             }
 
-            // PU-7: read this packet's raw bytes into the reused contiguous
-            // buffer. `read_from_device` requires the destination to be large
-            // enough to hold the whole packet (else it errors and releases the
-            // WASAPI buffer), so ensure capacity for the predicted packet size.
-            // `resize` only allocates when a packet exceeds the high-water mark
-            // (off the steady-state path); thereafter it is a no-op length set.
-            let needed = packet_frames as usize * bytes_per_frame;
-            if byte_buf.len() < needed {
-                byte_buf.resize(needed, 0);
-            }
-
-            // Copy the packet's bytes in a single `copy_from_slice` (inside
-            // wasapi-rs), into a contiguous slice — no per-byte `push_back`, no
-            // `make_contiguous` rotation. `frames_read` is the authoritative
-            // count of frames actually delivered.
-            let frames_read = match capture_client.read_from_device(&mut byte_buf[..needed]) {
-                Ok((frames, _buffer_info)) => frames as usize,
-                Err(e) => {
-                    // rsac-66a6: a read failure means the capture endpoint can no
-                    // longer deliver audio (device invalidated / unplugged). Flag
-                    // it as fatal and bail out of the drain loop; the outer-loop
-                    // check below exits the thread so cleanup signals terminal
-                    // `Error` rather than graceful `Stopping`.
-                    log::error!(
-                        "WASAPI thread: read_from_device failed (treating as device loss): {}",
-                        e
-                    );
-                    fatal_error = true;
-                    break;
-                }
-            };
-            if frames_read == 0 {
-                continue;
-            }
-
-            // The valid region is exactly `frames_read` whole frames. Slicing to
-            // it keeps the conversion exact even if WASAPI delivered fewer frames
-            // than `get_next_packet_size` predicted.
-            let valid = &byte_buf[..frames_read * bytes_per_frame];
-
-            // Reinterpret the F32LE bytes as `&[f32]` in one bulk operation
-            // instead of a per-sample `from_le_bytes` loop, mirroring the
-            // Linux/PipeWire path. WASAPI's GetBuffer region is sample-aligned and
-            // `byte_buf` is a `Vec<u8>` whose data pointer is at least word-
-            // aligned, so `align_to`'s head/tail are normally empty; we consume
-            // the aligned run of whole samples and ignore any unaligned edge.
-            // (`align_to` is used deliberately over `bytemuck::cast_slice`, which
-            // would *panic* on a misaligned slice — see PU-7 blueprint.) On the
-            // little-endian hosts Windows runs on, the in-memory layout equals the
-            // F32LE byte layout, so this reinterpret is a no-op at the bit level.
-            //
-            // SAFETY: every bit pattern is a valid `f32`, and we only read the
-            // `frames_read * bytes_per_frame` bytes that `read_from_device` just
-            // initialized within `valid`.
-            let samples = bytes_to_f32_aligned(valid);
-
-            if !samples.is_empty() {
-                // Push the borrowed sample view directly. `push_samples_or_drop`
-                // sources its backing buffer from the bridge free-list, so this
-                // is zero-allocation on the capture thread in steady state — and
-                // we no longer stage into an intermediate `Vec<f32>` at all.
-                producer.push_samples_or_drop(samples, channels, sample_rate);
-                // Wake a consumer parked in a blocking read (PU-5). This is sound
-                // here even though the producer push path is RT-disciplined: the
-                // WASAPI capture loop runs on rsac's OWN spawned polling thread
-                // (NOT an OS audio-callback context), so a Condvar notify is
-                // allowed (ADR-0001 forbids notify only from the Linux/macOS RT
-                // callbacks). Without this, a blocking reader only wakes via the
-                // bounded ≤1ms backstop poll.
-                producer.notify_consumers();
+            // Check stop flag after draining.
+            if stop_flag.load(Ordering::SeqCst) {
+                log::debug!("WASAPI thread: stop flag set after read, exiting");
+                break;
             }
         }
+    }));
 
-        // rsac-66a6: a fatal capture-client failure during the drain means the
-        // device is gone — exit the capture loop so cleanup signals terminal
-        // `Error`. Checked before the stop flag so a device-loss exit is never
-        // mis-reported as a graceful stop.
-        if fatal_error {
-            log::error!("WASAPI thread: fatal device error, exiting capture loop");
-            break;
-        }
-
-        // Check stop flag after draining.
-        if stop_flag.load(Ordering::SeqCst) {
-            log::debug!("WASAPI thread: stop flag set after read, exiting");
-            break;
-        }
+    // rsac-b3a0: route a caught capture-loop panic into the existing FATAL
+    // cleanup tail. The panic is contained above (it never unwinds past this
+    // function), and the terminal `signal_error()` below guarantees a blocked
+    // reader observes the fatal `StreamEnded` instead of retrying a dead
+    // stream forever (ADR-0010: no exit path leaves the bridge non-terminal).
+    if let Err(payload) = loop_result {
+        let msg = payload
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+            .unwrap_or("<non-string panic payload>");
+        log::error!(
+            "WASAPI thread: capture loop panicked ({}); containing the unwind \
+             and signalling terminal Error (rsac-b3a0 / ADR-0010)",
+            msg
+        );
+        fatal_error = true;
     }
 
     // ── Cleanup ──────────────────────────────────────────────────────
@@ -634,6 +764,16 @@ fn wasapi_capture_thread_main(
 
     let _ = audio_client.stop_stream();
     is_active.store(false, Ordering::SeqCst);
+    // WASAPI-hardening: if any delivered packet violated the interleaved-f32
+    // contract during this session, surface the total once at exit so the
+    // (rate-limited) per-packet errors have an authoritative final count.
+    if malformed_packet_count > 0 {
+        log::error!(
+            "WASAPI thread: {} packet(s) violated the interleaved-f32 delivery contract \
+             during this capture session (trailing partial frames were dropped)",
+            malformed_packet_count
+        );
+    }
     // rsac-66a6 (ADR-0010): a FATAL device-error exit must drive the bridge to the
     // terminal `Error` state (`signal_error`) so a parked Linux/blocking reader
     // observes a Fatal `StreamEnded` instead of an indefinitely-draining graceful
@@ -648,7 +788,7 @@ fn wasapi_capture_thread_main(
     }
     wasapi::deinitialize();
     if fatal_error {
-        log::debug!("WASAPI thread: exited after fatal device error");
+        log::debug!("WASAPI thread: exited after fatal error (device loss or contained panic)");
     } else {
         log::debug!("WASAPI thread: exited cleanly");
     }
@@ -935,6 +1075,49 @@ fn bytes_to_f32_aligned(bytes: &[u8]) -> &[f32] {
     samples
 }
 
+/// Reinterpret a run of F32LE capture bytes as interleaved `&[f32]` samples,
+/// enforcing the interleaved-f32 delivery contract (WASAPI-hardening).
+///
+/// This wraps [`bytes_to_f32_aligned`] with the *frame*-level invariant the raw
+/// alignment check does not cover: the delivered byte run must be a whole
+/// multiple of `bytes_per_frame` (i.e. the reinterpreted sample count must be a
+/// whole multiple of the channel count). rsac opens every WASAPI client — both
+/// the autoconvert system/device-loopback path and the process-loopback path —
+/// with an explicit 32-bit-float `desired_format`, and wasapi-rs sizes each
+/// packet by that same format, so in the normal case this is always satisfied.
+///
+/// The check exists to *fail loud, not silently corrupt* if that assumption is
+/// ever violated (the process-loopback autoconvert edge called out in the
+/// capture-loop TODO, or a future Windows delivery quirk). A partial trailing
+/// frame — bytes that don't complete a whole `channels`-wide frame — would, if
+/// naively reinterpreted, shift every subsequent sample into the wrong channel
+/// and permanently desync the stereo image. Instead we truncate to the last
+/// whole frame and report `malformed = true` so the caller can surface a
+/// throttled diagnostic.
+///
+/// Returns `(samples, malformed)`:
+/// - `samples`: the aligned, whole-frame run of interleaved f32 (possibly
+///   truncated to drop a partial trailing frame).
+/// - `malformed`: `true` iff the input byte length was not a whole multiple of
+///   `bytes_per_frame` (a contract violation worth logging).
+///
+/// `bytes_per_frame` must be non-zero (guaranteed by the caller: `channels >= 1`
+/// times 4 bytes/sample).
+///
+/// SAFETY of the caller: same as [`bytes_to_f32_aligned`] — `bytes` must be the
+/// initialized region `read_from_device` just wrote.
+#[inline]
+fn bytes_to_f32_frames(bytes: &[u8], bytes_per_frame: usize) -> (&[f32], bool) {
+    debug_assert!(bytes_per_frame != 0, "bytes_per_frame must be non-zero");
+    // Truncate to the last whole frame so a partial trailing frame can never
+    // shift channel alignment. In the normal case `remainder == 0` and this is
+    // a no-op slice.
+    let remainder = bytes.len() % bytes_per_frame;
+    let malformed = remainder != 0;
+    let whole = &bytes[..bytes.len() - remainder];
+    (bytes_to_f32_aligned(whole), malformed)
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────
 //
 // These tests are automatically Windows-only because this file has
@@ -974,6 +1157,88 @@ mod tests {
     #[test]
     fn bytes_to_f32_aligned_empty_is_empty() {
         assert!(bytes_to_f32_aligned(&[]).is_empty());
+    }
+
+    // ── bytes_to_f32_frames: interleaved-f32 invariant (WASAPI-hardening) ──
+
+    /// A byte run that is an exact multiple of `bytes_per_frame` is well-formed:
+    /// all whole frames are returned and `malformed` is false.
+    #[test]
+    fn bytes_to_f32_frames_whole_frames_not_malformed() {
+        // 2ch stereo → 8 bytes/frame. 3 whole frames = 6 f32 samples.
+        let bytes_per_frame = 2 * std::mem::size_of::<f32>();
+        let samples_in: [f32; 6] = [1.0, -1.0, 0.5, -0.5, 0.25, -0.25];
+        let mut bytes = Vec::new();
+        for s in samples_in {
+            bytes.extend_from_slice(&s.to_le_bytes());
+        }
+        let (out, malformed) = bytes_to_f32_frames(&bytes, bytes_per_frame);
+        assert!(!malformed, "a whole-frame byte run must not be malformed");
+        assert_eq!(out, &samples_in);
+        assert_eq!(
+            out.len() % 2,
+            0,
+            "sample count must stay a whole multiple of channels"
+        );
+    }
+
+    /// A byte run with a trailing partial frame is flagged malformed AND the
+    /// partial frame is dropped, so the returned sample count stays a whole
+    /// multiple of the channel count (never shifts channel alignment).
+    #[test]
+    fn bytes_to_f32_frames_partial_frame_is_dropped_and_flagged() {
+        // 2ch stereo → 8 bytes/frame. Provide 2 whole frames (16 bytes) + a
+        // partial third frame (4 bytes = 1 sample, half a stereo frame).
+        let bytes_per_frame = 2 * std::mem::size_of::<f32>();
+        let whole: [f32; 4] = [1.0, 2.0, 3.0, 4.0];
+        let mut bytes = Vec::new();
+        for s in whole {
+            bytes.extend_from_slice(&s.to_le_bytes());
+        }
+        // Append a single dangling sample (partial stereo frame).
+        bytes.extend_from_slice(&9.0f32.to_le_bytes());
+
+        let (out, malformed) = bytes_to_f32_frames(&bytes, bytes_per_frame);
+        assert!(
+            malformed,
+            "a trailing partial frame must be reported as malformed"
+        );
+        assert_eq!(
+            out, &whole,
+            "the partial trailing frame must be dropped, keeping whole frames only"
+        );
+        assert_eq!(
+            out.len() % 2,
+            0,
+            "after dropping the partial frame the sample count is frame-aligned"
+        );
+    }
+
+    /// Mono (1ch → 4 bytes/frame): every 4-byte sample is a whole frame, so a
+    /// clean f32 run is never malformed.
+    #[test]
+    fn bytes_to_f32_frames_mono_is_frame_aligned() {
+        let bytes_per_frame = std::mem::size_of::<f32>(); // 1 channel
+        let samples_in: [f32; 5] = [0.0, 0.1, 0.2, 0.3, 0.4];
+        let mut bytes = Vec::new();
+        for s in samples_in {
+            bytes.extend_from_slice(&s.to_le_bytes());
+        }
+        let (out, malformed) = bytes_to_f32_frames(&bytes, bytes_per_frame);
+        assert!(!malformed);
+        assert_eq!(out, &samples_in);
+    }
+
+    /// An empty input is well-formed (0 is a multiple of any frame size) and
+    /// yields no samples — the silent-packet / drained-buffer case.
+    #[test]
+    fn bytes_to_f32_frames_empty_is_wellformed_empty() {
+        let (out, malformed) = bytes_to_f32_frames(&[], 8);
+        assert!(
+            !malformed,
+            "an empty run is a whole (zero) number of frames"
+        );
+        assert!(out.is_empty());
     }
 
     // ── WindowsCaptureConfig Construction Tests ──────────────────────
@@ -1165,6 +1430,53 @@ mod tests {
             consumer.shared().state.get(),
             StreamState::Error,
             "a clean stop must never be mis-reported as terminal Error"
+        );
+    }
+
+    /// rsac-b3a0: a panic inside the capture loop is contained by the
+    /// `catch_unwind` wrapper and routed into the FATAL cleanup branch. This
+    /// pins the exact wiring `wasapi_capture_thread_main` uses — closure
+    /// panics → `loop_result.is_err()` → `fatal_error = true` →
+    /// `signal_error()` — against the bridge, proving no panic exit path can
+    /// leave the bridge non-terminal (a blocked reader must observe the fatal
+    /// `StreamEnded`, not an infinite Timeout-retry). The real thread main
+    /// needs a live WASAPI device to drive, so like the rsac-66a6 tests above
+    /// this exercises the contract at the producer/bridge level.
+    #[test]
+    fn test_capture_loop_panic_is_contained_and_lands_terminal_error() {
+        let (producer, consumer) = create_bridge(8, terminal_test_format());
+        producer.shared().state.force_set(StreamState::Running);
+
+        let mut fatal_error = false;
+
+        // Mirror the thread main's guard: the loop body panics mid-iteration.
+        let loop_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            panic!("simulated WASAPI capture-loop panic");
+        }));
+        assert!(
+            loop_result.is_err(),
+            "the guard must contain the panic (no unwind past the wrapper)"
+        );
+        if loop_result.is_err() {
+            fatal_error = true;
+        }
+
+        // Mirror the cleanup tail's branch.
+        if fatal_error {
+            producer.signal_error();
+        } else {
+            producer.signal_done();
+        }
+
+        assert_eq!(
+            consumer.shared().state.get(),
+            StreamState::Error,
+            "a contained capture-loop panic must land the bridge in terminal Error"
+        );
+        assert!(
+            consumer.shared().state.is_terminal(),
+            "Error is terminal — a blocked read_chunk gets the fatal StreamEnded, \
+             not an infinite Timeout-retry (ADR-0010)"
         );
     }
 

--- a/src/audio/windows/wasapi.rs
+++ b/src/audio/windows/wasapi.rs
@@ -357,9 +357,18 @@ impl WindowsApplicationCapture {
     }
 }
 
-// Unsafe Send implementations for Windows COM types
-// These are safe because we ensure COM is properly initialized and the types
-// are only used within the same thread context
+// SAFETY: `WindowsApplicationCapture` wraps a `wasapi::AudioClient`, which holds
+// COM interfaces the `windows`/`wasapi` crates conservatively mark `!Send`. rsac
+// only ever constructs and initializes this client after `initialize_mta()`
+// (see `initialize()`), i.e. in a Multi-Threaded Apartment where COM objects are
+// free-threaded and may legally be used from any thread. That MTA guarantee is
+// what makes moving the handle across threads sound — NOT "single-threaded use"
+// (which would contradict `Send`). This mirrors the identical MTA rationale on
+// `WindowsAudioDevice` / `WindowsDeviceEnumerator` below.
+//
+// NOTE: this type is legacy/RT-unsafe (see the type-level `audit L13` docs); the
+// canonical capture path is `WindowsCaptureThread`, whose WASAPI objects never
+// leave their own dedicated thread and so need no such assertion.
 unsafe impl Send for WindowsApplicationCapture {}
 
 // Note: Cannot implement Send for external COM types due to orphan rules

--- a/src/bridge/mock.rs
+++ b/src/bridge/mock.rs
@@ -30,7 +30,6 @@ use std::time::Duration;
 use crate::bridge::ring_buffer::create_bridge;
 use crate::bridge::state::StreamState;
 use crate::bridge::stream::{BridgeStream, PlatformStream};
-use crate::core::buffer::AudioBuffer;
 use crate::core::config::{AudioFormat, DeviceId, SampleFormat, StreamConfig};
 use crate::core::error::{AudioError, AudioResult};
 use crate::core::interface::{AudioDevice, CapturingStream, DeviceEnumerator};
@@ -193,8 +192,15 @@ impl AudioDevice for MockAudioDevice {
                         frames_per_buffer,
                         &mut phase,
                     );
-                    let buffer = AudioBuffer::new(data, channels, sample_rate);
-                    producer.push_or_drop(buffer);
+                    // rsac-0940: push STAMPED, exactly like the real backends
+                    // (WASAPI/PipeWire/CoreAudio all use the `_stamped`
+                    // variants), so mock streams deliver
+                    // `AudioBuffer::timestamp() == Some(..)` with the same
+                    // stream-position semantics as production capture. The
+                    // producer's internal nanosecond accumulator tracks the
+                    // cumulative frames across pushes (and leaves gaps for
+                    // drops), so no extra bookkeeping is needed here.
+                    producer.push_samples_or_drop_stamped(&data, channels, sample_rate);
                     std::thread::sleep(buffer_duration);
                 }
 
@@ -324,6 +330,7 @@ mod tests {
         assert_eq!(stream.format().channels, 2);
 
         // Read a few buffers
+        let mut last_ts: Option<Duration> = None;
         for _ in 0..3 {
             let buffer = stream.read_chunk().unwrap();
             assert_eq!(buffer.channels(), 2);
@@ -334,6 +341,19 @@ mod tests {
                 "Mock stream should deliver non-silent audio (rms={})",
                 rms
             );
+            // rsac-0940: the mock pushes STAMPED like the real backends, so
+            // every delivered buffer carries a non-decreasing stream-position
+            // timestamp (Some, never the unstamped None of the old mock).
+            let ts = buffer
+                .timestamp()
+                .expect("mock stream must deliver stamped buffers like real backends");
+            if let Some(prev) = last_ts {
+                assert!(
+                    ts >= prev,
+                    "mock timestamps must be non-decreasing (prev={prev:?}, got={ts:?})"
+                );
+            }
+            last_ts = Some(ts);
         }
 
         // Stop

--- a/src/bridge/mock.rs
+++ b/src/bridge/mock.rs
@@ -288,6 +288,10 @@ pub fn create_mock_stream(
         sample_format: SampleFormat::F32,
         buffer_size: None,
         capture_target: crate::core::config::CaptureTarget::SystemDefault,
+        #[cfg(target_os = "ios")]
+        ios_app_group: None,
+        #[cfg(target_os = "android")]
+        android_projection: None,
     };
     device.create_stream(&config)
 }

--- a/src/bridge/ring_buffer.rs
+++ b/src/bridge/ring_buffer.rs
@@ -87,6 +87,30 @@ fn unpack_window(packed: u64) -> (u32, u32) {
     ((packed >> 32) as u32, (packed & 0xFFFF_FFFF) as u32)
 }
 
+/// Convert a frame count at `sample_rate` to nanoseconds of stream time
+/// (`rsac-1b8c`).
+///
+/// Pure integer math — no float, no clock syscall, no allocation — so it is
+/// safe on the real-time producer path (ADR-0001). The intermediate product is
+/// computed in `u128` so `frames * 1_000_000_000` cannot overflow, and the
+/// result is saturated into `u64`: at nanosecond resolution a `u64` covers
+/// ~584 years of stream time, so saturation is a theoretical guard, never a
+/// practical limit. A `sample_rate` of `0` is clamped to `1` (degenerate input
+/// guard; matches the stamped-push family's historical behavior).
+///
+/// Note the per-call flooring: each call floors `frames * 1e9 / rate`
+/// independently, so an accumulator built from these values can drift below
+/// the exact rational position by at most 1 ns *per push* for rates that do
+/// not divide the frame count evenly (e.g. 44.1 kHz with odd frame counts).
+/// That bounded sub-nanosecond-per-buffer drift is the price of making the
+/// position rate-change-proof (see [`BridgeProducer::position_nanos`]).
+#[inline]
+fn frames_to_nanos(frames: u64, sample_rate: u32) -> u64 {
+    let rate = u128::from(sample_rate.max(1));
+    let nanos = (u128::from(frames) * 1_000_000_000) / rate;
+    u64::try_from(nanos).unwrap_or(u64::MAX)
+}
+
 /// Outcome of a single [`BridgeProducer::push_samples_reporting`] call.
 ///
 /// Surfaces overflow **eagerly**, in the callback, without polling the shared
@@ -590,6 +614,33 @@ pub struct BridgeProducer {
     /// momentarily empty (e.g. during warm-up before the consumer has recycled
     /// anything, or under sustained back-pressure when a push is rejected).
     scratch: Vec<f32>,
+    /// Cumulative **stream position in nanoseconds** of all audio offered to
+    /// the ring (pushed *or* dropped) by this producer's samples- and
+    /// buffer-push methods (`rsac-1b8c`).
+    ///
+    /// This replaces the former cumulative *frame* counter. Storing the
+    /// position in time units makes it **rate-renegotiation-proof**: a
+    /// mid-stream sample-rate change (e.g. PipeWire `param_changed` updating
+    /// the delivered rate live) only changes how fast *future* pushes advance
+    /// the position — already-issued timestamps never retroactively rescale
+    /// (a frame counter divided by the *new* rate would shift the entire past
+    /// timeline, e.g. a spurious ~884 ms jump for 48 k→44.1 k at 10 s).
+    ///
+    /// Advanced centrally in [`push_samples_or_drop_inner`] by
+    /// `frames * 1e9 / rate` (saturating integer math — see
+    /// [`frames_to_nanos`]; the u64 nanosecond horizon is ~584 years), so
+    /// **every** offered samples-push advances it regardless of variant —
+    /// mixing stamped and unstamped pushes on one producer keeps a single
+    /// contiguous timeline. The `AudioBuffer`-based [`push`]/[`push_or_drop`]
+    /// also advance it (see their docs). Counting dropped frames too means a
+    /// producer-side drop shows up as a *gap* between consecutive delivered
+    /// timestamps instead of being papered over. Plain `u64` (no atomic) —
+    /// the producer is single-threaded by contract.
+    ///
+    /// [`push_samples_or_drop_inner`]: Self::push_samples_or_drop_inner
+    /// [`push`]: Self::push
+    /// [`push_or_drop`]: Self::push_or_drop
+    position_nanos: u64,
 }
 
 // BridgeProducer is Send (can be moved to the callback thread) but not necessarily Sync.
@@ -604,9 +655,32 @@ impl BridgeProducer {
     /// the caller decides what to do with the rejected buffer.
     ///
     /// Increments `buffers_pushed` on success.
+    ///
+    /// # Stream-position interaction (`rsac-1b8c`)
+    ///
+    /// On **success** this advances the producer's internal stream position by
+    /// the buffer's frame count at the buffer's own sample rate, so mixing
+    /// `AudioBuffer` pushes with the `push_samples_*` family on one producer
+    /// yields a single contiguous timeline. It does **not** advance on
+    /// `Err(buffer)` — the buffer is handed back unconsumed, and a later retry
+    /// of the same buffer must not double-count its frames. (If the caller
+    /// drops a rejected buffer themselves, that gap is not recorded; use
+    /// [`push_or_drop`](Self::push_or_drop) for drop-with-gap semantics.) Any
+    /// timestamp already carried by the buffer is preserved as-is; the
+    /// position advance only keeps the internal counter coherent for
+    /// subsequent `_stamped` pushes.
     pub fn push(&mut self, buffer: AudioBuffer) -> Result<(), AudioBuffer> {
+        // Capture the advance inputs before the buffer is moved into the ring.
+        let frames = buffer.num_frames() as u64;
+        let rate = buffer.sample_rate();
         match self.producer.push(buffer) {
             Ok(()) => {
+                // rsac-1b8c: consumed audio advances the stream position (see
+                // the method docs — success only; a rejected buffer may be
+                // retried).
+                self.position_nanos = self
+                    .position_nanos
+                    .saturating_add(frames_to_nanos(frames, rate));
                 self.shared.buffers_pushed.fetch_add(1, Ordering::Relaxed);
                 self.shared.consecutive_drops.store(0, Ordering::Relaxed);
                 // Record a successful attempt in the sliding drop-rate window
@@ -629,10 +703,26 @@ impl BridgeProducer {
     ///
     /// This is the primary method used by audio callbacks — it never blocks
     /// and silently drops data when the consumer can't keep up.
+    ///
+    /// # Stream-position interaction (`rsac-1b8c`)
+    ///
+    /// Advances the producer's internal stream position by the buffer's frame
+    /// count **whether the push succeeds or drops** (the success arm advances
+    /// inside [`push`](Self::push); the drop arm advances here), so a drop
+    /// surfaces as a *gap* in the timeline seen by subsequent `_stamped`
+    /// pushes — same gap semantics as the `push_samples_*` family.
     pub fn push_or_drop(&mut self, buffer: AudioBuffer) -> bool {
         match self.push(buffer) {
             Ok(()) => true,
-            Err(_dropped) => {
+            Err(dropped) => {
+                // rsac-1b8c: the buffer is dropped here for good (gap
+                // semantics) — advance the stream position by its frames so
+                // the loss stays visible as a timestamp gap.
+                let frames = dropped.num_frames() as u64;
+                let rate = dropped.sample_rate();
+                self.position_nanos = self
+                    .position_nanos
+                    .saturating_add(frames_to_nanos(frames, rate));
                 self.shared.buffers_dropped.fetch_add(1, Ordering::Relaxed);
                 self.shared
                     .consecutive_drops
@@ -670,9 +760,19 @@ impl BridgeProducer {
     /// this instead of manually calling `data.to_vec()` + `AudioBuffer::new()` +
     /// `push_or_drop()`.
     ///
-    /// Delegates to [`push_samples_or_drop_at`](Self::push_samples_or_drop_at)
-    /// with no timestamp; see that method for the variant that stamps each
-    /// buffer with a stream-relative position.
+    /// # Stream-position interaction (`rsac-1b8c`)
+    ///
+    /// Although the delivered buffer carries **no timestamp**, this push still
+    /// advances the producer's internal stream position by its frame count
+    /// (the advance is centralized in the shared inner path, so *every*
+    /// offered samples-push counts). Mixing untimed and `_stamped` pushes on
+    /// one producer therefore yields one contiguous, non-overlapping timeline
+    /// — an untimed push consumes stream time even though it does not report
+    /// it.
+    ///
+    /// Delegates to the shared inner path with no timestamp; see
+    /// [`push_samples_or_drop_at`](Self::push_samples_or_drop_at) for the
+    /// variant that stamps each buffer with a caller-supplied position.
     #[inline]
     pub fn push_samples_or_drop(&mut self, data: &[f32], channels: u16, sample_rate: u32) -> bool {
         self.push_samples_or_drop_inner(data, channels, sample_rate, None)
@@ -691,6 +791,16 @@ impl BridgeProducer {
     ///
     /// Shares the exact same alloc-free free-list/scratch path as the untimed
     /// variant: in steady state it performs **no heap allocation**.
+    ///
+    /// # Stream-position interaction (`rsac-1b8c`)
+    ///
+    /// The caller-supplied `timestamp` is delivered as-is, but this push
+    /// **also** advances the producer's internal stream position by its frame
+    /// count (centralized in the shared inner path). So a later switch to the
+    /// counter-driven
+    /// [`push_samples_or_drop_stamped`](Self::push_samples_or_drop_stamped)
+    /// continues from a position that accounts for everything pushed through
+    /// this variant too.
     #[inline]
     pub fn push_samples_or_drop_at(
         &mut self,
@@ -702,13 +812,88 @@ impl BridgeProducer {
         self.push_samples_or_drop_inner(data, channels, sample_rate, Some(timestamp))
     }
 
+    /// Like [`push_samples_or_drop`](Self::push_samples_or_drop), but stamps the
+    /// buffer with a **stream-position timestamp derived from the nanosecond
+    /// position accumulator** — no clock syscall, pure integer math, so it is
+    /// exactly as RT-safe as the untimed variant (ADR-0001 preserved).
+    ///
+    /// The stamp is the position of this buffer's **first sample** relative to
+    /// stream start, read from `position_nanos` before
+    /// the push advances it. The position advances by this call's frames
+    /// (`frames * 1e9 / rate`, saturating — see `frames_to_nanos`) **whether
+    /// or not the push succeeds**, so a producer-side drop appears to the
+    /// consumer as a *gap* between consecutive buffer timestamps
+    /// (`t₂ − t₁ > frames₁/rate`) instead of a silently contiguous timeline —
+    /// making drop-induced discontinuities measurable downstream.
+    ///
+    /// # Rate renegotiation (`rsac-1b8c`)
+    ///
+    /// Because the accumulator stores elapsed **time**, not frames, a
+    /// mid-stream `sample_rate` change (e.g. PipeWire `param_changed` updating
+    /// the delivered rate live) is seamless: stamps issued before the change
+    /// are untouched, and deltas after it simply use the new rate. (The former
+    /// frame-counter design divided the *cumulative* frame count by the
+    /// *current* rate, retroactively rescaling the entire past timeline.)
+    ///
+    /// Semantics note: this is *stream position* (frames delivered by the OS),
+    /// not wall-clock time — periods where the OS delivers nothing (e.g. a
+    /// silent process-loopback session) do not advance it. A future upgrade to
+    /// per-backend device clocks (WASAPI `GetPosition`, PipeWire `pw_time`,
+    /// CoreAudio `mSampleTime`) is tracked in `rsac-ec25`; it would refine
+    /// these values, not change the API.
+    ///
+    /// This is the production push for backends that opt into timestamping on
+    /// their own (Rust-owned) capture threads; foreign C-callback boundaries
+    /// use [`push_samples_guarded_stamped`](Self::push_samples_guarded_stamped).
+    #[inline]
+    pub fn push_samples_or_drop_stamped(
+        &mut self,
+        data: &[f32],
+        channels: u16,
+        sample_rate: u32,
+    ) -> bool {
+        // Stamp = the position of this buffer's FIRST sample: read the
+        // accumulator BEFORE the inner push advances it (the advance itself is
+        // centralized in push_samples_or_drop_inner — rsac-1b8c).
+        let position = Duration::from_nanos(self.position_nanos);
+        self.push_samples_or_drop_inner(data, channels, sample_rate, Some(position))
+    }
+
+    /// Panic-guarded sibling of
+    /// [`push_samples_or_drop_stamped`](Self::push_samples_or_drop_stamped) for
+    /// the **foreign C-callback** boundaries (PipeWire `.process`, CoreAudio
+    /// IOProc) — same unwind containment as
+    /// [`push_samples_guarded`](Self::push_samples_guarded), same
+    /// stream-position stamping, same alloc-free happy path.
+    pub fn push_samples_guarded_stamped(
+        &mut self,
+        data: &[f32],
+        channels: u16,
+        sample_rate: u32,
+    ) -> bool {
+        // See push_samples_guarded for the AssertUnwindSafe rationale: a caught
+        // panic poisons the stream to Error, so a torn `&mut self` is moot.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.push_samples_or_drop_stamped(data, channels, sample_rate)
+        }));
+        match result {
+            Ok(pushed) => pushed,
+            Err(_payload) => {
+                self.on_push_panic();
+                false
+            }
+        }
+    }
+
     /// Like [`push_samples_or_drop`](Self::push_samples_or_drop), but reports the
     /// per-call overflow outcome **synchronously** (`rsac-0d25`).
     ///
     /// Returns a [`PushOutcome`] giving `pushed` and `dropped_this_call` without
     /// the caller having to poll the shared `buffers_dropped` counter — so a
     /// backend can compute a per-period drop rate cheaply, right in the callback.
-    /// Same alloc-free, lock-free path as [`push_samples_or_drop`](Self::push_samples_or_drop).
+    /// Same alloc-free, lock-free path as [`push_samples_or_drop`](Self::push_samples_or_drop),
+    /// including the stream-position advance (`rsac-1b8c` — the buffer is
+    /// untimed, but its frames still consume stream time).
     #[inline]
     pub fn push_samples_reporting(
         &mut self,
@@ -730,6 +915,18 @@ impl BridgeProducer {
     /// [`AudioBuffer::with_timestamp`]; otherwise with [`AudioBuffer::new`]. Both
     /// paths reuse the identical free-list/scratch logic, so the RT-allocation
     /// guarantee (ADR-0001) is unchanged for the timestamped variant.
+    ///
+    /// # Stream-position advance (`rsac-1b8c`)
+    ///
+    /// This is the **single** place the samples-push family advances
+    /// [`position_nanos`](Self::position_nanos): every offered push — stamped
+    /// or not, pushed or dropped — advances the position by its frame count,
+    /// so mixed stamped/unstamped usage can never silently desync the
+    /// timeline. The advance happens FIRST, before any fallible work, so even
+    /// a panic contained by the guarded wrappers (which account the buffer as
+    /// dropped via `on_push_panic`) leaves the position advanced — the
+    /// panic-drop shows up as a gap, consistent with an ordinary overflow
+    /// drop.
     fn push_samples_or_drop_inner(
         &mut self,
         data: &[f32],
@@ -737,6 +934,13 @@ impl BridgeProducer {
         sample_rate: u32,
         timestamp: Option<Duration>,
     ) -> bool {
+        // rsac-1b8c: advance the stream position for EVERY offered push (see
+        // the doc above). Integer math + saturating add — RT-safe (ADR-0001).
+        let frames = (data.len() / usize::from(channels.max(1))) as u64;
+        self.position_nanos = self
+            .position_nanos
+            .saturating_add(frames_to_nanos(frames, sample_rate));
+
         // Acquire a reusable Vec: prefer a recycled allocation from the
         // free-list ring, otherwise fall back to the single-slot scratch.
         // `used_scratch` records whether we consumed the scratch slot, so the
@@ -1579,6 +1783,7 @@ pub fn create_bridge_with_options(
             // Single-slot fallback for when the free-list ring is momentarily
             // empty. Pre-sized for a realistic worst-case callback period.
             scratch: Vec::with_capacity(RT_BUFFER_SAMPLE_CAPACITY),
+            position_nanos: 0,
         },
         BridgeConsumer {
             consumer,
@@ -2202,6 +2407,205 @@ mod tests {
             producer.recycled_available(),
             1,
             "pop should recycle one allocation back to the producer"
+        );
+    }
+
+    // rsac-ec25 wiring: the stamped push variants tag each buffer with its
+    // stream position (frames offered / rate), and dropped frames appear as a
+    // GAP between consecutive delivered timestamps rather than a contiguous
+    // timeline.
+    #[test]
+    fn stamped_push_carries_stream_position_and_drops_leave_gaps() {
+        let (mut producer, mut consumer) = create_bridge(4, test_format());
+
+        // Two clean pushes of 480 stereo frames @ 48 kHz → positions 0 and 10 ms.
+        assert!(producer.push_samples_or_drop_stamped(&[0.0; 960], 2, 48_000));
+        assert!(producer.push_samples_or_drop_stamped(&[0.0; 960], 2, 48_000));
+        let b1 = consumer.pop().expect("first buffer");
+        let b2 = consumer.pop().expect("second buffer");
+        assert_eq!(b1.timestamp(), Some(Duration::ZERO));
+        assert_eq!(b2.timestamp(), Some(Duration::from_millis(10)));
+
+        // Fill the ring until a push is dropped; the counter must still
+        // advance for the dropped frames.
+        let mut successful = 2u64;
+        loop {
+            if producer.push_samples_or_drop_stamped(&[0.0; 960], 2, 48_000) {
+                successful += 1;
+                assert!(successful < 64, "ring never filled — capacity change?");
+            } else {
+                break; // exactly one dropped push
+            }
+        }
+
+        // Drain everything delivered so far, then push once more: its stamp
+        // must account for ALL offered frames (successful + the dropped one) —
+        // i.e. the timeline shows a 10 ms hole where the drop happened.
+        while consumer.pop().is_some() {}
+        assert!(producer.push_samples_or_drop_stamped(&[0.0; 960], 2, 48_000));
+        let after = consumer.pop().expect("post-drop buffer");
+        let expected_frames = (successful + 1) * 480; // + the dropped push
+        let expected = Duration::from_nanos(expected_frames * 1_000_000_000 / 48_000);
+        assert_eq!(
+            after.timestamp(),
+            Some(expected),
+            "post-drop stamp must include the dropped frames as a gap"
+        );
+
+        // The guarded sibling shares the same counter/timeline.
+        assert!(producer.push_samples_guarded_stamped(&[0.0; 960], 2, 48_000));
+        let guarded = consumer.pop().expect("guarded buffer");
+        let expected2 = Duration::from_nanos((expected_frames + 480) * 1_000_000_000 / 48_000);
+        assert_eq!(guarded.timestamp(), Some(expected2));
+
+        // The untimed variant still leaves the timestamp empty (rsac-522b's
+        // two-variant contract is unchanged).
+        assert!(producer.push_samples_or_drop(&[0.0; 960], 2, 48_000));
+        assert_eq!(consumer.pop().expect("untimed buffer").timestamp(), None);
+    }
+
+    // rsac-1b8c: the stamp accumulator stores NANOSECONDS, not frames, so a
+    // mid-stream sample-rate renegotiation (e.g. PipeWire `param_changed`
+    // updating the delivered rate live) never retroactively rescales the past
+    // timeline: stamps issued before the change are unchanged, and post-change
+    // deltas use the new rate.
+    #[test]
+    fn stamped_push_survives_rate_renegotiation() {
+        let (mut producer, mut consumer) = create_bridge(8, test_format());
+
+        // Two 480-frame stereo pushes @ 48 kHz → stamps 0 ms and 10 ms.
+        assert!(producer.push_samples_or_drop_stamped(&[0.0; 960], 2, 48_000));
+        assert!(producer.push_samples_or_drop_stamped(&[0.0; 960], 2, 48_000));
+
+        // RATE CHANGE mid-stream: two 441-frame stereo pushes @ 44.1 kHz
+        // (10 ms each at the new rate).
+        assert!(producer.push_samples_or_drop_stamped(&[0.0; 882], 2, 44_100));
+        assert!(producer.push_samples_or_drop_stamped(&[0.0; 882], 2, 44_100));
+
+        let b1 = consumer.pop().expect("buffer 1");
+        let b2 = consumer.pop().expect("buffer 2");
+        let b3 = consumer.pop().expect("buffer 3");
+        let b4 = consumer.pop().expect("buffer 4");
+
+        assert_eq!(b1.timestamp(), Some(Duration::ZERO));
+        assert_eq!(b2.timestamp(), Some(Duration::from_millis(10)));
+        // The PAST timeline is untouched by the rate change: the first
+        // post-change stamp continues exactly where the old rate left off.
+        // (The former frame-counter design would have stamped this
+        // 960 frames / 44100 Hz ≈ 21.77 ms — a spurious retroactive jump.)
+        assert_eq!(
+            b3.timestamp(),
+            Some(Duration::from_millis(20)),
+            "a rate change must not retroactively rescale earlier stream time"
+        );
+        // And the post-change delta uses the NEW rate: 441 frames @ 44.1 kHz
+        // is exactly 10 ms.
+        assert_eq!(
+            b4.timestamp(),
+            Some(Duration::from_millis(30)),
+            "post-change deltas must advance at the new rate"
+        );
+    }
+
+    // rsac-1b8c: the position advance is centralized in the shared inner push,
+    // so mixing stamped and UNSTAMPED pushes on one producer yields a single
+    // contiguous, non-overlapping timeline (an unstamped push consumes stream
+    // time even though it does not report it).
+    #[test]
+    fn mixed_stamped_and_unstamped_pushes_share_one_timeline() {
+        let (mut producer, mut consumer) = create_bridge(8, test_format());
+
+        // stamped (0 ms) → untimed → reporting (both advance, no stamp) →
+        // stamped: the final stamp must cover the untimed pushes' audio.
+        assert!(producer.push_samples_or_drop_stamped(&[0.0; 960], 2, 48_000));
+        assert!(producer.push_samples_or_drop(&[0.0; 960], 2, 48_000));
+        assert!(
+            producer
+                .push_samples_reporting(&[0.0; 960], 2, 48_000)
+                .pushed
+        );
+        assert!(producer.push_samples_or_drop_stamped(&[0.0; 960], 2, 48_000));
+
+        let b1 = consumer.pop().expect("stamped 1");
+        let b2 = consumer.pop().expect("untimed");
+        let b3 = consumer.pop().expect("reporting");
+        let b4 = consumer.pop().expect("stamped 2");
+
+        assert_eq!(b1.timestamp(), Some(Duration::ZERO));
+        assert_eq!(b2.timestamp(), None, "untimed variant stays unstamped");
+        assert_eq!(b3.timestamp(), None, "reporting variant stays unstamped");
+        // The two untimed pushes consumed 2 × 10 ms of stream time, so the
+        // second stamped push starts at 30 ms. (A per-variant counter would
+        // have stamped it 10 ms — overlapping the untimed audio.)
+        assert_eq!(
+            b4.timestamp(),
+            Some(Duration::from_millis(30)),
+            "unstamped pushes must advance the shared timeline (no overlap)"
+        );
+    }
+
+    // rsac-1b8c: multiple consecutive drops accumulate into one cumulative
+    // timestamp gap exactly equal to the dropped duration.
+    #[test]
+    fn consecutive_drops_accumulate_into_one_cumulative_gap() {
+        // Capacity 2: two successful pushes fill the ring, then every further
+        // push drops until the consumer drains.
+        let (mut producer, mut consumer) = create_bridge(2, test_format());
+
+        assert!(producer.push_samples_or_drop_stamped(&[0.0; 960], 2, 48_000)); // 0 ms
+        assert!(producer.push_samples_or_drop_stamped(&[0.0; 960], 2, 48_000)); // 10 ms
+
+        // Three consecutive drops (ring full) — 30 ms of lost audio.
+        for _ in 0..3 {
+            assert!(!producer.push_samples_or_drop_stamped(&[0.0; 960], 2, 48_000));
+        }
+
+        // Drain the two delivered buffers, then the next successful push must
+        // be stamped past the WHOLE cumulative gap:
+        // (2 delivered + 3 dropped) × 10 ms = 50 ms.
+        assert_eq!(
+            consumer.pop().expect("b1").timestamp(),
+            Some(Duration::ZERO)
+        );
+        assert_eq!(
+            consumer.pop().expect("b2").timestamp(),
+            Some(Duration::from_millis(10))
+        );
+        assert!(producer.push_samples_or_drop_stamped(&[0.0; 960], 2, 48_000));
+        let after = consumer.pop().expect("post-drop buffer");
+        assert_eq!(
+            after.timestamp(),
+            Some(Duration::from_millis(50)),
+            "the cumulative gap must equal the dropped duration (3 × 10 ms)"
+        );
+    }
+
+    // rsac-1b8c: the AudioBuffer-based pushes advance the same stream position
+    // as the samples family — `push` on success, `push_or_drop` also on a drop
+    // — so mixing them with `_stamped` pushes keeps one coherent timeline. A
+    // REJECTED `push()` (Err hands the buffer back, retryable) must NOT
+    // advance, or a retry would double-count.
+    #[test]
+    fn audiobuffer_pushes_advance_the_stream_position() {
+        let (mut producer, mut consumer) = create_bridge(2, test_format());
+
+        // 480-frame stereo buffer @ 48 kHz = 10 ms of stream time.
+        let mk = || AudioBuffer::new(vec![0.0; 960], 2, 48_000);
+
+        producer.push(mk()).unwrap(); // success → advances (→ 10 ms)
+        producer.push(mk()).unwrap(); // success → advances (→ 20 ms)
+        assert!(!producer.push_or_drop(mk())); // ring full: drop → advances (→ 30 ms)
+
+        // A rejected push() hands the buffer back WITHOUT advancing.
+        assert!(producer.push(mk()).is_err());
+
+        while consumer.pop().is_some() {}
+        assert!(producer.push_samples_or_drop_stamped(&[0.0; 960], 2, 48_000));
+        assert_eq!(
+            consumer.pop().expect("stamped buffer").timestamp(),
+            Some(Duration::from_millis(30)),
+            "2 pushed + 1 dropped AudioBuffers = 30 ms of consumed stream \
+             time; the rejected push() must not have advanced"
         );
     }
 

--- a/src/bridge/stream.rs
+++ b/src/bridge/stream.rs
@@ -318,6 +318,22 @@ impl<S: PlatformStream + Sync + 'static> CapturingStream for BridgeStream<S> {
     // parked `AsyncAudioStream` is always woken when data or a terminal state
     // arrives. Returning `true` is therefore honest here; see
     // `CapturingStream::register_waker` for the full contract.
+    //
+    // SINGLE-CONSUMER CONSTRAINT (rsac-7aa2): `BridgeShared` holds exactly ONE
+    // AtomicWaker slot, and calling `AtomicWaker::register` from two tasks
+    // concurrently is the crate-documented unsupported case — the losing
+    // task's waker is silently dropped WITHOUT being woken, so a second
+    // concurrent `AsyncAudioStream` over the same stream can park forever on a
+    // promised-but-stolen wake. A defensive "wake the displaced waker" is
+    // deliberately NOT implemented: AtomicWaker offers no atomic
+    // register-and-return-old primitive, so the only sequence available is
+    // take() → wake(old) → register(new), which (a) opens a window where the
+    // slot is empty and a producer wake is lost (only partially mitigated by
+    // the consumer's post-register double-check), and (b) still lets two
+    // concurrent registrants clobber each other between the take and the
+    // register — it narrows the race without closing it while adding a new
+    // one. The constraint is instead documented on `audio_data_stream`
+    // (AudioCapture and Composition): at most one async consumer per capture.
     #[cfg(feature = "async-stream")]
     fn register_waker(&self, waker: &std::task::Waker) -> bool {
         self.shared.waker.register(waker);
@@ -505,6 +521,79 @@ mod tests {
             matches!(try_result.unwrap_err(), AudioError::StreamEnded { .. }),
             "try_read_chunk after stop must also be StreamEnded"
         );
+    }
+
+    // 7b. Terminal signal is symmetric: read_chunk and try_read_chunk both
+    // return the SAME fatal StreamEnded once the stream is terminal, and
+    // try_read_chunk does NOT collapse terminal into Ok(None) (ADR-0003 / the
+    // CapturingStream trait contract). This pins the property the AudioCapture
+    // read_chunk_* paths and all binding pumps rely on.
+    #[test]
+    fn terminal_read_is_fatal_and_symmetric_across_both_methods() {
+        let (_producer, stream) = create_test_stream();
+        stream.stop().unwrap();
+
+        // Blocking read: fatal StreamEnded.
+        let blocking = stream.read_chunk();
+        assert!(
+            matches!(
+                blocking,
+                Err(ref e) if e.is_fatal() && matches!(e, AudioError::StreamEnded { .. })
+            ),
+            "read_chunk on a terminal stream must be a fatal StreamEnded, got {blocking:?}"
+        );
+
+        // Non-blocking read: the SAME fatal terminal — never Ok(None).
+        let nonblocking = stream.try_read_chunk();
+        assert!(
+            !matches!(nonblocking, Ok(None)),
+            "try_read_chunk must NOT report a terminal stream as Ok(None)"
+        );
+        assert!(
+            matches!(
+                nonblocking,
+                Err(ref e) if e.is_fatal() && matches!(e, AudioError::StreamEnded { .. })
+            ),
+            "try_read_chunk on a terminal stream must be a fatal StreamEnded, got {nonblocking:?}"
+        );
+    }
+
+    // 7c. Drain-before-terminal: while Stopping, buffered tail data is returned
+    // by try_read_chunk (Ok(Some)); the fatal StreamEnded is only reported once
+    // the ring is empty AND the state is terminal. Proves reads never discard
+    // the tail on a bare running check.
+    #[test]
+    fn drains_tail_during_stopping_then_reports_fatal_terminal() {
+        let (mut producer, stream) = create_test_stream();
+        producer.push(test_buffer(0.11)).unwrap();
+
+        // Enter Stopping (still readable) with a queued tail buffer.
+        stream
+            .shared()
+            .state
+            .transition(StreamState::Running, StreamState::Stopping)
+            .unwrap();
+
+        // Tail is drained first.
+        let tail = stream.try_read_chunk().unwrap().expect("tail drained");
+        assert_eq!(tail.data()[0], 0.11);
+
+        // Ring empty but still Stopping → Ok(None), not terminal yet.
+        assert!(
+            matches!(stream.try_read_chunk(), Ok(None)),
+            "empty-but-Stopping ring must be Ok(None), not StreamEnded"
+        );
+
+        // Reach a terminal state → now the fatal terminal is reported.
+        stream
+            .shared()
+            .state
+            .transition(StreamState::Stopping, StreamState::Stopped)
+            .unwrap();
+        assert!(matches!(
+            stream.try_read_chunk(),
+            Err(AudioError::StreamEnded { .. })
+        ));
     }
 
     // M1: format() reflects the negotiated *delivery* format once a backend

--- a/src/compose/builder.rs
+++ b/src/compose/builder.rs
@@ -1,0 +1,670 @@
+//! Composition configuration: [`CompositionBuilder`], [`Group`],
+//! [`GroupLayout`], and the [`ChannelMap`] describing the composed layout.
+
+use std::time::Duration;
+
+use crate::api::AudioCaptureBuilder;
+use crate::core::capabilities::PlatformCapabilities;
+use crate::core::config::CaptureTarget;
+use crate::core::error::{AudioError, AudioResult};
+
+use super::stream::Composition;
+
+/// The maximum number of composed output channels. Mirrors the builder-side
+/// ceiling `AudioCaptureBuilder` enforces for a single capture, so a composed
+/// stream is never wider than any single capture is allowed to be.
+pub(crate) const MAX_COMPOSED_CHANNELS: u16 = 32;
+
+/// The maximum number of sources a composition may hold (config sanity bound —
+/// each source is a full platform capture with its own ring and OS stream).
+pub(crate) const MAX_SOURCES: usize = 16;
+
+/// How a [`Group`]'s sources map onto the composed output channels.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GroupLayout {
+    /// Fold every source in the group to mono (per-frame mean across the
+    /// source's channels) and gain-weighted-sum them into **one** output
+    /// channel.
+    Mono,
+    /// Fold every source in the group to stereo and gain-weighted-sum them
+    /// into **two** output channels. Mono sources are duplicated to L/R;
+    /// stereo sources pass through; wider sources are folded even→L / odd→R
+    /// (per-side mean).
+    Stereo,
+    /// Pass the group's **single** source through with its native channel
+    /// count (determined at [`Composition::start`]). v1 restriction: a
+    /// keep-channels group must contain exactly one source.
+    KeepChannels,
+}
+
+impl GroupLayout {
+    /// The number of output channels this layout contributes, when knowable
+    /// from the layout alone (`None` for [`KeepChannels`](Self::KeepChannels),
+    /// whose width is the source's negotiated channel count).
+    pub(crate) fn fixed_width(&self) -> Option<u16> {
+        match self {
+            GroupLayout::Mono => Some(1),
+            GroupLayout::Stereo => Some(2),
+            GroupLayout::KeepChannels => None,
+        }
+    }
+}
+
+/// One composition group: a named set of sources sharing a [`GroupLayout`].
+///
+/// Built fluently and handed to [`CompositionBuilder::group`]:
+///
+/// ```rust
+/// use rsac::compose::{Group, GroupLayout};
+/// use rsac::core::config::CaptureTarget;
+///
+/// let g = Group::new("voice")
+///     .source(CaptureTarget::ApplicationByName("discord".into()))
+///     .source_with_gain(CaptureTarget::ApplicationByName("zoom".into()), 0.8)
+///     .mixdown(GroupLayout::Mono);
+/// assert_eq!(g.sources().len(), 2);
+/// ```
+#[derive(Debug, Clone)]
+pub struct Group {
+    name: String,
+    sources: Vec<(CaptureTarget, f32)>,
+    layout: GroupLayout,
+}
+
+impl Group {
+    /// Creates a group with the given name and the default
+    /// [`GroupLayout::Stereo`] layout.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            sources: Vec::new(),
+            layout: GroupLayout::Stereo,
+        }
+    }
+
+    /// Adds a source with unit gain (1.0).
+    pub fn source(self, target: CaptureTarget) -> Self {
+        self.source_with_gain(target, 1.0)
+    }
+
+    /// Adds a source with an explicit linear gain applied during mixdown
+    /// (1.0 = unity; validation requires the gain to be finite and ≥ 0).
+    pub fn source_with_gain(mut self, target: CaptureTarget, gain: f32) -> Self {
+        self.sources.push((target, gain));
+        self
+    }
+
+    /// Sets the group's mixdown layout ([`Mono`](GroupLayout::Mono) or
+    /// [`Stereo`](GroupLayout::Stereo)); for native-channel passthrough use
+    /// [`keep_channels`](Self::keep_channels).
+    pub fn mixdown(mut self, layout: GroupLayout) -> Self {
+        self.layout = layout;
+        self
+    }
+
+    /// Sets the group to [`GroupLayout::KeepChannels`]: its single source's
+    /// native channels are appended to the composed output unchanged.
+    pub fn keep_channels(mut self) -> Self {
+        self.layout = GroupLayout::KeepChannels;
+        self
+    }
+
+    /// The group's name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The group's `(target, gain)` pairs, in declaration order.
+    pub fn sources(&self) -> &[(CaptureTarget, f32)] {
+        &self.sources
+    }
+
+    /// The group's layout.
+    pub fn layout(&self) -> GroupLayout {
+        self.layout
+    }
+}
+
+/// Where one composed output channel comes from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelOrigin {
+    /// Name of the group this channel belongs to.
+    pub group: String,
+    /// Index of the group in declaration order.
+    pub group_index: usize,
+    /// Channel index *within* the group (0-based; e.g. 0 = L, 1 = R for a
+    /// stereo group).
+    pub channel_in_group: u16,
+}
+
+/// Maps composed output channels back to the groups that produce them.
+///
+/// Entry `i` describes interleaved output channel `i`. Group channels are
+/// contiguous and appear in group declaration order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelMap {
+    entries: Vec<ChannelOrigin>,
+}
+
+impl ChannelMap {
+    pub(crate) fn new(entries: Vec<ChannelOrigin>) -> Self {
+        Self { entries }
+    }
+
+    /// Total number of composed output channels.
+    pub fn channels(&self) -> u16 {
+        self.entries.len() as u16
+    }
+
+    /// Per-channel origins, indexed by output channel.
+    pub fn entries(&self) -> &[ChannelOrigin] {
+        &self.entries
+    }
+
+    /// The contiguous output-channel range contributed by the named group, or
+    /// `None` if no group has that name.
+    pub fn group_range(&self, group: &str) -> Option<std::ops::Range<usize>> {
+        let start = self.entries.iter().position(|e| e.group == group)?;
+        let end = start
+            + self.entries[start..]
+                .iter()
+                .take_while(|e| e.group == group)
+                .count();
+        Some(start..end)
+    }
+}
+
+/// Fully validated composition parameters, produced by
+/// [`CompositionBuilder::build`] and consumed by [`Composition`].
+#[derive(Debug, Clone)]
+pub(crate) struct CompositionPlan {
+    pub session_rate: u32,
+    pub clamp_output: bool,
+    pub quantum: Duration,
+    pub stall_timeout: Duration,
+    pub max_buffer: Duration,
+    pub groups: Vec<Group>,
+}
+
+impl CompositionPlan {
+    /// Frames per composed tick at the session rate (≥ 1).
+    pub fn quantum_frames(&self) -> usize {
+        let frames =
+            (self.session_rate as u128 * self.quantum.as_nanos() / 1_000_000_000u128) as usize;
+        frames.max(1)
+    }
+
+    /// Per-source FIFO bound in frames at the session rate (≥ one quantum).
+    pub fn max_fifo_frames(&self) -> usize {
+        let frames =
+            (self.session_rate as u128 * self.max_buffer.as_nanos() / 1_000_000_000u128) as usize;
+        frames.max(self.quantum_frames())
+    }
+
+    /// Index (in flat declaration order across all groups) of the master-clock
+    /// source: the first `SystemDefault` / `Device` source, else source 0.
+    pub fn master_index(&self) -> usize {
+        let mut idx = 0usize;
+        let mut first_system = None;
+        for group in &self.groups {
+            for (target, _gain) in group.sources() {
+                if first_system.is_none()
+                    && matches!(
+                        target,
+                        CaptureTarget::SystemDefault | CaptureTarget::Device(_)
+                    )
+                {
+                    first_system = Some(idx);
+                }
+                idx += 1;
+            }
+        }
+        first_system.unwrap_or(0)
+    }
+}
+
+/// Builder for a multi-source [`Composition`] (ADR-0011).
+///
+/// See the [module docs](crate::compose) for the composition model and a full
+/// example. Defaults: 48 kHz session rate, 10 ms tick quantum, 250 ms master
+/// stall timeout, 1 s per-source buffering bound, no output clamping.
+#[derive(Debug, Clone)]
+pub struct CompositionBuilder {
+    session_rate: u32,
+    clamp_output: bool,
+    quantum: Duration,
+    stall_timeout: Duration,
+    max_buffer: Duration,
+    groups: Vec<Group>,
+}
+
+impl Default for CompositionBuilder {
+    fn default() -> Self {
+        Self {
+            session_rate: 48_000,
+            clamp_output: false,
+            quantum: Duration::from_millis(10),
+            stall_timeout: Duration::from_millis(250),
+            max_buffer: Duration::from_secs(1),
+            groups: Vec::new(),
+        }
+    }
+}
+
+impl CompositionBuilder {
+    /// Creates a builder with default settings (48 kHz, no clamping, 10 ms
+    /// quantum, 250 ms stall timeout, 1 s buffering bound, no groups).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the session sample rate in Hz. Sources delivering a different rate
+    /// are resampled to this rate. Must be one of
+    /// [`PlatformCapabilities::SUPPORTED_SAMPLE_RATES`].
+    pub fn sample_rate(mut self, rate: u32) -> Self {
+        self.session_rate = rate;
+        self
+    }
+
+    /// Enables/disables saturating output clamping to `[-1.0, 1.0]` after
+    /// summation. Default **off**: plain summation may exceed unity, which is
+    /// legal for f32 pipelines (and f32 WAV); clipping strategy is otherwise
+    /// the consumer's decision.
+    pub fn clamp_output(mut self, clamp: bool) -> Self {
+        self.clamp_output = clamp;
+        self
+    }
+
+    /// Sets the composed tick quantum (output buffer duration). Default 10 ms.
+    /// Clamped to at least one frame at the session rate.
+    pub fn quantum(mut self, quantum: Duration) -> Self {
+        self.quantum = quantum;
+        self
+    }
+
+    /// Sets how long the compositor waits for the master-clock source before
+    /// emitting a wall-clock fallback tick (so a stalled master never freezes
+    /// the session). Default 250 ms.
+    pub fn stall_timeout(mut self, timeout: Duration) -> Self {
+        self.stall_timeout = timeout;
+        self
+    }
+
+    /// Sets the per-source buffering bound. A source drifting ahead of the
+    /// master beyond this bound has its oldest samples trimmed (counted in
+    /// [`SourceStats::trimmed_frames`](super::SourceStats::trimmed_frames)).
+    /// Default 1 s; clamped to at least one quantum.
+    pub fn max_buffer(mut self, bound: Duration) -> Self {
+        self.max_buffer = bound;
+        self
+    }
+
+    /// Appends a group. Groups contribute output channels in the order they
+    /// are added.
+    pub fn group(mut self, group: Group) -> Self {
+        self.groups.push(group);
+        self
+    }
+
+    /// Read-only view of the groups added so far.
+    pub fn groups(&self) -> &[Group] {
+        &self.groups
+    }
+
+    /// Runs every device-independent validation [`build`](Self::build)
+    /// performs, without constructing anything.
+    ///
+    /// # Errors
+    ///
+    /// - [`AudioError::ConfigurationError`] — no groups; an empty group; a
+    ///   duplicate/empty group name; a keep-channels group with ≠ 1 source; a
+    ///   non-finite or negative gain; too many sources
+    ///   (> 16); a fixed-width channel total exceeding 32; a zero quantum or
+    ///   stall timeout.
+    /// - [`AudioError::InvalidParameter`] — unsupported session sample rate.
+    /// - [`AudioError::PlatformNotSupported`] — a target the current platform
+    ///   cannot capture (same check as
+    ///   [`AudioCaptureBuilder::preflight`](crate::api::AudioCaptureBuilder::preflight)).
+    pub fn preflight(&self) -> AudioResult<()> {
+        if self.groups.is_empty() {
+            return Err(AudioError::ConfigurationError {
+                message: "Composition requires at least one group".to_string(),
+            });
+        }
+        if self.quantum.is_zero() {
+            return Err(AudioError::ConfigurationError {
+                message: "Composition quantum must be non-zero".to_string(),
+            });
+        }
+        if self.stall_timeout.is_zero() {
+            return Err(AudioError::ConfigurationError {
+                message: "Composition stall_timeout must be non-zero".to_string(),
+            });
+        }
+
+        // Session rate uses the same whitelist a single capture's builder
+        // enforces, so the two contracts cannot drift.
+        if !PlatformCapabilities::SUPPORTED_SAMPLE_RATES.contains(&self.session_rate) {
+            return Err(AudioError::InvalidParameter {
+                param: "sample_rate".into(),
+                reason: format!(
+                    "Unsupported session sample rate: {} Hz. Supported: {}",
+                    self.session_rate,
+                    PlatformCapabilities::supported_sample_rates_display()
+                ),
+            });
+        }
+
+        let mut seen_names: Vec<&str> = Vec::with_capacity(self.groups.len());
+        let mut total_sources = 0usize;
+        let mut fixed_channels = 0u32;
+        for group in &self.groups {
+            if group.name().is_empty() {
+                return Err(AudioError::ConfigurationError {
+                    message: "Group names must be non-empty".to_string(),
+                });
+            }
+            if seen_names.contains(&group.name()) {
+                return Err(AudioError::ConfigurationError {
+                    message: format!("Duplicate group name: '{}'", group.name()),
+                });
+            }
+            seen_names.push(group.name());
+
+            if group.sources().is_empty() {
+                return Err(AudioError::ConfigurationError {
+                    message: format!("Group '{}' has no sources", group.name()),
+                });
+            }
+            if group.layout() == GroupLayout::KeepChannels && group.sources().len() != 1 {
+                return Err(AudioError::ConfigurationError {
+                    message: format!(
+                        "Group '{}' uses KeepChannels with {} sources; keep-channels groups \
+                         must contain exactly one source (v1 restriction — mix additional \
+                         sources via a Mono/Stereo group instead)",
+                        group.name(),
+                        group.sources().len()
+                    ),
+                });
+            }
+
+            total_sources += group.sources().len();
+
+            // KeepChannels width is only known after start(); count the fixed
+            // layouts now and re-check the full total at start().
+            if let Some(w) = group.layout().fixed_width() {
+                fixed_channels += u32::from(w);
+            }
+
+            for (target, gain) in group.sources() {
+                if !gain.is_finite() || *gain < 0.0 {
+                    return Err(AudioError::ConfigurationError {
+                        message: format!(
+                            "Source gain {} in group '{}' is invalid (must be finite and >= 0)",
+                            gain,
+                            group.name()
+                        ),
+                    });
+                }
+                // Per-target capability validation is delegated to the single
+                // source of truth: the capture builder's own preflight.
+                AudioCaptureBuilder::new()
+                    .with_target(target.clone())
+                    .sample_rate(self.session_rate)
+                    .preflight()?;
+            }
+        }
+
+        if total_sources > MAX_SOURCES {
+            return Err(AudioError::ConfigurationError {
+                message: format!(
+                    "Composition has {} sources; the maximum is {}",
+                    total_sources, MAX_SOURCES
+                ),
+            });
+        }
+        if fixed_channels > u32::from(MAX_COMPOSED_CHANNELS) {
+            return Err(AudioError::ConfigurationError {
+                message: format!(
+                    "Composition would produce at least {} output channels; the maximum is {}",
+                    fixed_channels, MAX_COMPOSED_CHANNELS
+                ),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Validates the configuration and constructs a (not yet started)
+    /// [`Composition`].
+    ///
+    /// No devices are touched here; source captures are created and started by
+    /// [`Composition::start`]. See [`preflight`](Self::preflight) for the
+    /// errors this can raise.
+    pub fn build(self) -> AudioResult<Composition> {
+        self.preflight()?;
+        Ok(Composition::from_plan(CompositionPlan {
+            session_rate: self.session_rate,
+            clamp_output: self.clamp_output,
+            quantum: self.quantum,
+            stall_timeout: self.stall_timeout,
+            max_buffer: self.max_buffer,
+            groups: self.groups,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::ProcessId;
+
+    fn sys_group(name: &str) -> Group {
+        Group::new(name)
+            .source(CaptureTarget::SystemDefault)
+            .mixdown(GroupLayout::Stereo)
+    }
+
+    #[test]
+    fn empty_builder_rejected() {
+        let err = CompositionBuilder::new().preflight().unwrap_err();
+        assert!(matches!(err, AudioError::ConfigurationError { .. }));
+    }
+
+    #[test]
+    fn minimal_valid_composition_passes_preflight() {
+        CompositionBuilder::new()
+            .group(sys_group("main"))
+            .preflight()
+            .expect("single stereo system group is valid");
+    }
+
+    #[test]
+    fn empty_group_rejected() {
+        let err = CompositionBuilder::new()
+            .group(Group::new("empty"))
+            .preflight()
+            .unwrap_err();
+        assert!(matches!(err, AudioError::ConfigurationError { .. }));
+    }
+
+    #[test]
+    fn empty_group_name_rejected() {
+        let err = CompositionBuilder::new()
+            .group(Group::new("").source(CaptureTarget::SystemDefault))
+            .preflight()
+            .unwrap_err();
+        assert!(matches!(err, AudioError::ConfigurationError { .. }));
+    }
+
+    #[test]
+    fn duplicate_group_names_rejected() {
+        let err = CompositionBuilder::new()
+            .group(sys_group("dup"))
+            .group(sys_group("dup"))
+            .preflight()
+            .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("Duplicate group name"), "got: {msg}");
+    }
+
+    #[test]
+    fn keep_channels_requires_exactly_one_source() {
+        let err = CompositionBuilder::new()
+            .group(
+                Group::new("keep")
+                    .source(CaptureTarget::SystemDefault)
+                    .source(CaptureTarget::SystemDefault)
+                    .keep_channels(),
+            )
+            .preflight()
+            .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("KeepChannels"), "got: {msg}");
+
+        // Exactly one source is fine.
+        CompositionBuilder::new()
+            .group(
+                Group::new("keep")
+                    .source(CaptureTarget::SystemDefault)
+                    .keep_channels(),
+            )
+            .preflight()
+            .expect("one-source keep group is valid");
+    }
+
+    #[test]
+    fn invalid_gain_rejected() {
+        for bad in [-0.5f32, f32::NAN, f32::INFINITY] {
+            let err = CompositionBuilder::new()
+                .group(
+                    Group::new("g")
+                        .source_with_gain(CaptureTarget::SystemDefault, bad)
+                        .mixdown(GroupLayout::Mono),
+                )
+                .preflight()
+                .unwrap_err();
+            assert!(
+                matches!(err, AudioError::ConfigurationError { .. }),
+                "gain {bad} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_sample_rate_rejected() {
+        let err = CompositionBuilder::new()
+            .sample_rate(12345)
+            .group(sys_group("main"))
+            .preflight()
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            AudioError::InvalidParameter { ref param, .. } if param == "sample_rate"
+        ));
+    }
+
+    #[test]
+    fn too_many_sources_rejected() {
+        let mut group = Group::new("many").mixdown(GroupLayout::Mono);
+        for _ in 0..(MAX_SOURCES + 1) {
+            group = group.source(CaptureTarget::SystemDefault);
+        }
+        let err = CompositionBuilder::new()
+            .group(group)
+            .preflight()
+            .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("sources"), "got: {msg}");
+    }
+
+    #[test]
+    fn zero_quantum_and_stall_timeout_rejected() {
+        let err = CompositionBuilder::new()
+            .quantum(Duration::ZERO)
+            .group(sys_group("main"))
+            .preflight()
+            .unwrap_err();
+        assert!(matches!(err, AudioError::ConfigurationError { .. }));
+
+        let err = CompositionBuilder::new()
+            .stall_timeout(Duration::ZERO)
+            .group(sys_group("main"))
+            .preflight()
+            .unwrap_err();
+        assert!(matches!(err, AudioError::ConfigurationError { .. }));
+    }
+
+    #[test]
+    fn process_tree_target_delegates_to_capture_preflight() {
+        // On platforms that support process-tree capture this passes; on ones
+        // that don't it must surface PlatformNotSupported — either way the
+        // decision comes from the capture builder's preflight, not compose.
+        let result = CompositionBuilder::new()
+            .group(
+                Group::new("tree")
+                    .source(CaptureTarget::ProcessTree(ProcessId(1)))
+                    .mixdown(GroupLayout::Stereo),
+            )
+            .preflight();
+        let caps = PlatformCapabilities::query();
+        if caps.supports_process_tree_capture {
+            result.expect("supported platform must pass");
+        } else {
+            assert!(matches!(
+                result.unwrap_err(),
+                AudioError::PlatformNotSupported { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn quantum_frames_and_master_index() {
+        let plan = CompositionPlan {
+            session_rate: 48_000,
+            clamp_output: false,
+            quantum: Duration::from_millis(10),
+            stall_timeout: Duration::from_millis(250),
+            max_buffer: Duration::from_secs(1),
+            groups: vec![
+                Group::new("apps")
+                    .source(CaptureTarget::ApplicationByName("x".into()))
+                    .mixdown(GroupLayout::Mono),
+                Group::new("sys")
+                    .source(CaptureTarget::SystemDefault)
+                    .keep_channels(),
+            ],
+        };
+        assert_eq!(plan.quantum_frames(), 480);
+        assert_eq!(plan.max_fifo_frames(), 48_000);
+        // Master is the first SystemDefault/Device source in flat order — the
+        // app source at index 0 is skipped in favor of the system source.
+        assert_eq!(plan.master_index(), 1);
+    }
+
+    #[test]
+    fn channel_map_group_range() {
+        let map = ChannelMap::new(vec![
+            ChannelOrigin {
+                group: "voice".into(),
+                group_index: 0,
+                channel_in_group: 0,
+            },
+            ChannelOrigin {
+                group: "sys".into(),
+                group_index: 1,
+                channel_in_group: 0,
+            },
+            ChannelOrigin {
+                group: "sys".into(),
+                group_index: 1,
+                channel_in_group: 1,
+            },
+        ]);
+        assert_eq!(map.channels(), 3);
+        assert_eq!(map.group_range("voice"), Some(0..1));
+        assert_eq!(map.group_range("sys"), Some(1..3));
+        assert_eq!(map.group_range("nope"), None);
+    }
+}

--- a/src/compose/engine.rs
+++ b/src/compose/engine.rs
@@ -1,0 +1,881 @@
+//! The compositor engine: per-source ingest FIFOs, master-clock pacing,
+//! silence padding / bounded trimming, per-group mixdown, and the thread that
+//! runs it all.
+//!
+//! Everything here executes on the dedicated `rsac-compose` thread (plus the
+//! caller thread during setup) — never on an OS audio callback thread, so
+//! allocation is acceptable (ADR-0001 governs the RT producer paths inside
+//! each inner capture, which are untouched).
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::bridge::ring_buffer::BridgeProducer;
+use crate::core::buffer::AudioBuffer;
+use crate::core::config::AudioFormat;
+use crate::core::error::AudioResult;
+
+use super::builder::GroupLayout;
+use super::resample::StreamResampler;
+
+/// How many buffers to drain from one source per ingest pass, so a single
+/// bursty source cannot starve the others or the tick check.
+const MAX_DRAIN_PER_POLL: usize = 32;
+
+/// Idle sleep between engine loop passes when no data moved.
+const IDLE_SLEEP: Duration = Duration::from_millis(1);
+
+/// Tolerance before a timestamp jump counts as a real intra-source gap
+/// (rsac-ae4e). Stream-position stamps are exact integer frame math, so a
+/// continuous stream lands within nanoseconds of the expected next position;
+/// 1 ms absorbs Duration rounding without hiding any real hole (the smallest
+/// drop a backend can produce is one OS callback period, ~2.5–10 ms).
+const GAP_EPSILON: Duration = Duration::from_millis(1);
+
+// ── Source abstraction (test seam) ──────────────────────────────────────
+
+/// What the engine needs from a capture source. Implemented by the real
+/// `AudioCapture`-backed source in `stream.rs` and by scripted fakes in tests.
+pub(crate) trait SourceReader: Send {
+    /// Non-blocking, terminal-observable read: `Ok(None)` = no data yet,
+    /// fatal `Err` = source ended (matches
+    /// [`CapturingStream::try_read_chunk`](crate::core::interface::CapturingStream::try_read_chunk)
+    /// semantics).
+    fn try_read(&mut self) -> AudioResult<Option<AudioBuffer>>;
+
+    /// Best-effort stop of the underlying capture (idempotent).
+    fn stop(&mut self);
+
+    /// Cumulative ring-overflow drop count *inside* the underlying capture
+    /// (its `overrun_count`) — audio lost upstream of the compositor
+    /// (rsac-ae4e). Defaults to `0` for sources with no inner ring (scripted
+    /// test sources). The engine snapshots this into
+    /// [`SourceStatsShared::inner_dropped`] every ingest pass so composed
+    /// consumers can attribute upstream loss to a specific source.
+    fn overruns(&self) -> u64 {
+        0
+    }
+}
+
+// ── Shared stats (engine writes, handle reads) ──────────────────────────
+
+/// Lock-free per-source counters shared between the engine thread and the
+/// public [`Composition`](super::Composition) handle.
+#[derive(Debug, Default)]
+pub(crate) struct SourceStatsShared {
+    pub buffers_received: AtomicU64,
+    pub padded_frames: AtomicU64,
+    pub trimmed_frames: AtomicU64,
+    /// Frames of silence inserted to compensate intra-source timestamp gaps
+    /// (rsac-ae4e), counted at the source's *delivered* rate — the rate the
+    /// silence was inserted at (see `Engine::ingest_buffer`).
+    pub gap_padded_frames: AtomicU64,
+    /// Snapshot of the inner capture's own ring-overflow drop count
+    /// (`SourceReader::overruns`), refreshed every ingest pass (rsac-ae4e).
+    pub inner_dropped: AtomicU64,
+    pub resampling: AtomicBool,
+    pub ended: AtomicBool,
+}
+
+/// Lock-free composition-wide counters.
+#[derive(Debug, Default)]
+pub(crate) struct EngineStatsShared {
+    /// Total ticks emitted (master-paced + fallback).
+    pub ticks: AtomicU64,
+    /// Ticks emitted by the wall-clock stall fallback rather than master data.
+    pub fallback_ticks: AtomicU64,
+    /// Per-source counters, in flat declaration order.
+    pub sources: Vec<Arc<SourceStatsShared>>,
+}
+
+// ── Engine configuration ────────────────────────────────────────────────
+
+/// Static mixdown spec for one source (flat declaration order).
+#[derive(Debug, Clone)]
+pub(crate) struct SourceSpec {
+    /// Linear gain applied during mixdown.
+    pub gain: f32,
+    /// Index of the group this source belongs to.
+    pub group: usize,
+    /// The source's fixed channel width. For keep-channels sources this is
+    /// the polled negotiated width; for mixdown sources it is locked to the
+    /// first delivered buffer (0 = not yet known).
+    pub channels: u16,
+    /// Whether this source targets a system/device endpoint whose clock ticks
+    /// through silence — i.e. a preferred candidate when the master clock has
+    /// to be re-elected after the current master ends.
+    pub clock_candidate: bool,
+}
+
+/// Static spec for one group's slice of the composed frame.
+#[derive(Debug, Clone)]
+pub(crate) struct GroupSpec {
+    pub layout: GroupLayout,
+    /// First output channel this group writes.
+    pub offset: usize,
+    /// Number of output channels this group owns.
+    pub width: usize,
+}
+
+/// Everything the engine thread needs, assembled by `Composition::start()`.
+pub(crate) struct EngineConfig {
+    pub composed_format: AudioFormat,
+    pub quantum_frames: usize,
+    pub max_fifo_frames: usize,
+    pub stall_timeout: Duration,
+    pub clamp_output: bool,
+    pub master_index: usize,
+    pub groups: Vec<GroupSpec>,
+    pub sources: Vec<SourceSpec>,
+}
+
+impl EngineConfig {
+    /// The session rate every source is aligned to. Single-sourced from the
+    /// composed delivery format so the two can never disagree.
+    pub fn session_rate(&self) -> u32 {
+        self.composed_format.sample_rate
+    }
+}
+
+// ── Per-source runtime state ────────────────────────────────────────────
+
+struct SourceState {
+    reader: Box<dyn SourceReader>,
+    spec: SourceSpec,
+    /// Interleaved samples at the session rate, `spec.channels` wide.
+    fifo: VecDeque<f32>,
+    resampler: Option<StreamResampler>,
+    /// Input rate the current resampler was built for (0 = none needed yet).
+    resampler_in_rate: u32,
+    /// Whether a channel-width mismatch was already warned about.
+    warned_channel_adapt: bool,
+    /// Whether a ragged (non-whole-frame) delivery was already warned about
+    /// (rsac-2195).
+    warned_ragged: bool,
+    /// Stream position (at the source's *delivered* rate) where the next
+    /// buffer is expected to start, derived from the source's own
+    /// stream-position timestamps (rsac-ae4e). `None` until the first stamped
+    /// buffer arrives; re-anchored to `ts + frames/rate` on every stamped
+    /// buffer thereafter, so there is no cumulative drift. Buffers without
+    /// timestamps neither consult nor advance it.
+    expected_next: Option<Duration>,
+    ended: bool,
+    stats: Arc<SourceStatsShared>,
+}
+
+impl SourceState {
+    fn fifo_frames(&self) -> usize {
+        if self.spec.channels == 0 {
+            0
+        } else {
+            self.fifo.len() / usize::from(self.spec.channels)
+        }
+    }
+}
+
+// ── Engine ──────────────────────────────────────────────────────────────
+
+pub(crate) struct Engine {
+    cfg: EngineConfig,
+    sources: Vec<SourceState>,
+    producer: BridgeProducer,
+    stop_flag: Arc<AtomicBool>,
+    active: Arc<AtomicBool>,
+    stats: Arc<EngineStatsShared>,
+    last_tick: Instant,
+    /// Reused per-tick output scratch (composed interleaved frame block).
+    out_scratch: Vec<f32>,
+    /// Reused per-source drain scratch.
+    src_scratch: Vec<f32>,
+}
+
+impl Engine {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        cfg: EngineConfig,
+        readers: Vec<Box<dyn SourceReader>>,
+        producer: BridgeProducer,
+        stop_flag: Arc<AtomicBool>,
+        active: Arc<AtomicBool>,
+        stats: Arc<EngineStatsShared>,
+    ) -> Self {
+        debug_assert_eq!(readers.len(), cfg.sources.len());
+        debug_assert_eq!(readers.len(), stats.sources.len());
+        let sources = readers
+            .into_iter()
+            .zip(cfg.sources.iter().cloned())
+            .zip(stats.sources.iter().cloned())
+            .map(|((reader, spec), stats)| SourceState {
+                reader,
+                spec,
+                fifo: VecDeque::new(),
+                resampler: None,
+                resampler_in_rate: 0,
+                warned_channel_adapt: false,
+                warned_ragged: false,
+                expected_next: None,
+                ended: false,
+                stats,
+            })
+            .collect();
+        let total_channels = usize::from(cfg.composed_format.channels);
+        let quantum = cfg.quantum_frames;
+        Self {
+            out_scratch: vec![0.0; quantum * total_channels],
+            src_scratch: Vec::new(),
+            cfg,
+            sources,
+            producer,
+            stop_flag,
+            active,
+            stats,
+            last_tick: Instant::now(),
+        }
+    }
+
+    /// The engine thread body: run the tick loop, then tear down (stop the
+    /// inner readers, put the composed ring into a terminal state, flip the
+    /// liveness flag).
+    ///
+    /// The tick loop executes under [`std::panic::catch_unwind`] so the
+    /// teardown is **unconditional** (rsac-1b83). Without the guard, a panic
+    /// anywhere in the loop would leave the ring `Running` and
+    /// `engine_active == true` forever: `ComposedStreamView::read_chunk`
+    /// swallows `Timeout` and loops, subscribe/drain pumps spin,
+    /// `is_running()` lies, and `Composition::stop` joins the dead thread and
+    /// silently discards the panic — a permanently non-terminal composition.
+    pub fn run(mut self) {
+        // AssertUnwindSafe: on a caught panic the teardown below immediately
+        // poisons the stream to the terminal `Error` state and stops every
+        // reader, so nothing ever acts on the potentially-torn engine state
+        // (same rationale as the bridge's `push_samples_guarded`).
+        let loop_result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.run_loop()));
+
+        // ── Infallible teardown — runs on BOTH exit paths ────────────────
+        // Stop the inner captures first (each stop guarded: one reader's
+        // panicking stop() must not strand the others or skip the terminal
+        // signal below).
+        for s in &mut self.sources {
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| s.reader.stop()));
+        }
+        // Then put the composed ring into a terminal state, and only THEN
+        // flip the active flag. Order matters on BOTH arms: the terminal
+        // signal must happen-before `active = false`, because the
+        // consumer-side view promotes Stopping → Stopped when it observes
+        // `!active` on an empty ring — flipping the flag first could promote
+        // from a still-Running state and fail the CAS.
+        match &loop_result {
+            // Clean exit: graceful end. `Stopping` keeps the ring drainable,
+            // preserving ADR-0003 drain-before-terminal semantics for the
+            // flushed tail — exactly the pre-existing path.
+            Ok(()) => self.producer.signal_done(),
+            // Panic: poison to the terminal `Error` state so blocking AND
+            // async readers wake immediately and observe the fatal
+            // `StreamEnded`. (`signal_done`'s graceful `Stopping` would keep
+            // them draining/parking forever instead — the hang this fixes.)
+            Err(payload) => {
+                log::error!(
+                    "rsac-compose engine panicked: {}; poisoning composed stream to Error",
+                    panic_message(payload.as_ref())
+                );
+                self.producer.signal_error();
+            }
+        }
+        self.active.store(false, Ordering::SeqCst);
+        log::debug!(
+            "rsac-compose engine exited (ticks={}, fallback_ticks={}, panicked={})",
+            self.stats.ticks.load(Ordering::Relaxed),
+            self.stats.fallback_ticks.load(Ordering::Relaxed),
+            loop_result.is_err()
+        );
+
+        // Teardown is complete — re-raise so the panic stays observable to
+        // whoever joins the thread (`Composition::stop` logs the join error
+        // instead of discarding it).
+        if let Err(payload) = loop_result {
+            std::panic::resume_unwind(payload);
+        }
+    }
+
+    /// The tick loop proper: loop until stopped or every source has ended and
+    /// drained. Split out of [`run`](Self::run) so the caller can wrap it in
+    /// `catch_unwind` while keeping the teardown *outside* the guarded region
+    /// (rsac-1b83).
+    fn run_loop(&mut self) {
+        self.last_tick = Instant::now();
+        // Wall-clock cadence for fallback ticks: one quantum's worth of time.
+        let quantum_duration = Duration::from_nanos(
+            (self.cfg.quantum_frames as u128 * 1_000_000_000u128
+                / self.cfg.session_rate().max(1) as u128) as u64,
+        );
+        // `true` once the wall-clock fallback has engaged; reset by the next
+        // master-paced tick. While engaged, fallback ticks run at *quantum*
+        // cadence (real-time rate) — the stall timeout only gates *entering*
+        // fallback, otherwise a stalled master would collapse throughput to
+        // one quantum per stall_timeout and force `trim_all` to discard most
+        // of the still-live sources' audio.
+        let mut fallback_engaged = false;
+        loop {
+            if self.stop_flag.load(Ordering::SeqCst) {
+                break;
+            }
+
+            let ingested = self.ingest_all();
+
+            // Master-paced ticks: emit while the master has a full quantum.
+            // The master is re-elected if the configured one has ended (see
+            // `effective_master_frames`), so a dead master hands the clock to
+            // a live source at full data rate instead of starving the session.
+            let mut emitted = false;
+            while self.effective_master_frames() >= self.cfg.quantum_frames {
+                self.emit_tick(self.cfg.quantum_frames, false);
+                emitted = true;
+                fallback_engaged = false;
+            }
+
+            // Wall-clock fallback: a stalled master never freezes the session.
+            // Entering costs a full stall_timeout; once engaged, ticks continue
+            // at quantum cadence until master data resumes.
+            if !emitted {
+                let threshold = if fallback_engaged {
+                    quantum_duration
+                } else {
+                    self.cfg.stall_timeout
+                };
+                if self.last_tick.elapsed() >= threshold {
+                    self.emit_tick(self.cfg.quantum_frames, true);
+                    emitted = true;
+                    fallback_engaged = true;
+                }
+            }
+
+            self.trim_all();
+
+            // Terminal condition: every source ended → flush remaining tails
+            // as final ticks, then exit.
+            if self.sources.iter().all(|s| s.ended) {
+                self.flush_tail();
+                break;
+            }
+
+            if !ingested && !emitted {
+                std::thread::sleep(IDLE_SLEEP);
+            }
+        }
+    }
+
+    /// FIFO depth (frames) of the *effective* master: the configured master
+    /// while it lives; after it ends, the clock is re-elected to the first
+    /// live clock-candidate source (system/device — ticks through silence),
+    /// else the first live source. Without re-election an ended master would
+    /// pin the session to wall-clock fallback pacing while `trim_all`
+    /// discards the still-live sources' audio.
+    fn effective_master_frames(&self) -> usize {
+        let configured = self.sources.get(self.cfg.master_index);
+        let master = match configured {
+            Some(s) if !s.ended => Some(s),
+            _ => self
+                .sources
+                .iter()
+                .find(|s| !s.ended && s.spec.clock_candidate)
+                .or_else(|| self.sources.iter().find(|s| !s.ended)),
+        };
+        master.map(|s| s.fifo_frames()).unwrap_or(0)
+    }
+
+    /// Drain pending buffers from every live source into its FIFO.
+    /// Returns `true` if any data moved.
+    fn ingest_all(&mut self) -> bool {
+        let mut moved = false;
+        let session_rate = self.cfg.session_rate();
+        let max_fifo_frames = self.cfg.max_fifo_frames;
+        for s in &mut self.sources {
+            if s.ended {
+                continue;
+            }
+            for _ in 0..MAX_DRAIN_PER_POLL {
+                match s.reader.try_read() {
+                    Ok(Some(buffer)) => {
+                        Self::ingest_buffer(s, buffer, session_rate, max_fifo_frames);
+                        moved = true;
+                    }
+                    Ok(None) => break,
+                    Err(e) if e.is_fatal() => {
+                        log::debug!("compose source ended: {e:?}");
+                        // rsac-fab0: recover the resampler's tail (the final
+                        // partial input chunk + the FFT delay residue) into
+                        // the FIFO *before* marking the source ended, so
+                        // `flush_tail`'s "no captured audio is discarded"
+                        // contract holds for resampled sources too.
+                        if let Some(rs) = s.resampler.as_mut() {
+                            match rs.flush(&mut s.fifo) {
+                                Ok(flushed) => moved |= flushed > 0,
+                                Err(fe) => log::warn!(
+                                    "compose resampler flush failed ({fe}); \
+                                     resampled tail may be truncated"
+                                ),
+                            }
+                        }
+                        s.ended = true;
+                        s.stats.ended.store(true, Ordering::Relaxed);
+                        break;
+                    }
+                    Err(e) => {
+                        // Transient read error: retry on the next pass.
+                        log::warn!("compose source transient read error (retrying): {e:?}");
+                        break;
+                    }
+                }
+            }
+            // rsac-ae4e: refresh the inner capture's own ring-overflow drop
+            // count into the shared stats (a plain load-and-store — the
+            // engine thread is non-RT). Runs on the ending pass too, so the
+            // final value survives the source's end.
+            s.stats
+                .inner_dropped
+                .store(s.reader.overruns(), Ordering::Relaxed);
+        }
+        moved
+    }
+
+    /// Normalize one delivered buffer (channel width, whole frames, then
+    /// rate) and append it to the source FIFO, compensating intra-source
+    /// timestamp gaps with silence (rsac-ae4e).
+    fn ingest_buffer(
+        s: &mut SourceState,
+        buffer: AudioBuffer,
+        session_rate: u32,
+        max_fifo_frames: usize,
+    ) {
+        s.stats.buffers_received.fetch_add(1, Ordering::Relaxed);
+        let buf_channels = buffer.channels().max(1);
+        let buf_rate = buffer.sample_rate().max(1);
+        let timestamp = buffer.timestamp();
+
+        // Lock the source's width on first data (keep-channels sources have it
+        // pre-set from the polled negotiated format).
+        if s.spec.channels == 0 {
+            s.spec.channels = buf_channels;
+        }
+
+        // Channel-width normalization keeps the FIFO stride constant even if a
+        // source's delivery width changes mid-stream (it shouldn't).
+        let data: &[f32] = buffer.data();
+        let adapted: Vec<f32>;
+        let samples: &[f32] = if buf_channels == s.spec.channels {
+            data
+        } else {
+            if !s.warned_channel_adapt {
+                log::warn!(
+                    "compose source delivered {} channels; adapting to its locked width {}",
+                    buf_channels,
+                    s.spec.channels
+                );
+                s.warned_channel_adapt = true;
+            }
+            adapted = adapt_channels(data, buf_channels, s.spec.channels);
+            &adapted
+        };
+
+        // rsac-2195: truncate to whole frames. A dangling partial frame would
+        // rotate this source's channel interleave for the rest of the session
+        // (every later L sample lands in R, and so on). Only a backend bug
+        // can produce one, so warn once — but keep the engine running with
+        // the truncated (correctly interleaved) remainder. Deliberately NOT a
+        // debug_assert: a panic here would divert into the engine's
+        // panic-teardown (rsac-1b83) and kill the whole composition for a
+        // condition the truncation fully recovers from.
+        let ch = usize::from(s.spec.channels.max(1));
+        let usable = samples.len() - samples.len() % ch;
+        if usable != samples.len() && !s.warned_ragged {
+            log::warn!(
+                "compose source delivered a ragged buffer ({} samples, {} channels); \
+                 truncating the dangling partial frame to preserve interleave",
+                samples.len(),
+                ch
+            );
+            s.warned_ragged = true;
+        }
+        let samples = &samples[..usable];
+        let frames_delivered = usable / ch;
+
+        // ── Intra-source gap compensation (rsac-ae4e) ────────────────────
+        // All backends stamp stream-position timestamps where producer-side
+        // ring drops appear as gaps between consecutive stamps. If this
+        // buffer starts past where the previous one ended, the hole is real
+        // lost audio: re-insert it as silence so the source's lane stays
+        // time-aligned instead of permanently compressing. Bounded to the
+        // FIFO cap (scaled to the delivered rate) so a pathological stamp
+        // jump cannot allocate unboundedly — anything larger would be
+        // trimmed straight back out by `trim_all` anyway.
+        let gap_frames_in: u64 = match (timestamp, s.expected_next) {
+            (Some(ts), Some(expected)) if ts > expected + GAP_EPSILON => {
+                let raw = ((ts - expected).as_secs_f64() * f64::from(buf_rate)).round() as u64;
+                let cap = (max_fifo_frames as u128 * u128::from(buf_rate)
+                    / u128::from(session_rate.max(1))) as u64;
+                raw.min(cap.max(1))
+            }
+            _ => 0,
+        };
+        if let Some(ts) = timestamp {
+            // Re-anchor to the delivered stamp every buffer (never accumulate
+            // locally), so expectation and stamps cannot drift apart.
+            s.expected_next = Some(ts + frames_to_duration(frames_delivered as u64, buf_rate));
+        }
+        if gap_frames_in > 0 {
+            s.stats
+                .gap_padded_frames
+                .fetch_add(gap_frames_in, Ordering::Relaxed);
+        }
+
+        if buf_rate == session_rate {
+            // Direct path: the gap silence goes straight into the FIFO ahead
+            // of the buffer's samples (both already at the session rate).
+            if gap_frames_in > 0 {
+                s.fifo
+                    .extend(std::iter::repeat_n(0.0f32, gap_frames_in as usize * ch));
+            }
+            s.fifo.extend(samples.iter().copied());
+            return;
+        }
+
+        // Rate conversion path. (Re)create the resampler if the delivered rate
+        // changed or none exists yet.
+        if s.resampler.is_none() || s.resampler_in_rate != buf_rate {
+            if s.resampler.is_some() {
+                log::warn!(
+                    "compose source input rate changed {} -> {} Hz; rebuilding resampler",
+                    s.resampler_in_rate,
+                    buf_rate
+                );
+            }
+            match StreamResampler::new(buf_rate, session_rate, s.spec.channels) {
+                Ok(rs) => {
+                    s.resampler = Some(rs);
+                    s.resampler_in_rate = buf_rate;
+                    s.stats.resampling.store(true, Ordering::Relaxed);
+                }
+                Err(e) => {
+                    log::error!("compose: cannot resample source ({e}); dropping its data");
+                    return;
+                }
+            }
+        }
+        if let Some(rs) = s.resampler.as_mut() {
+            // Resampled path: the gap silence is fed through the RESAMPLER
+            // INPUT (at the delivered rate) rather than appended to the FIFO
+            // after resampling. This is the simpler *correct* option: the
+            // resampler's cumulative in/out accounting — which makes the
+            // end-of-stream flush trim exact (see `StreamResampler::flush`) —
+            // then counts the gap as ordinary input, and the FIFO receives it
+            // converted at exactly the same ratio as the surrounding audio.
+            // Session-rate silence injected directly into the FIFO would
+            // bypass that accounting and desynchronize the flush-trim math.
+            if gap_frames_in > 0 {
+                let zeros = vec![0.0f32; gap_frames_in as usize * ch];
+                if let Err(e) = rs.push(&zeros, &mut s.fifo) {
+                    log::error!("compose resampler error on gap silence ({e}); gap dropped");
+                }
+            }
+            if let Err(e) = rs.push(samples, &mut s.fifo) {
+                log::error!("compose resampler error ({e}); dropping buffer");
+            }
+        }
+    }
+
+    /// Bound every FIFO: a source drifting ahead of consumption has its oldest
+    /// samples trimmed so latency stays bounded.
+    fn trim_all(&mut self) {
+        for s in &mut self.sources {
+            let frames = s.fifo_frames();
+            if frames > self.cfg.max_fifo_frames {
+                let excess = frames - self.cfg.max_fifo_frames;
+                let drop_samples = excess * usize::from(s.spec.channels);
+                s.fifo.drain(..drop_samples);
+                s.stats
+                    .trimmed_frames
+                    .fetch_add(excess as u64, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// After every source has ended, drain whatever is left in the FIFOs as
+    /// final (possibly partial) ticks so no captured audio is discarded.
+    fn flush_tail(&mut self) {
+        loop {
+            let remaining = self
+                .sources
+                .iter()
+                .map(|s| s.fifo_frames())
+                .max()
+                .unwrap_or(0);
+            if remaining == 0 {
+                break;
+            }
+            let frames = remaining.min(self.cfg.quantum_frames);
+            self.emit_tick(frames, false);
+        }
+    }
+
+    /// Mix one tick of `frames` frames from every source FIFO into a composed
+    /// interleaved buffer and push it into the bridge ring. Sources without
+    /// enough data are zero-padded (counted per source).
+    fn emit_tick(&mut self, frames: usize, fallback: bool) {
+        let total_channels = usize::from(self.cfg.composed_format.channels);
+        let needed = frames * total_channels;
+        if self.out_scratch.len() < needed {
+            self.out_scratch.resize(needed, 0.0);
+        }
+        let out = &mut self.out_scratch[..needed];
+        out.fill(0.0);
+
+        for s in &mut self.sources {
+            let ch = usize::from(s.spec.channels.max(1));
+            let group = &self.cfg.groups[s.spec.group];
+
+            let have_frames = s.fifo_frames();
+            let take = have_frames.min(frames);
+            let pad = frames - take;
+            if pad > 0 {
+                s.stats
+                    .padded_frames
+                    .fetch_add(pad as u64, Ordering::Relaxed);
+            }
+            if take == 0 {
+                continue; // fully padded: contributes silence (already zeroed)
+            }
+
+            // Drain `take` frames into contiguous scratch for strided access.
+            let take_samples = take * ch;
+            self.src_scratch.clear();
+            self.src_scratch
+                .extend(s.fifo.drain(..take_samples.min(s.fifo.len())));
+            let src = &self.src_scratch;
+
+            mix_source_into(
+                out,
+                total_channels,
+                src,
+                ch,
+                take,
+                s.spec.gain,
+                group.layout,
+                group.offset,
+                group.width,
+            );
+        }
+
+        if self.cfg.clamp_output {
+            for v in out.iter_mut() {
+                *v = v.clamp(-1.0, 1.0);
+            }
+        }
+
+        // rsac-2195: stamped, free-list-backed push. Replaces the previous
+        // `AudioBuffer::with_timestamp(out.to_vec(), ..)` — a heap allocation
+        // per tick — plus the engine's own frames-emitted counter and its
+        // Duration math, all of which the producer subsumes: it stamps each
+        // buffer with its stream position from an internal frames-offered
+        // counter with identical semantics (the position advances whether or
+        // not the push succeeds, so drop-on-full still surfaces as a
+        // timestamp gap to the consumer, and drops are still counted in the
+        // composed stream's overrun/backpressure stats).
+        let pushed = self.producer.push_samples_or_drop_stamped(
+            out,
+            self.cfg.composed_format.channels,
+            self.cfg.session_rate(),
+        );
+        if pushed {
+            // rsac-2195: wake a parked blocking reader right now instead of
+            // after the 1 ms WAKE_BACKSTOP_POLL backstop slice. The engine
+            // thread is non-RT — exactly the caller `notify_consumers()` is
+            // documented for (the ADR-0001 prohibition applies only to the
+            // OS audio-callback push paths).
+            self.producer.notify_consumers();
+        }
+
+        self.stats.ticks.fetch_add(1, Ordering::Relaxed);
+        if fallback {
+            self.stats.fallback_ticks.fetch_add(1, Ordering::Relaxed);
+        }
+        self.last_tick = Instant::now();
+    }
+}
+
+/// Best-effort extraction of a human-readable message from a caught panic
+/// payload (`&str` and `String` payloads cover `panic!`/`assert!`/`expect`;
+/// anything else gets a placeholder). Shared by the engine's catch-unwind
+/// teardown and `Composition::stop`'s join-error logging (rsac-1b83).
+pub(crate) fn panic_message(payload: &(dyn std::any::Any + Send)) -> &str {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        s
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.as_str()
+    } else {
+        "<non-string panic payload>"
+    }
+}
+
+/// Stream-position duration of `frames` frames at `rate` Hz — the same
+/// integer-nanosecond math the backends' stamped pushes use, so the engine's
+/// expected-next positions stay in exact lockstep with delivered timestamps
+/// (rsac-ae4e).
+fn frames_to_duration(frames: u64, rate: u32) -> Duration {
+    Duration::from_nanos(((frames as u128 * 1_000_000_000) / u128::from(rate.max(1))) as u64)
+}
+
+/// Mix `take` frames of one source (interleaved `src`, `src_ch` wide) into the
+/// composed output slice according to the group layout.
+#[allow(clippy::too_many_arguments)]
+fn mix_source_into(
+    out: &mut [f32],
+    total_channels: usize,
+    src: &[f32],
+    src_ch: usize,
+    take: usize,
+    gain: f32,
+    layout: GroupLayout,
+    offset: usize,
+    width: usize,
+) {
+    match layout {
+        GroupLayout::Mono => {
+            for f in 0..take {
+                let frame = &src[f * src_ch..(f + 1) * src_ch];
+                let mono = frame.iter().sum::<f32>() / src_ch as f32;
+                out[f * total_channels + offset] += gain * mono;
+            }
+        }
+        GroupLayout::Stereo => match src_ch {
+            1 => {
+                for f in 0..take {
+                    let v = gain * src[f];
+                    out[f * total_channels + offset] += v;
+                    out[f * total_channels + offset + 1] += v;
+                }
+            }
+            2 => {
+                for f in 0..take {
+                    out[f * total_channels + offset] += gain * src[f * 2];
+                    out[f * total_channels + offset + 1] += gain * src[f * 2 + 1];
+                }
+            }
+            n => {
+                // Fold wider sources even→L / odd→R (per-side mean).
+                let left_n = n.div_ceil(2) as f32;
+                let right_n = (n / 2).max(1) as f32;
+                for f in 0..take {
+                    let frame = &src[f * n..(f + 1) * n];
+                    let (mut l, mut r) = (0.0f32, 0.0f32);
+                    for (c, &v) in frame.iter().enumerate() {
+                        if c % 2 == 0 {
+                            l += v;
+                        } else {
+                            r += v;
+                        }
+                    }
+                    out[f * total_channels + offset] += gain * l / left_n;
+                    out[f * total_channels + offset + 1] += gain * r / right_n;
+                }
+            }
+        },
+        GroupLayout::KeepChannels => {
+            // Pass native channels through; if the locked width diverged from
+            // the group width (shouldn't happen), truncate/zero-pad per frame.
+            let copy = src_ch.min(width);
+            for f in 0..take {
+                let frame = &src[f * src_ch..(f + 1) * src_ch];
+                let out_frame = &mut out[f * total_channels + offset..];
+                for c in 0..copy {
+                    out_frame[c] += gain * frame[c];
+                }
+            }
+        }
+    }
+}
+
+/// Convert interleaved samples from `from` channels to `to` channels per
+/// frame: shared channels copy through, extra target channels are silence,
+/// extra source channels are discarded. (Used only to keep a source's FIFO
+/// stride constant if its delivery width changes mid-stream; group mixdown
+/// handles the real fold.)
+fn adapt_channels(data: &[f32], from: u16, to: u16) -> Vec<f32> {
+    let (from, to) = (usize::from(from.max(1)), usize::from(to.max(1)));
+    let frames = data.len() / from;
+    let mut out = vec![0.0f32; frames * to];
+    let copy = from.min(to);
+    for f in 0..frames {
+        out[f * to..f * to + copy].copy_from_slice(&data[f * from..f * from + copy]);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adapt_channels_widen_and_narrow() {
+        // 2ch -> 1ch: keeps channel 0.
+        let stereo = [1.0, 2.0, 3.0, 4.0];
+        assert_eq!(adapt_channels(&stereo, 2, 1), vec![1.0, 3.0]);
+        // 1ch -> 2ch: channel 1 is silence.
+        assert_eq!(adapt_channels(&[5.0, 6.0], 1, 2), vec![5.0, 0.0, 6.0, 0.0]);
+    }
+
+    #[test]
+    fn mix_mono_layout_folds_and_sums() {
+        // 2 output channels total; mono group at offset 1.
+        let mut out = vec![0.0f32; 2 * 2];
+        let src = [1.0f32, 3.0, 5.0, 7.0]; // stereo source, 2 frames
+        mix_source_into(&mut out, 2, &src, 2, 2, 0.5, GroupLayout::Mono, 1, 1);
+        // frame 0: mean(1,3)=2 * 0.5 = 1.0 → out[1]; frame 1: mean(5,7)=6*0.5=3.0 → out[3]
+        assert_eq!(out, vec![0.0, 1.0, 0.0, 3.0]);
+    }
+
+    #[test]
+    fn mix_stereo_layout_mono_source_duplicates() {
+        let mut out = vec![0.0f32; 2 * 2];
+        let src = [0.25f32, 0.5];
+        mix_source_into(&mut out, 2, &src, 1, 2, 2.0, GroupLayout::Stereo, 0, 2);
+        assert_eq!(out, vec![0.5, 0.5, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn mix_stereo_layout_folds_wide_source() {
+        // 4-channel source folded to stereo: L = mean(c0,c2), R = mean(c1,c3).
+        let mut out = vec![0.0f32; 2];
+        let src = [1.0f32, 2.0, 3.0, 4.0]; // one frame
+        mix_source_into(&mut out, 2, &src, 4, 1, 1.0, GroupLayout::Stereo, 0, 2);
+        assert_eq!(out, vec![2.0, 3.0]);
+    }
+
+    #[test]
+    fn mix_keep_channels_passthrough_with_gain() {
+        let mut out = vec![0.0f32; 3]; // 3 output channels, 1 frame
+        let src = [1.0f32, -1.0]; // stereo frame
+        mix_source_into(
+            &mut out,
+            3,
+            &src,
+            2,
+            1,
+            0.5,
+            GroupLayout::KeepChannels,
+            1,
+            2,
+        );
+        assert_eq!(out, vec![0.0, 0.5, -0.5]);
+    }
+
+    #[test]
+    fn mix_sums_two_sources_into_same_group() {
+        let mut out = vec![0.0f32; 1];
+        mix_source_into(&mut out, 1, &[0.25], 1, 1, 1.0, GroupLayout::Mono, 0, 1);
+        mix_source_into(&mut out, 1, &[0.5], 1, 1, 0.5, GroupLayout::Mono, 0, 1);
+        assert!((out[0] - 0.5).abs() < 1e-6, "0.25 + 0.25 = {}", out[0]);
+    }
+}

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -1,0 +1,123 @@
+//! Multi-source channel composition (ADR-0011, opt-in `compose` feature).
+//!
+//! This module composes **multiple capture sources into one multi-channel
+//! stream**. Sources are declared in *groups*; each group contributes a fixed
+//! set of output channels:
+//!
+//! - [`GroupLayout::Mono`] — every source in the group is folded to mono and
+//!   gain-weighted-summed into **1** output channel.
+//! - [`GroupLayout::Stereo`] — every source is folded to stereo (mono sources
+//!   are duplicated to L/R, >2-channel sources are even/odd-averaged) and
+//!   summed into **2** output channels.
+//! - [`GroupLayout::KeepChannels`] — the group's single source passes its
+//!   native channels through unchanged (v1: exactly one source per
+//!   keep-channels group).
+//!
+//! Groups append **in declaration order** into one interleaved-f32 frame; the
+//! [`ChannelMap`] reports which output channel belongs to which group.
+//!
+//! # Rate alignment
+//!
+//! Every source is delivered at whatever rate its backend negotiated (e.g.
+//! Windows process loopback cannot autoconvert). Sources whose delivered rate
+//! differs from the session rate (default 48 kHz) are resampled with `rubato`
+//! on the dedicated compositor thread — never on an OS callback thread
+//! (ADR-0001 is untouched).
+//!
+//! # Pacing model (master clock + silence padding)
+//!
+//! One source is the **master clock**: the first source (in declaration order)
+//! targeting [`CaptureTarget::SystemDefault`] or [`CaptureTarget::Device`]
+//! (device clocks tick through silence; application taps go quiet when the app
+//! stops playing), else the first source overall. The composed stream emits a
+//! fixed-size tick whenever the master has accumulated a quantum of frames.
+//! At each tick, sources that are *behind* are **silence-padded** and sources
+//! drifting *ahead* are **bounded-trimmed**; per-source
+//! [`SourceStats::padded_frames`] / [`SourceStats::trimmed_frames`] counters
+//! expose both. If the master itself stalls past
+//! [`CompositionBuilder::stall_timeout`], a wall-clock fallback tick keeps the
+//! session alive.
+//!
+//! # Timestamps and intra-source gap fidelity
+//!
+//! All three backends stamp every delivered buffer with a **stream-position
+//! timestamp** (frames delivered ÷ rate), and a producer-side ring drop
+//! advances the stamp without delivering frames — so lost audio appears as a
+//! *gap* between consecutive stamps. The engine uses those stamps for
+//! **intra-source gap compensation**: a stamp jumping past the expected next
+//! position has the missing span re-inserted as silence (counted in
+//! [`SourceStats::gap_padded_frames`]), so an inner ring overflow shows up as
+//! a hole in that source's channels instead of permanently time-compressing
+//! its lane against the others. Buffers without timestamps are ingested
+//! as-is. **Cross-source** alignment still uses the master-clock pacing
+//! described above; refining it against per-backend device clocks (wall-time
+//! alignment) remains future work (`rsac-ec25`).
+//!
+//! # Delivery contract
+//!
+//! [`Composition`] implements the same [`CapturingStream`] contract as a
+//! single capture — the composed buffers flow through the standard bridge
+//! ring, so terminal semantics (ADR-0003), overrun counters, backpressure
+//! reporting, and (with the `async-stream` feature) waker registration all
+//! behave exactly like a plain [`AudioCapture`](crate::api::AudioCapture).
+//!
+//! The composition **owns the consumption of its inner captures** (a bridge
+//! ring has a single logical consumer): do not read the composed sources
+//! through any other handle while a composition runs.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use rsac::compose::{CompositionBuilder, Group, GroupLayout};
+//! use rsac::core::config::CaptureTarget;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut session = CompositionBuilder::new()
+//!     .sample_rate(48000)
+//!     .group(
+//!         Group::new("voice")
+//!             .source(CaptureTarget::ApplicationByName("discord".into()))
+//!             .source_with_gain(CaptureTarget::ApplicationByName("zoom".into()), 0.8)
+//!             .mixdown(GroupLayout::Mono), // → 1 channel
+//!     )
+//!     .group(
+//!         Group::new("system")
+//!             .source(CaptureTarget::SystemDefault)
+//!             .keep_channels(), // → source's native channels
+//!     )
+//!     .build()?;
+//!
+//! session.start()?;
+//! let map = session.channel_map().expect("started");
+//! println!("composed {} channels: {:?}", map.channels(), map);
+//! loop {
+//!     match session.read_chunk_nonblocking() {
+//!         // interleaved f32, `map.channels()` channels @ 48 kHz
+//!         Ok(Some(buffer)) => { let _ = buffer.num_frames(); }
+//!         // No data *yet* — not end-of-stream; poll again shortly.
+//!         Ok(None) => std::thread::sleep(std::time::Duration::from_millis(1)),
+//!         // Fatal terminal (composition ended and drained) ends the loop.
+//!         Err(e) if e.is_fatal() => break,
+//!         // Transient errors are retryable.
+//!         Err(e) => eprintln!("transient read error: {e}"),
+//!     }
+//! }
+//! session.stop()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [`CaptureTarget::SystemDefault`]: crate::core::config::CaptureTarget::SystemDefault
+//! [`CaptureTarget::Device`]: crate::core::config::CaptureTarget::Device
+//! [`CapturingStream`]: crate::core::interface::CapturingStream
+
+mod builder;
+mod engine;
+mod resample;
+mod stream;
+
+#[cfg(test)]
+mod tests;
+
+pub use builder::{ChannelMap, ChannelOrigin, CompositionBuilder, Group, GroupLayout};
+pub use stream::{Composition, CompositionStats, SourceStats};

--- a/src/compose/resample.rs
+++ b/src/compose/resample.rs
@@ -1,0 +1,431 @@
+//! Streaming per-source resampler: wraps `rubato`'s synchronous FFT resampler
+//! to convert a source's delivered rate to the composition session rate.
+//!
+//! Runs exclusively on the compositor thread (non-RT — allocation is fine
+//! here; ADR-0001 concerns the OS callback threads, which this code never
+//! touches). Input and output are interleaved f32, adapted for rubato via
+//! `audioadapter`'s [`InterleavedSlice`].
+
+use std::collections::VecDeque;
+
+use audioadapter_buffers::direct::InterleavedSlice;
+use rubato::{Fft, FixedSync, Indexing, Resampler};
+
+use crate::core::error::{AudioError, AudioResult};
+
+/// Fixed input chunk size (frames) fed to the FFT resampler. A middle-ground
+/// per rubato's guidance ("a few hundred to a few thousand frames"); the
+/// wrapper buffers arbitrary-size pushes into chunks of this size.
+const CHUNK_FRAMES: usize = 1024;
+
+/// Streaming rate converter for one source (fixed channel count).
+pub(crate) struct StreamResampler {
+    inner: Fft<f32>,
+    channels: usize,
+    /// Input (delivered) rate in Hz — with `to_rate`, drives the exact
+    /// output-length accounting in [`flush`](Self::flush).
+    from_rate: u32,
+    /// Output (session) rate in Hz.
+    to_rate: u32,
+    /// Interleaved input samples not yet consumed by the resampler.
+    pending: Vec<f32>,
+    /// Interleaved output scratch, sized for the resampler's max output chunk.
+    out_scratch: Vec<f32>,
+    /// Leading output frames still to swallow (the resampler's algorithmic
+    /// delay is silence we trim so composition alignment isn't skewed by it).
+    delay_frames_remaining: usize,
+    /// Cumulative input frames accepted by [`push`](Self::push) (including
+    /// any still buffered in `pending`). The stream owes exactly
+    /// `round(frames_in * to/from)` output frames in total — the target
+    /// [`flush`](Self::flush) trims to (rsac-fab0).
+    frames_in: u64,
+    /// Cumulative output frames emitted (after the algorithmic-delay skip).
+    frames_out: u64,
+    /// Set once [`flush`](Self::flush) has run; a flushed resampler emits
+    /// nothing further (flush is idempotent).
+    flushed: bool,
+}
+
+impl std::fmt::Debug for StreamResampler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamResampler")
+            .field("channels", &self.channels)
+            .field("pending_samples", &self.pending.len())
+            .field("delay_frames_remaining", &self.delay_frames_remaining)
+            .field("frames_in", &self.frames_in)
+            .field("frames_out", &self.frames_out)
+            .field("flushed", &self.flushed)
+            .finish()
+    }
+}
+
+impl StreamResampler {
+    /// Creates a resampler converting `from_rate` → `to_rate` for `channels`
+    /// interleaved channels.
+    pub fn new(from_rate: u32, to_rate: u32, channels: u16) -> AudioResult<Self> {
+        let channels = usize::from(channels.max(1));
+        let inner = Fft::<f32>::new(
+            from_rate as usize,
+            to_rate as usize,
+            CHUNK_FRAMES,
+            2,
+            channels,
+            FixedSync::Input,
+        )
+        .map_err(|e| AudioError::ConfigurationError {
+            message: format!(
+                "Failed to create resampler {from_rate} Hz -> {to_rate} Hz ({channels} ch): {e}"
+            ),
+        })?;
+        let max_out_frames = inner.output_frames_max();
+        let delay = inner.output_delay();
+        Ok(Self {
+            inner,
+            channels,
+            from_rate: from_rate.max(1),
+            to_rate: to_rate.max(1),
+            pending: Vec::with_capacity(CHUNK_FRAMES * channels * 2),
+            out_scratch: vec![0.0; max_out_frames.max(1) * channels],
+            delay_frames_remaining: delay,
+            frames_in: 0,
+            frames_out: 0,
+            flushed: false,
+        })
+    }
+
+    /// Feeds interleaved input samples and appends resampled interleaved
+    /// output samples to `out`. Input that doesn't yet fill a full resampler
+    /// chunk is buffered internally for the next call.
+    pub fn push(&mut self, interleaved: &[f32], out: &mut VecDeque<f32>) -> AudioResult<()> {
+        self.frames_in += (interleaved.len() / self.channels) as u64;
+        self.pending.extend_from_slice(interleaved);
+
+        loop {
+            let need = self.inner.input_frames_next();
+            let have = self.pending.len() / self.channels;
+            if have < need {
+                return Ok(());
+            }
+
+            let input = InterleavedSlice::new(self.pending.as_slice(), self.channels, have)
+                .map_err(|e| AudioError::InternalError {
+                    message: format!("resampler input adapter: {e}"),
+                    source: None,
+                })?;
+            let out_capacity = self.out_scratch.len() / self.channels;
+            let mut output = InterleavedSlice::new_mut(
+                self.out_scratch.as_mut_slice(),
+                self.channels,
+                out_capacity,
+            )
+            .map_err(|e| AudioError::InternalError {
+                message: format!("resampler output adapter: {e}"),
+                source: None,
+            })?;
+            let indexing = Indexing {
+                input_offset: 0,
+                output_offset: 0,
+                active_channels_mask: None,
+                partial_len: None,
+            };
+
+            let (consumed_frames, produced_frames) = self
+                .inner
+                .process_into_buffer(&input, &mut output, Some(&indexing))
+                .map_err(|e| AudioError::InternalError {
+                    message: format!("resampler process failed: {e}"),
+                    source: None,
+                })?;
+
+            // Swallow the algorithmic-delay prefix, then forward the rest.
+            let skip = self.delay_frames_remaining.min(produced_frames);
+            self.delay_frames_remaining -= skip;
+            out.extend(&self.out_scratch[skip * self.channels..produced_frames * self.channels]);
+            self.frames_out += (produced_frames - skip) as u64;
+
+            self.pending.drain(..consumed_frames * self.channels);
+        }
+    }
+
+    /// Drains everything the resampler still owes at end-of-stream
+    /// (rsac-fab0): the final partial input chunk buffered in `pending` plus
+    /// the FFT algorithmic-delay residue that [`push`](Self::push) swallows
+    /// at the front.
+    ///
+    /// [`push`](Self::push) only processes full `CHUNK_FRAMES` input chunks,
+    /// so at a source's natural end up to `CHUNK_FRAMES − 1` input frames sit
+    /// unprocessed in `pending`, and `output_delay()` frames of real audio
+    /// are still inside the FFT pipeline (the whole signal is time-shifted
+    /// behind the delay prefix trimmed off the front). Dropping both loses
+    /// ~25–45 ms per resampled source and violates the engine's flush-tail
+    /// contract ("no captured audio is discarded").
+    ///
+    /// Mechanism — mirrors rubato's own `process_all_into_buffer` tail
+    /// handling:
+    ///
+    /// 1. Process `pending` as a partial chunk via rubato v3's
+    ///    `Indexing { partial_len: Some(valid_frames), .. }` (rubato
+    ///    zero-pads the rest of the chunk internally).
+    /// 2. Pump all-zero chunks (`partial_len: Some(0)`) to expel the
+    ///    remaining delay residue.
+    /// 3. Trim so cumulative output == `round(frames_in * to/from)` — exact
+    ///    by construction from the `frames_in`/`frames_out` counters; the
+    ///    surplus beyond that is resampler-internal zero padding, not
+    ///    captured audio.
+    ///
+    /// Appends the flushed interleaved samples to `out` and returns the
+    /// number of *frames* appended. Idempotent: a second call emits nothing
+    /// and returns 0.
+    pub fn flush(&mut self, out: &mut VecDeque<f32>) -> AudioResult<usize> {
+        if self.flushed {
+            return Ok(0);
+        }
+        self.flushed = true;
+
+        // Total output the input stream owes: round(frames_in * to/from).
+        let expected_total = ((self.frames_in as u128 * u128::from(self.to_rate)
+            + u128::from(self.from_rate) / 2)
+            / u128::from(self.from_rate)) as u64;
+        let start = self.frames_out;
+
+        // Safety bound on the pump loop. The shortfall is at most
+        // `output_delay()` plus one output chunk, and every pass produces on
+        // the order of `CHUNK_FRAMES * to/from` frames, so a handful of
+        // passes always suffices; 64 is far beyond any real delay and turns
+        // a logic regression into a truncated-tail warning instead of an
+        // infinite loop on the compositor thread.
+        const MAX_FLUSH_PASSES: usize = 64;
+
+        let mut first = true;
+        let mut passes = 0usize;
+        while self.frames_out < expected_total {
+            if passes >= MAX_FLUSH_PASSES {
+                log::warn!(
+                    "resampler flush did not converge after {MAX_FLUSH_PASSES} passes \
+                     ({} of {} frames emitted); tail truncated",
+                    self.frames_out,
+                    expected_total
+                );
+                break;
+            }
+            passes += 1;
+
+            // First pass processes the buffered partial chunk; later passes
+            // feed pure zero-padding (partial_len == 0) to expel the delay.
+            let partial_frames = if first {
+                self.pending.len() / self.channels
+            } else {
+                0
+            };
+            first = false;
+
+            let input = InterleavedSlice::new(
+                &self.pending[..partial_frames * self.channels],
+                self.channels,
+                partial_frames,
+            )
+            .map_err(|e| AudioError::InternalError {
+                message: format!("resampler flush input adapter: {e}"),
+                source: None,
+            })?;
+            let out_capacity = self.out_scratch.len() / self.channels;
+            let mut output = InterleavedSlice::new_mut(
+                self.out_scratch.as_mut_slice(),
+                self.channels,
+                out_capacity,
+            )
+            .map_err(|e| AudioError::InternalError {
+                message: format!("resampler flush output adapter: {e}"),
+                source: None,
+            })?;
+            let indexing = Indexing {
+                input_offset: 0,
+                output_offset: 0,
+                active_channels_mask: None,
+                partial_len: Some(partial_frames),
+            };
+
+            let (_consumed_frames, produced_frames) = self
+                .inner
+                .process_into_buffer(&input, &mut output, Some(&indexing))
+                .map_err(|e| AudioError::InternalError {
+                    message: format!("resampler flush process failed: {e}"),
+                    source: None,
+                })?;
+
+            // Same delay-skip as `push`, plus the end-trim: never emit past
+            // what the input actually owes.
+            let skip = self.delay_frames_remaining.min(produced_frames);
+            self.delay_frames_remaining -= skip;
+            let mut emit = produced_frames - skip;
+            let owed = (expected_total - self.frames_out) as usize;
+            if emit > owed {
+                emit = owed;
+            }
+            out.extend(&self.out_scratch[skip * self.channels..(skip + emit) * self.channels]);
+            self.frames_out += emit as u64;
+        }
+        self.pending.clear();
+        Ok((self.frames_out - start) as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feed a sine at `freq` Hz through the resampler and verify the output
+    /// still contains that tone (Goertzel power dominance) at the new rate.
+    fn goertzel_power(samples: &[f32], sample_rate: f32, freq: f32) -> f32 {
+        let n = samples.len() as f32;
+        let k = (0.5 + n * freq / sample_rate).floor();
+        let w = 2.0 * std::f32::consts::PI * k / n;
+        let coeff = 2.0 * w.cos();
+        let (mut s_prev, mut s_prev2) = (0.0f32, 0.0f32);
+        for &x in samples {
+            let s = x + coeff * s_prev - s_prev2;
+            s_prev2 = s_prev;
+            s_prev = s;
+        }
+        s_prev2 * s_prev2 + s_prev * s_prev - coeff * s_prev * s_prev2
+    }
+
+    fn sine_interleaved(freq: f32, rate: u32, channels: usize, frames: usize) -> Vec<f32> {
+        let mut data = Vec::with_capacity(frames * channels);
+        for f in 0..frames {
+            let t = f as f32 / rate as f32;
+            let v = (2.0 * std::f32::consts::PI * freq * t).sin() * 0.5;
+            for _ in 0..channels {
+                data.push(v);
+            }
+        }
+        data
+    }
+
+    fn run_case(from: u32, to: u32) {
+        let channels = 2usize;
+        let freq = 440.0f32;
+        let input_frames = from as usize; // 1 second of input
+        let input = sine_interleaved(freq, from, channels, input_frames);
+
+        let mut rs = StreamResampler::new(from, to, channels as u16).expect("create");
+        let mut out = VecDeque::new();
+        // Push in awkward, uneven chunks to exercise the internal buffering.
+        for chunk in input.chunks(1234 * channels) {
+            rs.push(chunk, &mut out).expect("push");
+        }
+
+        let out: Vec<f32> = out.into_iter().collect();
+        let out_frames = out.len() / channels;
+        let expected = (input_frames as f64 * to as f64 / from as f64) as usize;
+        // FixedInput mode retains up to a chunk internally; allow that slack.
+        assert!(
+            out_frames > expected.saturating_sub(3 * CHUNK_FRAMES),
+            "{from}->{to}: produced {out_frames} frames, expected ~{expected}"
+        );
+
+        // Mono-ize channel 0 and check the 440 Hz tone dominates 1 kHz.
+        let ch0: Vec<f32> = out.iter().step_by(channels).copied().collect();
+        // Skip any residual leading transient.
+        let steady = &ch0[ch0.len() / 4..];
+        let p_tone = goertzel_power(steady, to as f32, freq);
+        let p_other = goertzel_power(steady, to as f32, 1000.0);
+        assert!(
+            p_tone > 10.0 * p_other.max(f32::EPSILON),
+            "{from}->{to}: tone power {p_tone} not dominant over {p_other}"
+        );
+    }
+
+    #[test]
+    fn resamples_44100_to_48000() {
+        run_case(44_100, 48_000);
+    }
+
+    #[test]
+    fn resamples_48000_to_44100() {
+        run_case(48_000, 44_100);
+    }
+
+    #[test]
+    fn small_pushes_buffer_until_chunk() {
+        let mut rs = StreamResampler::new(44_100, 48_000, 1).expect("create");
+        let mut out = VecDeque::new();
+        // Fewer than CHUNK_FRAMES total → nothing can be produced yet.
+        rs.push(&[0.1; 100], &mut out).expect("push");
+        assert!(out.is_empty(), "sub-chunk input must be buffered");
+        // Topping it past the chunk size produces output.
+        rs.push(&vec![0.1; CHUNK_FRAMES], &mut out).expect("push");
+        assert!(!out.is_empty(), "full chunk must produce output");
+    }
+
+    /// rsac-fab0: `flush` must recover BOTH the buffered partial input chunk
+    /// and the FFT algorithmic-delay residue, converging on exactly
+    /// `round(frames_in * to/from)` cumulative output frames.
+    #[test]
+    fn flush_recovers_partial_chunk_and_delay_tail() {
+        let (from, to) = (44_100u32, 48_000u32);
+        let input_frames = 5000usize; // deliberately NOT a multiple of 1024
+        let input = sine_interleaved(440.0, from, 1, input_frames);
+
+        let mut rs = StreamResampler::new(from, to, 1).expect("create");
+        let mut out = VecDeque::new();
+        rs.push(&input, &mut out).expect("push");
+        let before_flush = out.len();
+        let flushed = rs.flush(&mut out).expect("flush");
+
+        let expected =
+            (input_frames as u64 * u64::from(to) + u64::from(from) / 2) / u64::from(from);
+        assert_eq!(
+            out.len() as u64,
+            expected,
+            "cumulative output must be exactly round(in * to/from)"
+        );
+        assert_eq!(
+            flushed,
+            out.len() - before_flush,
+            "flush must report the frames it appended"
+        );
+        // The tail was previously abandoned entirely (partial chunk + delay
+        // residue) — the whole point of flush is that it is nonzero.
+        assert!(flushed > 0, "flush must recover a nonzero tail");
+
+        // The recovered tail is real audio (the end of the sine), not the
+        // resampler's internal zero padding.
+        let tail: Vec<f32> = out.iter().rev().take(128).copied().collect();
+        let energy: f32 = tail.iter().map(|v| v * v).sum();
+        assert!(
+            energy > 1e-3,
+            "flushed tail must carry the sine's energy, got {energy}"
+        );
+
+        // Idempotent: a second flush emits nothing.
+        let mut extra = VecDeque::new();
+        assert_eq!(rs.flush(&mut extra).expect("re-flush"), 0);
+        assert!(extra.is_empty(), "re-flush must not emit");
+    }
+
+    /// The exact-length accounting also holds when downsampling and when the
+    /// input arrives in awkward uneven pushes (stereo).
+    #[test]
+    fn flush_exact_length_downsampling_stereo() {
+        let (from, to) = (48_000u32, 44_100u32);
+        let channels = 2usize;
+        let input_frames = 4321usize;
+        let input = sine_interleaved(300.0, from, channels, input_frames);
+
+        let mut rs = StreamResampler::new(from, to, channels as u16).expect("create");
+        let mut out = VecDeque::new();
+        for chunk in input.chunks(777 * channels) {
+            rs.push(chunk, &mut out).expect("push");
+        }
+        rs.flush(&mut out).expect("flush");
+
+        let expected =
+            (input_frames as u64 * u64::from(to) + u64::from(from) / 2) / u64::from(from);
+        assert_eq!(
+            (out.len() / channels) as u64,
+            expected,
+            "cumulative output frames must be exactly round(in * to/from)"
+        );
+    }
+}

--- a/src/compose/stream.rs
+++ b/src/compose/stream.rs
@@ -1,0 +1,1027 @@
+//! The public composition handle: [`Composition`], its stats snapshots, and
+//! the `PlatformStream` shim that plugs the compositor into the standard
+//! bridge ring.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::api::AudioCaptureBuilder;
+use crate::bridge::ring_buffer::create_bridge;
+use crate::bridge::state::StreamState;
+use crate::bridge::stream::{BridgeStream, PlatformStream};
+use crate::core::buffer::AudioBuffer;
+use crate::core::config::{AudioFormat, SampleFormat};
+use crate::core::error::{AudioError, AudioResult};
+use crate::core::interface::CapturingStream;
+
+use super::builder::{
+    ChannelMap, ChannelOrigin, CompositionPlan, GroupLayout, MAX_COMPOSED_CHANNELS,
+};
+use super::engine::{
+    Engine, EngineConfig, EngineStatsShared, GroupSpec, SourceReader, SourceSpec, SourceStatsShared,
+};
+
+/// How long `start()` polls a keep-channels source for its negotiated format
+/// before falling back to the requested channel count.
+const FORMAT_POLL_TIMEOUT: Duration = Duration::from_secs(2);
+const FORMAT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Ring capacity (in composed buffers) between the compositor thread and the
+/// consumer. At the default 10 ms quantum this buffers ~1.3 s of audio.
+const COMPOSED_RING_CAPACITY: usize = 128;
+
+// ── PlatformStream shim ─────────────────────────────────────────────────
+
+/// The compositor's `PlatformStream`: "stopping the OS capture" means telling
+/// the engine thread to stop (which stops every inner capture and signals the
+/// composed ring done).
+pub(crate) struct ComposePlatformStream {
+    stop_flag: Arc<AtomicBool>,
+    active: Arc<AtomicBool>,
+}
+
+impl ComposePlatformStream {
+    pub(crate) fn new(stop_flag: Arc<AtomicBool>, active: Arc<AtomicBool>) -> Self {
+        Self { stop_flag, active }
+    }
+}
+
+impl PlatformStream for ComposePlatformStream {
+    fn stop_capture(&self) -> AudioResult<()> {
+        self.stop_flag.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn is_active(&self) -> bool {
+        self.active.load(Ordering::SeqCst)
+    }
+}
+
+// ── Real capture-backed SourceReader ────────────────────────────────────
+
+/// Wraps a started `AudioCapture` as an engine source. Uses the
+/// terminal-observable read path so the engine sees `StreamEnded` (fatal)
+/// instead of a masked recoverable error.
+struct CaptureSource {
+    capture: crate::api::AudioCapture,
+}
+
+impl SourceReader for CaptureSource {
+    fn try_read(&mut self) -> AudioResult<Option<AudioBuffer>> {
+        self.capture.read_chunk_nonblocking()
+    }
+
+    fn stop(&mut self) {
+        let _ = self.capture.stop();
+    }
+
+    fn overruns(&self) -> u64 {
+        // rsac-ae4e: the inner capture's own ring-overflow drop count — audio
+        // lost before the compositor ever saw it. The engine snapshots this
+        // into `SourceStats::inner_dropped` so composed consumers can tell
+        // WHICH source is losing data upstream (the loss itself surfaces in
+        // the output as timestamp-gap silence, see `gap_padded_frames`).
+        self.capture.overrun_count()
+    }
+}
+
+// ── Composed stream view (drain-complete promotion) ─────────────────────
+
+/// The composed stream all consumer paths read through.
+///
+/// Wraps the bridge stream with one extra rule the engine makes possible: the
+/// compositor knows when **no more data can ever arrive** (every source ended
+/// and the tail was flushed before the engine exited). The platform backends
+/// cannot know this — their graceful end (`signal_done`) parks the stream in
+/// the drainable `Stopping` state forever. Here, once the engine has exited
+/// (`engine_active == false`) *and* the ring is observed empty, the view
+/// promotes `Stopping → Stopped` and surfaces the fatal
+/// [`AudioError::StreamEnded`] — so read loops, `drain_to`, and async
+/// consumers all end on their own after a composition finishes (ADR-0003
+/// drain-before-terminal is preserved: the promotion only fires on an empty
+/// ring).
+pub(crate) struct ComposedStreamView {
+    stream: BridgeStream<ComposePlatformStream>,
+    engine_active: Arc<AtomicBool>,
+}
+
+impl ComposedStreamView {
+    pub(crate) fn new(
+        stream: BridgeStream<ComposePlatformStream>,
+        engine_active: Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            stream,
+            engine_active,
+        }
+    }
+}
+
+impl CapturingStream for ComposedStreamView {
+    fn read_chunk(&self) -> AudioResult<AudioBuffer> {
+        loop {
+            // Fast path + drain-complete promotion.
+            match self.try_read_chunk() {
+                Ok(Some(buffer)) => return Ok(buffer),
+                Ok(None) => {}
+                Err(e) => return Err(e),
+            }
+            // Park on the inner blocking read; a Timeout re-runs the promotion
+            // check (an engine exit mid-park surfaces within one timeout slice).
+            match self.stream.read_chunk() {
+                Ok(buffer) => return Ok(buffer),
+                Err(AudioError::Timeout { .. }) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    fn try_read_chunk(&self) -> AudioResult<Option<AudioBuffer>> {
+        // Sample the engine-liveness flag BEFORE reading the ring. The engine
+        // flips it to inactive only AFTER its final pushes + signal_done(), so
+        // "inactive observed first, then the ring read back empty" proves the
+        // ring is truly drained. Sampling in the other order is a TOCTOU: the
+        // engine's final flush could land between an empty pop and the flag
+        // load, and the promotion below would strand that tail unreadable.
+        let inactive_before_read = !self.engine_active.load(Ordering::SeqCst);
+        match self.stream.try_read_chunk() {
+            // Empty ring + engine already exited before the read → nothing can
+            // ever arrive: promote the graceful Stopping to terminal Stopped
+            // (idempotent CAS; a failed CAS means another reader already
+            // promoted) and report the clean end-of-stream.
+            Ok(None) if inactive_before_read => {
+                let _ = self
+                    .stream
+                    .shared()
+                    .state
+                    .transition(StreamState::Stopping, StreamState::Stopped);
+                Err(AudioError::StreamEnded {
+                    reason: "Composition ended (all sources terminal, ring drained)".to_string(),
+                })
+            }
+            other => other,
+        }
+    }
+
+    fn stop(&self) -> AudioResult<()> {
+        self.stream.stop()
+    }
+
+    fn format(&self) -> AudioFormat {
+        self.stream.format()
+    }
+
+    fn is_running(&self) -> bool {
+        self.stream.is_running()
+    }
+
+    fn overrun_count(&self) -> u64 {
+        self.stream.overrun_count()
+    }
+
+    fn buffers_captured(&self) -> u64 {
+        self.stream.buffers_captured()
+    }
+
+    fn buffers_pushed(&self) -> u64 {
+        self.stream.buffers_pushed()
+    }
+
+    fn buffers_dropped(&self) -> u64 {
+        CapturingStream::buffers_dropped(&self.stream)
+    }
+
+    fn is_under_backpressure(&self) -> bool {
+        self.stream.is_under_backpressure()
+    }
+
+    fn drop_window_snapshot(&self) -> (u64, u64) {
+        self.stream.drop_window_snapshot()
+    }
+
+    #[cfg(feature = "async-stream")]
+    fn register_waker(&self, waker: &std::task::Waker) -> bool {
+        self.stream.register_waker(waker)
+    }
+
+    #[cfg(feature = "async-stream")]
+    fn is_stream_producing(&self) -> bool {
+        self.stream.is_stream_producing()
+    }
+}
+
+// ── Shared pipeline assembly ────────────────────────────────────────────
+
+/// The composed data plane: producer half for the engine, consumer view for
+/// the public handle, and the engine lifecycle flags.
+pub(crate) struct ComposedPipeline {
+    pub producer: crate::bridge::ring_buffer::BridgeProducer,
+    pub view: Arc<ComposedStreamView>,
+    pub stop_flag: Arc<AtomicBool>,
+    pub active: Arc<AtomicBool>,
+}
+
+/// Assembles the composed bridge ring + stream view exactly once, shared by
+/// `Composition::start()` and the engine test harness so the tests exercise
+/// the production wiring (negotiated-format recording, state transition,
+/// platform-stream flags) rather than a hand-rolled copy that can drift.
+pub(crate) fn assemble_pipeline(
+    composed_format: AudioFormat,
+    ring_capacity: usize,
+    read_timeout: Duration,
+) -> AudioResult<ComposedPipeline> {
+    let (producer, consumer) = create_bridge(ring_capacity, composed_format.clone());
+    consumer.shared().set_negotiated_format(&composed_format);
+    consumer
+        .shared()
+        .state
+        .transition(StreamState::Created, StreamState::Running)
+        .map_err(|e| AudioError::InternalError {
+            message: format!("compose bridge state transition failed: {e:?}"),
+            source: None,
+        })?;
+
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    let active = Arc::new(AtomicBool::new(true));
+    let platform = ComposePlatformStream::new(Arc::clone(&stop_flag), Arc::clone(&active));
+    let view = Arc::new(ComposedStreamView::new(
+        BridgeStream::new(consumer, platform, composed_format, read_timeout),
+        Arc::clone(&active),
+    ));
+    Ok(ComposedPipeline {
+        producer,
+        view,
+        stop_flag,
+        active,
+    })
+}
+
+// ── Stats snapshots ─────────────────────────────────────────────────────
+
+/// Point-in-time counters for one composed source.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct SourceStats {
+    /// Name of the group the source belongs to.
+    pub group: String,
+    /// The source's capture target, rendered via `CaptureTarget`'s `Display`.
+    pub target: String,
+    /// Buffers received from the inner capture so far.
+    pub buffers_received: u64,
+    /// Frames of silence inserted because the source was behind at tick time.
+    pub padded_frames: u64,
+    /// Frames trimmed because the source drifted past the buffering bound.
+    pub trimmed_frames: u64,
+    /// Frames of silence inserted to compensate **intra-source timestamp
+    /// gaps** (rsac-ae4e): when the source's buffer timestamps jump past the
+    /// expected next stream position — how a ring overflow inside the inner
+    /// capture manifests, since drops advance the stamp without delivering
+    /// frames — the missing span is re-inserted as silence so the source's
+    /// channels stay time-aligned instead of permanently compressing.
+    /// Counted in frames at the source's *delivered* rate (the rate the
+    /// silence was inserted at, before any resampling to the session rate).
+    pub gap_padded_frames: u64,
+    /// Ring-overflow drops inside the source's own capture (its
+    /// [`overrun_count`](crate::api::AudioCapture::overrun_count)) — buffers
+    /// lost upstream of the compositor. A nonzero value here alongside a
+    /// growing [`gap_padded_frames`](Self::gap_padded_frames) identifies
+    /// which source is responsible for silence holes in the composed output.
+    pub inner_dropped: u64,
+    /// Whether this source is being resampled to the session rate.
+    pub resampling: bool,
+    /// Whether the source's stream has ended.
+    pub ended: bool,
+}
+
+/// Point-in-time snapshot of a running composition.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct CompositionStats {
+    /// Composed buffers (ticks) emitted so far.
+    pub ticks: u64,
+    /// Ticks emitted by the wall-clock stall fallback (master had no data).
+    pub fallback_ticks: u64,
+    /// Per-source counters, in flat declaration order.
+    pub sources: Vec<SourceStats>,
+}
+
+// ── Composition ─────────────────────────────────────────────────────────
+
+/// Handle to the engine thread, kept so `stop()`/`Drop` can join it.
+struct EngineHandle {
+    stop_flag: Arc<AtomicBool>,
+    join: Mutex<Option<std::thread::JoinHandle<()>>>,
+}
+
+/// A multi-source composed capture session (ADR-0011).
+///
+/// Created by [`CompositionBuilder::build`](super::CompositionBuilder::build);
+/// inert until [`start`](Self::start). See the [module docs](crate::compose)
+/// for the composition model.
+///
+/// # Reading
+///
+/// `Composition` implements [`CapturingStream`], and the inherent
+/// [`read_chunk_nonblocking`](Self::read_chunk_nonblocking) /
+/// [`read_chunk_blocking`](Self::read_chunk_blocking) pair mirrors
+/// [`AudioCapture::read_chunk_nonblocking`](crate::api::AudioCapture::read_chunk_nonblocking) /
+/// [`AudioCapture::read_chunk_blocking`](crate::api::AudioCapture::read_chunk_blocking)
+/// — the **terminal-observable** read family (the fatal
+/// [`AudioError::StreamEnded`] is surfaced once the composition ends and
+/// drains). Composed buffers are interleaved f32 at the session rate with
+/// [`channel_map().channels()`](ChannelMap::channels) channels.
+///
+/// # Ownership of inner captures
+///
+/// The composition owns and consumes its inner captures; do not read the same
+/// sources through other handles while it runs.
+pub struct Composition {
+    plan: CompositionPlan,
+    stream: Option<Arc<ComposedStreamView>>,
+    engine: Option<EngineHandle>,
+    channel_map: Option<ChannelMap>,
+    stats: Option<Arc<EngineStatsShared>>,
+    /// Flat `(group_name, target_display)` per source, for stats snapshots.
+    source_labels: Vec<(String, String)>,
+    /// Composed buffers dropped by this handle's subscribe pumps because a
+    /// subscriber's bounded channel was full (rsac-d6a8). Aggregated across
+    /// every subscription; surfaced via
+    /// [`subscriber_dropped_count`](Composition::subscriber_dropped_count).
+    subscriber_dropped: Arc<AtomicU64>,
+}
+
+impl std::fmt::Debug for Composition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Composition")
+            .field("started", &self.stream.is_some())
+            .field("groups", &self.plan.groups.len())
+            .field("session_rate", &self.plan.session_rate)
+            .field("channel_map", &self.channel_map)
+            .finish()
+    }
+}
+
+impl Composition {
+    pub(crate) fn from_plan(plan: CompositionPlan) -> Self {
+        let source_labels = plan
+            .groups
+            .iter()
+            .flat_map(|g| {
+                g.sources()
+                    .iter()
+                    .map(|(t, _)| (g.name().to_string(), t.to_string()))
+            })
+            .collect();
+        Self {
+            plan,
+            stream: None,
+            engine: None,
+            channel_map: None,
+            stats: None,
+            source_labels,
+            subscriber_dropped: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Builds and starts one capture per source, resolves the composed channel
+    /// layout, and spawns the compositor thread.
+    ///
+    /// On any failure every already-started inner capture is stopped before
+    /// the error is returned — a failed `start()` leaks nothing.
+    ///
+    /// # Errors
+    ///
+    /// - Any error from building/starting an inner capture (device resolution,
+    ///   format negotiation, stream creation).
+    /// - [`AudioError::ConfigurationError`] if the resolved layout exceeds 32
+    ///   output channels, or if the composition was already started.
+    /// - [`AudioError::InternalError`] if the compositor thread cannot spawn.
+    pub fn start(&mut self) -> AudioResult<()> {
+        if self.stream.is_some() {
+            return Err(AudioError::ConfigurationError {
+                message: "Composition is already started".to_string(),
+            });
+        }
+
+        // ── 1. Build + start one capture per source ──────────────────
+        let mut captures: Vec<crate::api::AudioCapture> = Vec::new();
+        let result = (|| -> AudioResult<()> {
+            for group in &self.plan.groups {
+                for (target, _gain) in group.sources() {
+                    let mut capture = AudioCaptureBuilder::new()
+                        .with_target(target.clone())
+                        .sample_rate(self.plan.session_rate)
+                        .build()?;
+                    capture.start()?;
+                    captures.push(capture);
+                }
+            }
+            Ok(())
+        })();
+        if let Err(e) = result {
+            for c in &mut captures {
+                let _ = c.stop();
+            }
+            return Err(e);
+        }
+
+        // ── 2. Resolve group widths / channel map ────────────────────
+        // Keep-channels groups need the source's negotiated width; poll its
+        // format briefly (Linux only learns it at stream-open).
+        let mut entries: Vec<ChannelOrigin> = Vec::new();
+        let mut group_specs: Vec<GroupSpec> = Vec::new();
+        let mut source_specs: Vec<SourceSpec> = Vec::new();
+        let mut offset = 0usize;
+        let mut flat_idx = 0usize;
+        for (gi, group) in self.plan.groups.iter().enumerate() {
+            let width = match group.layout().fixed_width() {
+                Some(w) => usize::from(w),
+                None => {
+                    let w = poll_channels(&captures[flat_idx]);
+                    usize::from(w)
+                }
+            };
+            for c in 0..width {
+                entries.push(ChannelOrigin {
+                    group: group.name().to_string(),
+                    group_index: gi,
+                    channel_in_group: c as u16,
+                });
+            }
+            group_specs.push(GroupSpec {
+                layout: group.layout(),
+                offset,
+                width,
+            });
+            for (target, gain) in group.sources() {
+                source_specs.push(SourceSpec {
+                    gain: *gain,
+                    group: gi,
+                    // Keep sources lock their width now; mixdown sources lock
+                    // on first delivered buffer.
+                    channels: if group.layout() == GroupLayout::KeepChannels {
+                        width as u16
+                    } else {
+                        0
+                    },
+                    // System/device endpoints tick through silence, so they are
+                    // the preferred clock if the master has to be re-elected.
+                    clock_candidate: matches!(
+                        target,
+                        crate::core::config::CaptureTarget::SystemDefault
+                            | crate::core::config::CaptureTarget::Device(_)
+                    ),
+                });
+                flat_idx += 1;
+            }
+            offset += width;
+        }
+
+        let total_channels = offset;
+        if total_channels == 0 || total_channels > usize::from(MAX_COMPOSED_CHANNELS) {
+            for c in &mut captures {
+                let _ = c.stop();
+            }
+            return Err(AudioError::ConfigurationError {
+                message: format!(
+                    "Composed layout resolves to {total_channels} output channels \
+                     (must be 1..={MAX_COMPOSED_CHANNELS})"
+                ),
+            });
+        }
+
+        let composed_format = AudioFormat {
+            sample_rate: self.plan.session_rate,
+            channels: total_channels as u16,
+            sample_format: SampleFormat::F32,
+        };
+
+        // ── 3. Bridge ring + stream (shared assembly) ────────────────
+        let pipeline = match assemble_pipeline(
+            composed_format.clone(),
+            COMPOSED_RING_CAPACITY,
+            Duration::from_secs(1),
+        ) {
+            Ok(p) => p,
+            Err(e) => {
+                for c in &mut captures {
+                    let _ = c.stop();
+                }
+                return Err(e);
+            }
+        };
+        let ComposedPipeline {
+            producer,
+            view: stream,
+            stop_flag,
+            active,
+        } = pipeline;
+
+        // ── 4. Spawn the engine ──────────────────────────────────────
+        let stats = Arc::new(EngineStatsShared {
+            sources: (0..source_specs.len())
+                .map(|_| Arc::new(SourceStatsShared::default()))
+                .collect(),
+            ..Default::default()
+        });
+        let readers: Vec<Box<dyn SourceReader>> = captures
+            .into_iter()
+            .map(|capture| Box::new(CaptureSource { capture }) as Box<dyn SourceReader>)
+            .collect();
+        let cfg = EngineConfig {
+            composed_format,
+            quantum_frames: self.plan.quantum_frames(),
+            max_fifo_frames: self.plan.max_fifo_frames(),
+            stall_timeout: self.plan.stall_timeout,
+            clamp_output: self.plan.clamp_output,
+            master_index: self.plan.master_index(),
+            groups: group_specs,
+            sources: source_specs,
+        };
+        let engine = Engine::new(
+            cfg,
+            readers,
+            producer,
+            Arc::clone(&stop_flag),
+            Arc::clone(&active),
+            Arc::clone(&stats),
+        );
+        let join = std::thread::Builder::new()
+            .name("rsac-compose".into())
+            .spawn(move || engine.run())
+            .map_err(|e| AudioError::InternalError {
+                message: format!("Failed to spawn compositor thread: {e}"),
+                source: None,
+            })?;
+
+        self.stream = Some(stream);
+        self.engine = Some(EngineHandle {
+            stop_flag,
+            join: Mutex::new(Some(join)),
+        });
+        self.channel_map = Some(ChannelMap::new(entries));
+        self.stats = Some(stats);
+        Ok(())
+    }
+
+    /// Stops the composition: signals the engine (which stops every inner
+    /// capture and ends the composed ring) and joins the compositor thread.
+    /// Idempotent; a not-yet-started composition returns `Ok(())`.
+    ///
+    /// # Buffered tail is discarded
+    ///
+    /// An **explicit** `stop()` ends readability immediately — the underlying
+    /// stream lands in the terminal `Stopped` state and subsequent reads
+    /// return the fatal [`AudioError::StreamEnded`] without draining any
+    /// composed buffers still in the ring (the same contract as
+    /// [`AudioCapture::stop`](crate::api::AudioCapture::stop)). ADR-0003's
+    /// drain-before-terminal semantics apply to the composition's **natural
+    /// end** (all sources terminal → engine flushes its tail → reads drain
+    /// the ring → then `StreamEnded`), not to an explicit stop. To capture
+    /// everything, read until the terminal error *before* calling `stop()`.
+    pub fn stop(&mut self) -> AudioResult<()> {
+        if let Some(stream) = &self.stream {
+            // Transitions the ring to Stopping and fires ComposePlatformStream::
+            // stop_capture (the engine stop flag). Tolerate "already stopped".
+            let _ = stream.stop();
+        }
+        if let Some(engine) = &self.engine {
+            engine.stop_flag.store(true, Ordering::SeqCst);
+            if let Ok(mut guard) = engine.join.lock() {
+                if let Some(handle) = guard.take() {
+                    if handle.thread().id() != std::thread::current().id() {
+                        if let Err(payload) = handle.join() {
+                            // rsac-1b83: never discard a panicked engine
+                            // silently. Its own catch-unwind teardown already
+                            // poisoned the composed stream (readers saw the
+                            // fatal terminal); this log is the last-stop
+                            // observability for the panic itself.
+                            log::error!(
+                                "rsac-compose engine thread panicked: {}",
+                                super::engine::panic_message(payload.as_ref())
+                            );
+                        }
+                    } else {
+                        *guard = Some(handle);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Non-blocking read of the next composed buffer — the **terminal-observable**
+    /// family, mirroring
+    /// [`AudioCapture::read_chunk_nonblocking`](crate::api::AudioCapture::read_chunk_nonblocking):
+    ///
+    /// - `Ok(Some(buf))` while composed data remains (including the buffered
+    ///   tail after the composition's natural end),
+    /// - `Ok(None)` when the ring is momentarily empty but not yet terminal,
+    /// - the fatal [`AudioError::StreamEnded`] once the composition has ended
+    ///   **and** the ring is drained.
+    ///
+    /// Consumers branch on [`AudioError::is_fatal`]: retry recoverable errors,
+    /// end cleanly on the fatal terminal — exactly like the `AudioCapture`
+    /// sibling and the C FFI pumps.
+    ///
+    /// *(Renamed from `read_buffer` pre-release (rsac-7aa2): the old name
+    /// collided with [`AudioCapture::read_buffer`](crate::api::AudioCapture::read_buffer),
+    /// which is the **downgraded, never-fatal** family — the same name must not
+    /// carry different terminal semantics on the two handles.)*
+    ///
+    /// # Errors
+    ///
+    /// [`AudioError::StreamReadError`] (recoverable) if the composition is not
+    /// started; the fatal [`AudioError::StreamEnded`] at the drained end.
+    pub fn read_chunk_nonblocking(&self) -> AudioResult<Option<AudioBuffer>> {
+        self.started_stream()?.try_read_chunk()
+    }
+
+    /// Blocking read of the next composed buffer — the **terminal-observable**
+    /// blocking sibling, mirroring
+    /// [`AudioCapture::read_chunk_blocking`](crate::api::AudioCapture::read_chunk_blocking):
+    /// blocks until a composed buffer is available (including the drainable
+    /// tail) or the composition reaches its terminal, in which case it returns
+    /// the fatal [`AudioError::StreamEnded`] promptly.
+    ///
+    /// *(Renamed from `read_buffer_blocking` pre-release — see
+    /// [`read_chunk_nonblocking`](Self::read_chunk_nonblocking).)*
+    ///
+    /// # Errors
+    ///
+    /// [`AudioError::StreamReadError`] (recoverable) if the composition is not
+    /// started; the fatal [`AudioError::StreamEnded`] at the drained end.
+    pub fn read_chunk_blocking(&self) -> AudioResult<AudioBuffer> {
+        self.started_stream()?.read_chunk()
+    }
+
+    /// `true` while the composed stream is running (started and not yet
+    /// stopped/ended). Mirrors
+    /// [`AudioCapture::is_running`](crate::api::AudioCapture::is_running).
+    pub fn is_running(&self) -> bool {
+        self.stream
+            .as_ref()
+            .map(|s| s.is_running())
+            .unwrap_or(false)
+    }
+
+    /// The composed channel layout. `None` until [`start`](Self::start)
+    /// succeeds (keep-channels widths are resolved at start).
+    pub fn channel_map(&self) -> Option<&ChannelMap> {
+        self.channel_map.as_ref()
+    }
+
+    /// Point-in-time composition counters. `None` until
+    /// [`start`](Self::start) succeeds.
+    pub fn stats(&self) -> Option<CompositionStats> {
+        let shared = self.stats.as_ref()?;
+        let sources = shared
+            .sources
+            .iter()
+            .zip(self.source_labels.iter())
+            .map(|(s, (group, target))| SourceStats {
+                group: group.clone(),
+                target: target.clone(),
+                buffers_received: s.buffers_received.load(Ordering::Relaxed),
+                padded_frames: s.padded_frames.load(Ordering::Relaxed),
+                trimmed_frames: s.trimmed_frames.load(Ordering::Relaxed),
+                gap_padded_frames: s.gap_padded_frames.load(Ordering::Relaxed),
+                inner_dropped: s.inner_dropped.load(Ordering::Relaxed),
+                resampling: s.resampling.load(Ordering::Relaxed),
+                ended: s.ended.load(Ordering::Relaxed),
+            })
+            .collect();
+        Some(CompositionStats {
+            ticks: shared.ticks.load(Ordering::Relaxed),
+            fallback_ticks: shared.fallback_ticks.load(Ordering::Relaxed),
+            sources,
+        })
+    }
+
+    /// Drains composed audio into an [`AudioSink`](crate::sink::AudioSink) on
+    /// a dedicated background thread — the composition analogue of
+    /// [`RunningCapture::drain_to`](crate::api::RunningCapture::drain_to)
+    /// (same loop, same recoverable-vs-fatal policy, same flush/close
+    /// finalization, and — rsac-7aa2 — the same acceptance policy). Do not mix
+    /// with manual reads on the same composition.
+    ///
+    /// # Accepted states (drain-the-tail; rsac-7aa2)
+    ///
+    /// Accepted whenever the composed stream exists: `Running`, the drainable
+    /// `Stopping` window (an ended composition's buffered output is drained
+    /// into the sink before finalization), or an already-terminal stream — the
+    /// drain thread then exits on its first read and still finalizes
+    /// (`flush()` then `close()`) the sink, so e.g. a WAV header is always
+    /// written. The gate is stream **presence** only, matching
+    /// `RunningCapture::drain_to` (see its rustdoc for why presence beats a
+    /// state check). Only a not-started composition is rejected.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AudioError::StreamReadError`] if the composition is not
+    /// started.
+    pub fn drain_to<S>(&self, sink: S) -> AudioResult<crate::api::DrainHandle>
+    where
+        S: crate::sink::AudioSink + 'static,
+    {
+        let stream = self.started_stream()?.clone();
+        crate::api::spawn_drain_thread(stream, sink)
+    }
+
+    /// Creates a push subscription delivering composed buffers over a
+    /// **bounded** [`mpsc`](std::sync::mpsc) channel — the composition
+    /// analogue of
+    /// [`AudioCapture::subscribe`](crate::api::AudioCapture::subscribe) (same
+    /// background pump, same bounded 128-buffer channel, same
+    /// recoverable-vs-fatal policy, same ~1 ms idle-poll latency floor).
+    ///
+    /// # Backpressure: drop, don't block, and count it (rsac-d6a8)
+    ///
+    /// A subscriber slower than real time fills the channel; further composed
+    /// buffers are **dropped** (never queued without bound) and counted in
+    /// [`subscriber_dropped_count`](Self::subscriber_dropped_count). This loss
+    /// is downstream of the composed ring, so it is invisible to
+    /// [`overrun_count`](CapturingStream::overrun_count).
+    ///
+    /// # Accepted states (rsac-7aa2)
+    ///
+    /// Accepted whenever the composed stream exists — `Running` **or** the
+    /// drainable `Stopping` window: a composition whose sources all ended
+    /// still holds its buffered output, and subscribing then delivers that
+    /// tail followed by the clean end (the old `is_running()` gate stranded
+    /// it). An already-terminal stream yields a channel that ends immediately.
+    /// Only a not-started composition is rejected.
+    ///
+    /// The pump exits when the composition reaches its fatal terminal (all
+    /// sources ended and the ring drained, or an explicit stop) — the channel
+    /// then disconnects — or when the receiver is dropped. **Multiple
+    /// subscriptions are allowed but each subscriber competes for buffers** (a
+    /// single logical consumer per composed buffer, exactly as with
+    /// [`AudioCapture::subscribe`](crate::api::AudioCapture::subscribe)); the
+    /// background reader likewise competes with
+    /// [`read_chunk_nonblocking`](Self::read_chunk_nonblocking) and
+    /// [`drain_to`](Self::drain_to) for buffers from the same ring — do not
+    /// mix delivery modes on one composition.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AudioError::StreamReadError`] if the composition is not
+    /// started.
+    pub fn subscribe(&self) -> AudioResult<std::sync::mpsc::Receiver<AudioBuffer>> {
+        // Presence gate only (rsac-7aa2): Running and the drainable Stopping
+        // window are both accepted; see the rustdoc above.
+        let stream = self.started_stream()?;
+        crate::api::spawn_subscribe_thread(stream.clone(), Arc::clone(&self.subscriber_dropped))
+    }
+
+    /// Like [`subscribe`](Self::subscribe), but each item is an
+    /// [`AudioResult<AudioBuffer>`] and the **fatal terminal** error is
+    /// delivered as the final channel item before the disconnect — the
+    /// composition analogue of
+    /// [`AudioCapture::subscribe_with_errors`](crate::api::AudioCapture::subscribe_with_errors).
+    ///
+    /// The bounded-channel/drop-and-count policy, the ~1/s coalescing of
+    /// repeated same-variant recoverable errors, and the blocking send that
+    /// guarantees the final terminal item are all shared with the
+    /// `AudioCapture` sibling — see its rustdoc for the full contract. The
+    /// acceptance policy matches [`subscribe`](Self::subscribe): any existing
+    /// stream (`Running` or the drainable `Stopping` window) is accepted.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AudioError::StreamReadError`] if the composition is not
+    /// started.
+    pub fn subscribe_with_errors(
+        &self,
+    ) -> AudioResult<std::sync::mpsc::Receiver<AudioResult<AudioBuffer>>> {
+        // Presence gate only (rsac-7aa2) — see subscribe().
+        let stream = self.started_stream()?;
+        crate::api::spawn_subscribe_with_errors_thread(
+            stream.clone(),
+            Arc::clone(&self.subscriber_dropped),
+        )
+    }
+
+    /// Total composed buffers dropped by this composition's subscribe pumps
+    /// because a subscriber's bounded channel was full — the composition
+    /// analogue of
+    /// [`AudioCapture::subscriber_dropped_count`](crate::api::AudioCapture::subscriber_dropped_count)
+    /// (rsac-d6a8).
+    ///
+    /// This loss happens *downstream* of the composed ring, so it is invisible
+    /// to [`overrun_count`](CapturingStream::overrun_count) and the per-source
+    /// [`SourceStats`] counters. Aggregated across every subscription created
+    /// from this handle; monotone for the handle's lifetime. `0` means no
+    /// subscriber has ever fallen behind.
+    pub fn subscriber_dropped_count(&self) -> u64 {
+        self.subscriber_dropped.load(Ordering::Relaxed)
+    }
+
+    /// Returns an asynchronous stream of composed audio buffers — the
+    /// composition analogue of
+    /// [`AudioCapture::audio_data_stream`](crate::api::AudioCapture::audio_data_stream).
+    ///
+    /// The returned [`AsyncAudioStream`](crate::bridge::AsyncAudioStream)
+    /// implements [`futures_core::Stream`], is waker-driven (the compositor
+    /// wakes the task when it pushes a composed buffer), and yields a final
+    /// `None` after the composition ends and the ring drains.
+    ///
+    /// # Single async consumer (waker contract; rsac-7aa2)
+    ///
+    /// The composed bridge holds exactly **one** waker slot. Two
+    /// `AsyncAudioStream`s over the same composition polled from two tasks
+    /// concurrently are **unsupported** — each registration displaces (and
+    /// silently drops, without waking) the other task's waker, so the
+    /// displaced task can park forever. Use at most one async consumer per
+    /// composition; see
+    /// [`AudioCapture::audio_data_stream`](crate::api::AudioCapture::audio_data_stream)
+    /// for the full rationale.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AudioError::StreamReadError`] if the composition has not been
+    /// started.
+    #[cfg(feature = "async-stream")]
+    pub fn audio_data_stream(&self) -> AudioResult<crate::bridge::AsyncAudioStream<'_>> {
+        let stream = self.started_stream()?;
+        Ok(crate::bridge::AsyncAudioStream::new(&**stream))
+    }
+
+    fn started_stream(&self) -> AudioResult<&Arc<ComposedStreamView>> {
+        self.stream
+            .as_ref()
+            .ok_or_else(|| AudioError::StreamReadError {
+                reason: "Composition is not started. Call start() first.".to_string(),
+            })
+    }
+}
+
+#[cfg(test)]
+impl Composition {
+    /// Test seam (crate-internal): attach an externally assembled composed
+    /// stream view — the engine-test harness pipeline — so the PUBLIC handle's
+    /// gate policies (subscribe/drain acceptance in the `Stopping` window) can
+    /// be exercised without device-backed inner captures.
+    pub(crate) fn attach_stream_for_tests(&mut self, view: Arc<ComposedStreamView>) {
+        self.stream = Some(view);
+    }
+}
+
+impl Drop for Composition {
+    fn drop(&mut self) {
+        // Best-effort deterministic teardown; stop() is idempotent.
+        let _ = self.stop();
+    }
+}
+
+// ── CapturingStream delegation ──────────────────────────────────────────
+
+/// [`CapturingStream`] delegation so generic consumers (sinks, pumps, the
+/// async adapter) can drive a `Composition` like any single capture.
+///
+/// One asymmetry to know: the **trait** [`stop`](CapturingStream::stop)
+/// (`&self`) only *signals* — it ends the composed ring and flags the engine
+/// to stop, **without joining** the compositor thread — while the **inherent**
+/// [`Composition::stop`] (`&mut self`) signals *and joins*. The `&self` stop
+/// exists so a concurrent reader can be unblocked without forming a `&mut`
+/// alias (the C FFI's `rsac_composition_stop` relies on it); the engine thread
+/// still exits on its own once signalled and is joined by the inherent
+/// `stop`/`Drop`, so nothing leaks either way.
+impl CapturingStream for Composition {
+    fn read_chunk(&self) -> AudioResult<AudioBuffer> {
+        self.started_stream()?.read_chunk()
+    }
+
+    fn try_read_chunk(&self) -> AudioResult<Option<AudioBuffer>> {
+        self.started_stream()?.try_read_chunk()
+    }
+
+    fn stop(&self) -> AudioResult<()> {
+        // &self stop: signal the ring + engine; the join happens in the
+        // inherent `stop(&mut self)` / `Drop`. The engine exits on its own
+        // once signalled, so not joining here is safe (never leaks: Drop joins).
+        // A not-started composition is a no-op `Ok(())`, matching the inherent
+        // `stop(&mut self)` so the two same-named paths cannot disagree.
+        // Like the inherent stop, this discards any buffered composed tail
+        // (see [`Composition::stop`] — drain first if you need it).
+        let Some(stream) = self.stream.as_ref() else {
+            return Ok(());
+        };
+        stream.stop()?;
+        if let Some(engine) = &self.engine {
+            engine.stop_flag.store(true, Ordering::SeqCst);
+        }
+        Ok(())
+    }
+
+    /// Returns the composed delivery format.
+    ///
+    /// **Before [`start`](Composition::start)** this is a *provisional
+    /// estimate*: keep-channels groups' widths are unknown until their
+    /// source's format is negotiated at start, so they are estimated at 2
+    /// channels. After a successful `start()` the returned format is
+    /// authoritative and matches [`channel_map()`](Composition::channel_map)
+    /// (which, unlike this method, honestly returns `None` until start —
+    /// prefer it when you must distinguish an estimate from a resolved
+    /// layout).
+    fn format(&self) -> AudioFormat {
+        if let Some(stream) = &self.stream {
+            return stream.format();
+        }
+        // Not started: best-effort provisional (keep-channels widths unknown,
+        // estimated at 2). Authoritative only after start().
+        let mut channels = 0u16;
+        for g in &self.plan.groups {
+            channels = channels.saturating_add(g.layout().fixed_width().unwrap_or(2));
+        }
+        AudioFormat {
+            sample_rate: self.plan.session_rate,
+            channels: channels.max(1),
+            sample_format: SampleFormat::F32,
+        }
+    }
+
+    fn is_running(&self) -> bool {
+        self.stream
+            .as_ref()
+            .map(|s| s.is_running())
+            .unwrap_or(false)
+    }
+
+    fn overrun_count(&self) -> u64 {
+        self.stream.as_ref().map(|s| s.overrun_count()).unwrap_or(0)
+    }
+
+    fn buffers_captured(&self) -> u64 {
+        self.stream
+            .as_ref()
+            .map(|s| s.buffers_captured())
+            .unwrap_or(0)
+    }
+
+    fn buffers_pushed(&self) -> u64 {
+        self.stream
+            .as_ref()
+            .map(|s| s.buffers_pushed())
+            .unwrap_or(0)
+    }
+
+    fn buffers_dropped(&self) -> u64 {
+        self.stream
+            .as_ref()
+            .map(|s| s.buffers_dropped())
+            .unwrap_or(0)
+    }
+
+    fn is_under_backpressure(&self) -> bool {
+        self.stream
+            .as_ref()
+            .map(|s| s.is_under_backpressure())
+            .unwrap_or(false)
+    }
+
+    fn drop_window_snapshot(&self) -> (u64, u64) {
+        self.stream
+            .as_ref()
+            .map(|s| s.drop_window_snapshot())
+            .unwrap_or((0, 0))
+    }
+
+    #[cfg(feature = "async-stream")]
+    fn register_waker(&self, waker: &std::task::Waker) -> bool {
+        // Honest wake promise: only a started stream can wake a parked task.
+        self.stream
+            .as_ref()
+            .map(|s| s.register_waker(waker))
+            .unwrap_or(false)
+    }
+
+    #[cfg(feature = "async-stream")]
+    fn is_stream_producing(&self) -> bool {
+        self.stream
+            .as_ref()
+            .map(|s| s.is_stream_producing())
+            .unwrap_or(true)
+    }
+}
+
+/// Poll a started capture for its negotiated channel count (Linux learns the
+/// format at stream-open, slightly after `start()`); falls back to the
+/// requested default (2) with a warning if it never materializes.
+fn poll_channels(capture: &crate::api::AudioCapture) -> u16 {
+    let deadline = Instant::now() + FORMAT_POLL_TIMEOUT;
+    loop {
+        if let Some(format) = capture.format() {
+            return format.channels.max(1);
+        }
+        if Instant::now() >= deadline {
+            log::warn!(
+                "compose: keep-channels source did not report a negotiated format \
+                 within {FORMAT_POLL_TIMEOUT:?}; assuming 2 channels"
+            );
+            return 2;
+        }
+        std::thread::sleep(FORMAT_POLL_INTERVAL);
+    }
+}

--- a/src/compose/tests.rs
+++ b/src/compose/tests.rs
@@ -1,0 +1,1306 @@
+//! Engine-loop tests: drive the full compositor thread with scripted sources
+//! and read the composed output through a real `BridgeStream` — the same data
+//! plane a device-backed composition uses, with zero hardware dependency.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::core::buffer::AudioBuffer;
+use crate::core::config::{AudioFormat, SampleFormat};
+use crate::core::error::{AudioError, AudioResult};
+use crate::core::interface::CapturingStream;
+
+use super::builder::{CompositionBuilder, Group, GroupLayout};
+use super::engine::{
+    Engine, EngineConfig, EngineStatsShared, GroupSpec, SourceReader, SourceSpec, SourceStatsShared,
+};
+use super::stream::{assemble_pipeline, ComposedStreamView};
+
+// ── Scripted source ─────────────────────────────────────────────────────
+
+/// A `SourceReader` that plays back a fixed script of buffers, then either
+/// ends (fatal `StreamEnded`) or stays live returning `Ok(None)`.
+struct ScriptedSource {
+    buffers: VecDeque<AudioBuffer>,
+    end_when_empty: bool,
+    stopped: Arc<AtomicBool>,
+}
+
+impl ScriptedSource {
+    fn ending(buffers: Vec<AudioBuffer>) -> (Self, Arc<AtomicBool>) {
+        let stopped = Arc::new(AtomicBool::new(false));
+        (
+            Self {
+                buffers: buffers.into(),
+                end_when_empty: true,
+                stopped: Arc::clone(&stopped),
+            },
+            stopped,
+        )
+    }
+
+    fn live(buffers: Vec<AudioBuffer>) -> (Self, Arc<AtomicBool>) {
+        let stopped = Arc::new(AtomicBool::new(false));
+        (
+            Self {
+                buffers: buffers.into(),
+                end_when_empty: false,
+                stopped: Arc::clone(&stopped),
+            },
+            stopped,
+        )
+    }
+}
+
+impl SourceReader for ScriptedSource {
+    fn try_read(&mut self) -> AudioResult<Option<AudioBuffer>> {
+        match self.buffers.pop_front() {
+            Some(b) => Ok(Some(b)),
+            None if self.end_when_empty => Err(AudioError::StreamEnded {
+                reason: "scripted source exhausted".to_string(),
+            }),
+            None => Ok(None),
+        }
+    }
+
+    fn stop(&mut self) {
+        self.stopped.store(true, Ordering::SeqCst);
+    }
+}
+
+// ── Harness ─────────────────────────────────────────────────────────────
+
+fn const_buffer(value: f32, channels: u16, rate: u32, frames: usize) -> AudioBuffer {
+    AudioBuffer::new(vec![value; frames * usize::from(channels)], channels, rate)
+}
+
+/// Like [`const_buffer`], but stamped with a stream-position timestamp — the
+/// shape every backend now delivers (rsac-ae4e gap-compensation tests).
+fn stamped_buffer(
+    value: f32,
+    channels: u16,
+    rate: u32,
+    frames: usize,
+    ts: Duration,
+) -> AudioBuffer {
+    AudioBuffer::with_timestamp(
+        vec![value; frames * usize::from(channels)],
+        AudioFormat {
+            sample_rate: rate,
+            channels,
+            sample_format: SampleFormat::F32,
+        },
+        ts,
+    )
+}
+
+struct Harness {
+    stream: Arc<ComposedStreamView>,
+    stats: Arc<EngineStatsShared>,
+    stop_flag: Arc<AtomicBool>,
+    join: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Harness {
+    /// Spawns a real engine thread over the given config and sources; the
+    /// returned harness reads composed buffers from the bridge stream. Uses
+    /// the SAME pipeline assembly as `Composition::start()`
+    /// (`assemble_pipeline`) so these tests exercise the production wiring.
+    fn spawn(cfg: EngineConfig, readers: Vec<Box<dyn SourceReader>>) -> Self {
+        let pipeline = assemble_pipeline(cfg.composed_format.clone(), 256, Duration::from_secs(2))
+            .expect("pipeline assembly");
+        let stats = Arc::new(EngineStatsShared {
+            sources: (0..readers.len())
+                .map(|_| Arc::new(SourceStatsShared::default()))
+                .collect(),
+            ..Default::default()
+        });
+        let engine = Engine::new(
+            cfg,
+            readers,
+            pipeline.producer,
+            Arc::clone(&pipeline.stop_flag),
+            pipeline.active,
+            Arc::clone(&stats),
+        );
+        let stop_flag = pipeline.stop_flag;
+        let stream = pipeline.view;
+        let join = std::thread::spawn(move || engine.run());
+        Self {
+            stream,
+            stats,
+            stop_flag,
+            join: Some(join),
+        }
+    }
+
+    /// Drains the composed stream until the terminal `StreamEnded`, returning
+    /// every composed buffer. Panics if the stream doesn't end within ~5 s.
+    fn drain_to_end(&self) -> Vec<AudioBuffer> {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let mut out = Vec::new();
+        loop {
+            match self.stream.try_read_chunk() {
+                Ok(Some(b)) => out.push(b),
+                Ok(None) => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "composed stream did not end in time"
+                    );
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                Err(e) if e.is_fatal() => break,
+                Err(e) => panic!("unexpected recoverable error: {e:?}"),
+            }
+        }
+        out
+    }
+
+    fn shutdown(mut self) {
+        self.stop_flag.store(true, Ordering::SeqCst);
+        if let Some(j) = self.join.take() {
+            let _ = j.join();
+        }
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        self.stop_flag.store(true, Ordering::SeqCst);
+        if let Some(j) = self.join.take() {
+            let _ = j.join();
+        }
+    }
+}
+
+fn fmt(channels: u16, rate: u32) -> AudioFormat {
+    AudioFormat {
+        sample_rate: rate,
+        channels,
+        sample_format: SampleFormat::F32,
+    }
+}
+
+/// Convenience: config for `sources` with 10 ms quantum @ 48 kHz.
+fn cfg(
+    total_channels: u16,
+    groups: Vec<GroupSpec>,
+    sources: Vec<SourceSpec>,
+    master_index: usize,
+) -> EngineConfig {
+    EngineConfig {
+        composed_format: fmt(total_channels, 48_000),
+        quantum_frames: 480,
+        max_fifo_frames: 48_000,
+        stall_timeout: Duration::from_millis(250),
+        clamp_output: false,
+        master_index,
+        groups,
+        sources,
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+/// Two sources, two groups (mono mixdown + keep-channels stereo): the
+/// composed stream is 3 channels wide with the group values in declaration
+/// order, ends cleanly when both sources end, and loses no frames.
+#[test]
+fn composes_mono_and_keep_groups_end_to_end() {
+    let n_buffers = 10usize;
+    // Source 0 (group 0, mono mixdown): stereo 0.25s.
+    let (src_a, stopped_a) = ScriptedSource::ending(
+        (0..n_buffers)
+            .map(|_| const_buffer(0.25, 2, 48_000, 480))
+            .collect(),
+    );
+    // Source 1 (group 1, keep stereo, master): stereo 0.5s.
+    let (src_b, stopped_b) = ScriptedSource::ending(
+        (0..n_buffers)
+            .map(|_| const_buffer(0.5, 2, 48_000, 480))
+            .collect(),
+    );
+
+    let harness = Harness::spawn(
+        cfg(
+            3,
+            vec![
+                GroupSpec {
+                    layout: GroupLayout::Mono,
+                    offset: 0,
+                    width: 1,
+                },
+                GroupSpec {
+                    layout: GroupLayout::KeepChannels,
+                    offset: 1,
+                    width: 2,
+                },
+            ],
+            vec![
+                SourceSpec {
+                    gain: 1.0,
+                    group: 0,
+                    channels: 0,
+                    clock_candidate: false,
+                },
+                SourceSpec {
+                    gain: 1.0,
+                    group: 1,
+                    channels: 2,
+                    clock_candidate: false,
+                },
+            ],
+            1, // master = keep source
+        ),
+        vec![Box::new(src_a), Box::new(src_b)],
+    );
+
+    let buffers = harness.drain_to_end();
+    let total_frames: usize = buffers.iter().map(|b| b.num_frames()).sum();
+    assert_eq!(total_frames, n_buffers * 480, "no frames lost or invented");
+
+    // Composed buffers carry contiguous stream-position timestamps
+    // (frames emitted / session rate), mirroring the backends' stamped pushes.
+    let mut expected_frames = 0u64;
+    for b in &buffers {
+        let expected = Duration::from_nanos(expected_frames * 1_000_000_000 / 48_000);
+        assert_eq!(
+            b.timestamp(),
+            Some(expected),
+            "composed tick timestamp must be its stream position"
+        );
+        expected_frames += b.num_frames() as u64;
+    }
+
+    for b in &buffers {
+        assert_eq!(b.channels(), 3);
+        assert_eq!(b.sample_rate(), 48_000);
+        let data = b.data();
+        for f in 0..b.num_frames() {
+            assert!((data[f * 3] - 0.25).abs() < 1e-6, "mono group value");
+            assert!((data[f * 3 + 1] - 0.5).abs() < 1e-6, "keep L value");
+            assert!((data[f * 3 + 2] - 0.5).abs() < 1e-6, "keep R value");
+        }
+    }
+
+    // Engine teardown stopped both readers.
+    assert!(stopped_a.load(Ordering::SeqCst));
+    assert!(stopped_b.load(Ordering::SeqCst));
+    harness.shutdown();
+}
+
+/// A source that runs dry before the master is silence-padded (zeros in its
+/// channels) and its `padded_frames` counter reflects the shortfall.
+#[test]
+fn behind_source_is_silence_padded_and_counted() {
+    let master_buffers = 10usize;
+    let short_buffers = 4usize;
+    let (short_src, _) = ScriptedSource::ending(
+        (0..short_buffers)
+            .map(|_| const_buffer(0.8, 1, 48_000, 480))
+            .collect(),
+    );
+    let (master_src, _) = ScriptedSource::ending(
+        (0..master_buffers)
+            .map(|_| const_buffer(0.5, 1, 48_000, 480))
+            .collect(),
+    );
+
+    let harness = Harness::spawn(
+        cfg(
+            2,
+            vec![
+                GroupSpec {
+                    layout: GroupLayout::Mono,
+                    offset: 0,
+                    width: 1,
+                },
+                GroupSpec {
+                    layout: GroupLayout::Mono,
+                    offset: 1,
+                    width: 1,
+                },
+            ],
+            vec![
+                SourceSpec {
+                    gain: 1.0,
+                    group: 0,
+                    channels: 0,
+                    clock_candidate: false,
+                },
+                SourceSpec {
+                    gain: 1.0,
+                    group: 1,
+                    channels: 0,
+                    clock_candidate: false,
+                },
+            ],
+            1,
+        ),
+        vec![Box::new(short_src), Box::new(master_src)],
+    );
+
+    let buffers = harness.drain_to_end();
+    let total_frames: usize = buffers.iter().map(|b| b.num_frames()).sum();
+    assert_eq!(
+        total_frames,
+        master_buffers * 480,
+        "master paces the output"
+    );
+
+    // Early frames carry the short source; late frames are silence in ch 0.
+    let all: Vec<f32> = buffers
+        .iter()
+        .flat_map(|b| b.data().iter().copied())
+        .collect();
+    let first_frame_ch0 = all[0];
+    let last_frame_ch0 = all[all.len() - 2];
+    assert!((first_frame_ch0 - 0.8).abs() < 1e-6);
+    assert!(last_frame_ch0.abs() < 1e-9, "tail must be padded silence");
+
+    let padded = harness.stats.sources[0]
+        .padded_frames
+        .load(Ordering::Relaxed);
+    assert_eq!(
+        padded as usize,
+        (master_buffers - short_buffers) * 480,
+        "padding counter matches the shortfall"
+    );
+    harness.shutdown();
+}
+
+/// A source drifting far ahead of the master has its oldest samples trimmed
+/// at the buffering bound, and the trim counter records it.
+#[test]
+fn ahead_source_is_bounded_and_trimmed() {
+    // Master delivers 1 buffer; the other source delivers 1 s + extra.
+    let (master_src, _) = ScriptedSource::live(vec![const_buffer(0.5, 1, 48_000, 480)]);
+    let (fast_src, _) = ScriptedSource::live(
+        (0..150)
+            .map(|_| const_buffer(0.1, 1, 48_000, 480))
+            .collect(),
+    );
+
+    let mut config = cfg(
+        2,
+        vec![
+            GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 0,
+                width: 1,
+            },
+            GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 1,
+                width: 1,
+            },
+        ],
+        vec![
+            SourceSpec {
+                gain: 1.0,
+                group: 0,
+                channels: 0,
+                clock_candidate: false,
+            },
+            SourceSpec {
+                gain: 1.0,
+                group: 1,
+                channels: 0,
+                clock_candidate: false,
+            },
+        ],
+        0,
+    );
+    // Tight bound: half a second.
+    config.max_fifo_frames = 24_000;
+    // Long stall timeout so the fallback doesn't drain the fast source first.
+    config.stall_timeout = Duration::from_secs(10);
+
+    let harness = Harness::spawn(config, vec![Box::new(master_src), Box::new(fast_src)]);
+
+    // Give the engine time to ingest and trim (sources stay live; no end).
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let trimmed = harness.stats.sources[1]
+            .trimmed_frames
+            .load(Ordering::Relaxed);
+        if trimmed > 0 {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "fast source was never trimmed"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    harness.shutdown();
+}
+
+/// A 44.1 kHz source is transparently resampled to the 48 kHz session: the
+/// resampling flag flips on and the composed output still carries its signal.
+#[test]
+fn heterogeneous_rate_source_is_resampled() {
+    // ~1 s of 44.1 kHz audio in 441-frame buffers (mono, constant 0.3).
+    let n = 100usize;
+    let (src, _) =
+        ScriptedSource::ending((0..n).map(|_| const_buffer(0.3, 1, 44_100, 441)).collect());
+
+    let harness = Harness::spawn(
+        cfg(
+            1,
+            vec![GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 0,
+                width: 1,
+            }],
+            vec![SourceSpec {
+                gain: 1.0,
+                group: 0,
+                channels: 0,
+                clock_candidate: false,
+            }],
+            0,
+        ),
+        vec![Box::new(src)],
+    );
+
+    let buffers = harness.drain_to_end();
+    assert!(
+        harness.stats.sources[0].resampling.load(Ordering::Relaxed),
+        "resampling flag must be set"
+    );
+    let total_frames: usize = buffers.iter().map(|b| b.num_frames()).sum();
+    // rsac-fab0: with the end-of-stream resampler flush, the composed output
+    // carries EXACTLY round(input * to/from) frames — the final partial input
+    // chunk and the FFT delay residue included, trimmed to the exact length
+    // owed. ±1 frame of slack for rounding-convention differences only.
+    let expected = (44_100u64 * 48_000 + 44_100 / 2) / 44_100; // = 48_000
+    assert!(
+        (total_frames as i64 - expected as i64).abs() <= 1,
+        "expected {expected}±1 resampled frames, got {total_frames}"
+    );
+    // Constant DC input should come out near-constant after the transient.
+    let all: Vec<f32> = buffers
+        .iter()
+        .flat_map(|b| b.data().iter().copied())
+        .collect();
+    let mid = all[all.len() / 2];
+    assert!((mid - 0.3).abs() < 0.05, "signal preserved, got {mid}");
+    harness.shutdown();
+}
+
+/// When the master stalls, the wall-clock fallback keeps ticking (with the
+/// master padded) so a live secondary source still flows.
+#[test]
+fn stalled_master_triggers_fallback_ticks() {
+    let (master_src, _) = ScriptedSource::live(vec![]); // never produces
+    let (live_src, _) =
+        ScriptedSource::live((0..50).map(|_| const_buffer(0.4, 1, 48_000, 480)).collect());
+
+    let mut config = cfg(
+        2,
+        vec![
+            GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 0,
+                width: 1,
+            },
+            GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 1,
+                width: 1,
+            },
+        ],
+        vec![
+            SourceSpec {
+                gain: 1.0,
+                group: 0,
+                channels: 0,
+                clock_candidate: false,
+            },
+            SourceSpec {
+                gain: 1.0,
+                group: 1,
+                channels: 0,
+                clock_candidate: false,
+            },
+        ],
+        0, // master is the silent source
+    );
+    config.stall_timeout = Duration::from_millis(20);
+
+    let harness = Harness::spawn(config, vec![Box::new(master_src), Box::new(live_src)]);
+
+    // Wait for fallback ticks to appear.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if harness.stats.fallback_ticks.load(Ordering::Relaxed) >= 3 {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "no fallback ticks despite stalled master"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    // Composed output must exist and carry the live source's signal in ch 1.
+    let mut saw_live_signal = false;
+    while let Ok(Some(b)) = harness.stream.try_read_chunk() {
+        let data = b.data();
+        if data.chunks(2).any(|f| (f[1] - 0.4).abs() < 1e-6) {
+            saw_live_signal = true;
+        }
+        // Master channel is always padded silence.
+        assert!(data.chunks(2).all(|f| f[0].abs() < 1e-9));
+        if saw_live_signal {
+            break;
+        }
+    }
+    assert!(
+        saw_live_signal,
+        "live source audio must flow during fallback"
+    );
+    harness.shutdown();
+}
+
+/// `clamp_output` bounds a hot sum to [-1, 1]; without it the sum exceeds 1.
+#[test]
+fn clamp_output_bounds_hot_sum() {
+    let make_sources = || -> Vec<Box<dyn SourceReader>> {
+        let (a, _) = ScriptedSource::ending(vec![const_buffer(0.8, 1, 48_000, 480)]);
+        let (b, _) = ScriptedSource::ending(vec![const_buffer(0.7, 1, 48_000, 480)]);
+        vec![Box::new(a), Box::new(b)]
+    };
+    let group = || {
+        vec![GroupSpec {
+            layout: GroupLayout::Mono,
+            offset: 0,
+            width: 1,
+        }]
+    };
+    let sources_spec = || {
+        vec![
+            SourceSpec {
+                gain: 1.0,
+                group: 0,
+                channels: 0,
+                clock_candidate: false,
+            },
+            SourceSpec {
+                gain: 1.0,
+                group: 0,
+                channels: 0,
+                clock_candidate: false,
+            },
+        ]
+    };
+
+    // Unclamped: 0.8 + 0.7 = 1.5.
+    let harness = Harness::spawn(cfg(1, group(), sources_spec(), 0), make_sources());
+    let buffers = harness.drain_to_end();
+    let peak = buffers
+        .iter()
+        .flat_map(|b| b.data().iter())
+        .fold(0.0f32, |m, &v| m.max(v));
+    assert!((peak - 1.5).abs() < 1e-6, "unclamped sum, got {peak}");
+    harness.shutdown();
+
+    // Clamped: bounded at 1.0.
+    let mut config = cfg(1, group(), sources_spec(), 0);
+    config.clamp_output = true;
+    let harness = Harness::spawn(config, make_sources());
+    let buffers = harness.drain_to_end();
+    let peak = buffers
+        .iter()
+        .flat_map(|b| b.data().iter())
+        .fold(0.0f32, |m, &v| m.max(v));
+    assert!((peak - 1.0).abs() < 1e-6, "clamped sum, got {peak}");
+    harness.shutdown();
+}
+
+/// Per-source gain weights the mixdown sum.
+#[test]
+fn per_source_gain_is_applied() {
+    let (a, _) = ScriptedSource::ending(vec![const_buffer(0.5, 1, 48_000, 480)]);
+    let (b, _) = ScriptedSource::ending(vec![const_buffer(0.5, 1, 48_000, 480)]);
+
+    let harness = Harness::spawn(
+        cfg(
+            1,
+            vec![GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 0,
+                width: 1,
+            }],
+            vec![
+                SourceSpec {
+                    gain: 1.0,
+                    group: 0,
+                    channels: 0,
+                    clock_candidate: false,
+                },
+                SourceSpec {
+                    gain: 0.5,
+                    group: 0,
+                    channels: 0,
+                    clock_candidate: false,
+                },
+            ],
+            0,
+        ),
+        vec![Box::new(a), Box::new(b)],
+    );
+    let buffers = harness.drain_to_end();
+    let v = buffers[0].data()[0];
+    assert!((v - 0.75).abs() < 1e-6, "0.5*1.0 + 0.5*0.5 = 0.75, got {v}");
+    harness.shutdown();
+}
+
+/// Regression guard for the ended-master pacing flaw: when the configured
+/// master source ends while another source stays live, the clock is
+/// re-elected to the live source and output continues at **full data rate**
+/// (master-paced ticks), not at the wall-clock fallback cadence — so the live
+/// source's audio is neither slowed to ~quantum-per-stall_timeout nor
+/// trim-discarded.
+#[test]
+fn ended_master_reelects_live_clock_at_full_rate() {
+    let master_buffers = 2usize;
+    let live_buffers = 50usize;
+    // Configured master: ends almost immediately.
+    let (master_src, _) = ScriptedSource::ending(
+        (0..master_buffers)
+            .map(|_| const_buffer(0.5, 1, 48_000, 480))
+            .collect(),
+    );
+    // Live source: delivers 0.5 s of audio and stays live.
+    let (live_src, _) = ScriptedSource::live(
+        (0..live_buffers)
+            .map(|_| const_buffer(0.25, 1, 48_000, 480))
+            .collect(),
+    );
+
+    let mut config = cfg(
+        2,
+        vec![
+            GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 0,
+                width: 1,
+            },
+            GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 1,
+                width: 1,
+            },
+        ],
+        vec![
+            SourceSpec {
+                gain: 1.0,
+                group: 0,
+                channels: 0,
+                clock_candidate: true, // the configured master
+            },
+            SourceSpec {
+                gain: 1.0,
+                group: 1,
+                channels: 0,
+                clock_candidate: true, // preferred re-election target
+            },
+        ],
+        0,
+    );
+    // A long stall timeout proves progress comes from re-election, not from
+    // the wall-clock fallback (which would need 10 s per emitted quantum).
+    config.stall_timeout = Duration::from_secs(10);
+
+    let harness = Harness::spawn(config, vec![Box::new(master_src), Box::new(live_src)]);
+
+    // All 50 quanta must be emitted promptly, paced by the re-elected master.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if harness.stats.ticks.load(Ordering::Relaxed) >= live_buffers as u64 {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "output stalled after the master ended (ticks={}) — clock was not re-elected",
+            harness.stats.ticks.load(Ordering::Relaxed)
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    assert_eq!(
+        harness.stats.fallback_ticks.load(Ordering::Relaxed),
+        0,
+        "progress must come from data-paced ticks, not the wall-clock fallback"
+    );
+    assert_eq!(
+        harness.stats.sources[1]
+            .trimmed_frames
+            .load(Ordering::Relaxed),
+        0,
+        "the live source must not be trim-discarded after the master ends"
+    );
+    harness.shutdown();
+}
+
+// ── Engine panic containment (rsac-1b83) ────────────────────────────────
+
+/// A panic anywhere in the engine loop must surface as a **fatal terminal**
+/// on the composed stream — never a hang — and `is_running()` must go false.
+/// The engine's catch-unwind teardown poisons the ring via `signal_error`;
+/// without it the ring stays `Running` forever: blocking reads loop on
+/// Timeout, pumps spin, and the composition is permanently non-terminal.
+#[test]
+fn engine_panic_poisons_stream_with_fatal_terminal() {
+    /// Delivers a few buffers, then panics inside `try_read` — i.e. inside
+    /// the engine's ingest path on the compositor thread. (The panic prints
+    /// to stderr via the default hook; that noise is expected here.)
+    struct PanickingSource {
+        reads_left: usize,
+    }
+    impl SourceReader for PanickingSource {
+        fn try_read(&mut self) -> AudioResult<Option<AudioBuffer>> {
+            if self.reads_left == 0 {
+                panic!("scripted engine panic (rsac-1b83 test)");
+            }
+            self.reads_left -= 1;
+            Ok(Some(const_buffer(0.5, 1, 48_000, 480)))
+        }
+        fn stop(&mut self) {}
+    }
+
+    let harness = Harness::spawn(
+        cfg(
+            1,
+            vec![GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 0,
+                width: 1,
+            }],
+            vec![SourceSpec {
+                gain: 1.0,
+                group: 0,
+                channels: 0,
+                clock_candidate: false,
+            }],
+            0,
+        ),
+        vec![Box::new(PanickingSource { reads_left: 3 })],
+    );
+
+    // Timeout-bounded: a regression (permanently non-terminal composition)
+    // fails the deadline assert instead of hanging the suite.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let fatal = loop {
+        match harness.stream.try_read_chunk() {
+            // Pre-panic ticks may or may not surface before the poison ends
+            // readability; either way, keep polling until the terminal.
+            Ok(_) => {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "engine panic never surfaced a terminal error (composition hung)"
+                );
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            Err(e) => break e,
+        }
+    };
+    assert!(
+        fatal.is_fatal(),
+        "the panic terminal must be fatal, got {fatal:?}"
+    );
+
+    // The blocking read path returns the same fatal terminal immediately —
+    // the state is already terminal, so this cannot park.
+    let blocking = harness.stream.read_chunk();
+    assert!(
+        matches!(blocking, Err(ref e) if e.is_fatal()),
+        "read_chunk after an engine panic must be the fatal terminal, got {blocking:?}"
+    );
+
+    assert!(
+        !harness.stream.is_running(),
+        "is_running() must report the engine's death, not lie"
+    );
+    harness.shutdown();
+}
+
+// ── Intra-source gap compensation (rsac-ae4e) ───────────────────────────
+
+/// A timestamped source whose stamps jump past the expected next position
+/// (how an inner ring overflow manifests) has the hole re-inserted as
+/// silence: output stays time-continuous and `gap_padded_frames` counts it.
+#[test]
+fn timestamp_gap_is_compensated_with_silence() {
+    // Buffer 0 spans 0..10 ms; buffer 1 starts at 20 ms → a 10 ms hole
+    // (480 frames @ 48 kHz) where the inner ring dropped data.
+    let (src, _) = ScriptedSource::ending(vec![
+        stamped_buffer(0.5, 1, 48_000, 480, Duration::ZERO),
+        stamped_buffer(0.5, 1, 48_000, 480, Duration::from_millis(20)),
+    ]);
+    let harness = Harness::spawn(
+        cfg(
+            1,
+            vec![GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 0,
+                width: 1,
+            }],
+            vec![SourceSpec {
+                gain: 1.0,
+                group: 0,
+                channels: 0,
+                clock_candidate: false,
+            }],
+            0,
+        ),
+        vec![Box::new(src)],
+    );
+
+    let buffers = harness.drain_to_end();
+    let all: Vec<f32> = buffers
+        .iter()
+        .flat_map(|b| b.data().iter().copied())
+        .collect();
+    assert_eq!(
+        all.len(),
+        3 * 480,
+        "output must span the full 30 ms timeline (data + gap + data)"
+    );
+    assert!(
+        all[..480].iter().all(|v| (v - 0.5).abs() < 1e-6),
+        "first 10 ms carries buffer 0"
+    );
+    assert!(
+        all[480..960].iter().all(|v| v.abs() < 1e-9),
+        "the 10 ms hole must be silence, not time-compressed away"
+    );
+    assert!(
+        all[960..].iter().all(|v| (v - 0.5).abs() < 1e-6),
+        "last 10 ms carries buffer 1"
+    );
+    assert_eq!(
+        harness.stats.sources[0]
+            .gap_padded_frames
+            .load(Ordering::Relaxed),
+        480,
+        "gap_padded_frames must count the inserted silence"
+    );
+    harness.shutdown();
+}
+
+/// A source delivering buffers WITHOUT timestamps keeps the exact legacy
+/// behavior: no gap detection, no inserted silence, counter stays zero.
+#[test]
+fn untimestamped_source_gets_no_gap_compensation() {
+    let n = 4usize;
+    let (src, _) =
+        ScriptedSource::ending((0..n).map(|_| const_buffer(0.5, 1, 48_000, 480)).collect());
+    let harness = Harness::spawn(
+        cfg(
+            1,
+            vec![GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 0,
+                width: 1,
+            }],
+            vec![SourceSpec {
+                gain: 1.0,
+                group: 0,
+                channels: 0,
+                clock_candidate: false,
+            }],
+            0,
+        ),
+        vec![Box::new(src)],
+    );
+    let buffers = harness.drain_to_end();
+    let total_frames: usize = buffers.iter().map(|b| b.num_frames()).sum();
+    assert_eq!(total_frames, n * 480, "delivered frames only, no padding");
+    assert_eq!(
+        harness.stats.sources[0]
+            .gap_padded_frames
+            .load(Ordering::Relaxed),
+        0,
+        "no timestamps → no gap compensation"
+    );
+    harness.shutdown();
+}
+
+/// rsac-ae4e(3): the engine snapshots each source's inner overrun count
+/// (`SourceReader::overruns`) into the shared stats.
+#[test]
+fn inner_overruns_are_snapshotted_into_stats() {
+    struct OverrunningSource {
+        inner: ScriptedSource,
+    }
+    impl SourceReader for OverrunningSource {
+        fn try_read(&mut self) -> AudioResult<Option<AudioBuffer>> {
+            self.inner.try_read()
+        }
+        fn stop(&mut self) {
+            self.inner.stop();
+        }
+        fn overruns(&self) -> u64 {
+            7
+        }
+    }
+
+    let (inner, _) = ScriptedSource::ending(vec![const_buffer(0.5, 1, 48_000, 480)]);
+    let harness = Harness::spawn(
+        cfg(
+            1,
+            vec![GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 0,
+                width: 1,
+            }],
+            vec![SourceSpec {
+                gain: 1.0,
+                group: 0,
+                channels: 0,
+                clock_candidate: false,
+            }],
+            0,
+        ),
+        vec![Box::new(OverrunningSource { inner })],
+    );
+    let _ = harness.drain_to_end();
+    assert_eq!(
+        harness.stats.sources[0]
+            .inner_dropped
+            .load(Ordering::Relaxed),
+        7,
+        "inner overrun count must be snapshotted into the per-source stats"
+    );
+    harness.shutdown();
+}
+
+// ── Ragged-buffer truncation (rsac-2195) ────────────────────────────────
+
+/// A delivered buffer with a dangling partial frame must be truncated to
+/// whole frames on ingest — otherwise the half-frame rotates the source's
+/// channel interleave (every later L sample lands in R) for the rest of the
+/// session.
+#[test]
+fn ragged_buffer_is_truncated_and_interleave_survives() {
+    // Buffer 0: 480 clean stereo frames of (0.1, 0.2) + ONE dangling sample.
+    let mut ragged_data = Vec::with_capacity(480 * 2 + 1);
+    for _ in 0..480 {
+        ragged_data.extend_from_slice(&[0.1, 0.2]);
+    }
+    ragged_data.push(0.1); // the dangling half frame
+    let ragged = AudioBuffer::new(ragged_data, 2, 48_000);
+    // Buffer 1: 480 clean stereo frames with DIFFERENT per-channel values, so
+    // any interleave rotation is unmistakable.
+    let clean = {
+        let mut data = Vec::with_capacity(480 * 2);
+        for _ in 0..480 {
+            data.extend_from_slice(&[0.3, 0.4]);
+        }
+        AudioBuffer::new(data, 2, 48_000)
+    };
+    let (src, _) = ScriptedSource::ending(vec![ragged, clean]);
+
+    let harness = Harness::spawn(
+        cfg(
+            2,
+            vec![GroupSpec {
+                layout: GroupLayout::KeepChannels,
+                offset: 0,
+                width: 2,
+            }],
+            vec![SourceSpec {
+                gain: 1.0,
+                group: 0,
+                channels: 2,
+                clock_candidate: false,
+            }],
+            0,
+        ),
+        vec![Box::new(src)],
+    );
+
+    let buffers = harness.drain_to_end();
+    let all: Vec<f32> = buffers
+        .iter()
+        .flat_map(|b| b.data().iter().copied())
+        .collect();
+    assert_eq!(
+        all.len(),
+        960 * 2,
+        "dangling half-frame dropped: exactly 960 whole frames flow through"
+    );
+    for f in 0..960 {
+        let (l, r) = (all[f * 2], all[f * 2 + 1]);
+        assert!(
+            (l - 0.1).abs() < 1e-6 || (l - 0.3).abs() < 1e-6,
+            "L slot polluted at frame {f}: {l} (interleave rotated)"
+        );
+        assert!(
+            (r - 0.2).abs() < 1e-6 || (r - 0.4).abs() < 1e-6,
+            "R slot polluted at frame {f}: {r} (interleave rotated)"
+        );
+    }
+    harness.shutdown();
+}
+
+// ── Push + async delivery over the composed view ────────────────────────
+
+/// The shared subscribe pump delivers composed buffers and then the fatal
+/// terminal as the FINAL item before the channel disconnects (same contract
+/// as `AudioCapture::subscribe_with_errors`, exercised over the composed
+/// view + drain-complete promotion).
+#[test]
+fn subscribe_with_errors_delivers_buffers_then_terminal() {
+    let n = 5usize;
+    let (src, _) =
+        ScriptedSource::ending((0..n).map(|_| const_buffer(0.5, 1, 48_000, 480)).collect());
+    let harness = Harness::spawn(
+        cfg(
+            1,
+            vec![GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 0,
+                width: 1,
+            }],
+            vec![SourceSpec {
+                gain: 1.0,
+                group: 0,
+                channels: 0,
+                clock_candidate: false,
+            }],
+            0,
+        ),
+        vec![Box::new(src)],
+    );
+
+    let rx = crate::api::spawn_subscribe_with_errors_thread(
+        harness.stream.clone(),
+        Arc::new(AtomicU64::new(0)),
+    )
+    .expect("subscribe pump spawns");
+
+    let mut frames = 0usize;
+    let mut saw_terminal = false;
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(Ok(buffer)) => frames += buffer.num_frames(),
+            Ok(Err(e)) => {
+                assert!(
+                    e.is_fatal(),
+                    "final delivered error must be fatal, got {e:?}"
+                );
+                saw_terminal = true;
+                break;
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    assert!(saw_terminal, "terminal error must arrive as the final item");
+    assert_eq!(frames, n * 480, "all composed frames delivered via push");
+    // After the terminal item the channel disconnects.
+    assert!(matches!(
+        rx.recv_timeout(Duration::from_secs(1)),
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected)
+    ));
+    harness.shutdown();
+}
+
+/// rsac-7aa2(1): `Composition::subscribe{,_with_errors}` must accept the
+/// drainable `Stopping` window. A composition whose scripted sources end
+/// immediately leaves the engine exited and the composed ring parked in
+/// `Stopping` with the entire output still buffered; subscribing only AFTER
+/// the engine finished (the old `is_running()` gate rejected exactly this
+/// call, stranding the buffered output) must still deliver every composed
+/// frame followed by the clean terminal.
+#[test]
+fn subscribe_after_engine_finished_drains_buffered_tail() {
+    let n = 5usize;
+    let (src, _) =
+        ScriptedSource::ending((0..n).map(|_| const_buffer(0.5, 1, 48_000, 480)).collect());
+    let harness = Harness::spawn(
+        cfg(
+            1,
+            vec![GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 0,
+                width: 1,
+            }],
+            vec![SourceSpec {
+                gain: 1.0,
+                group: 0,
+                channels: 0,
+                clock_candidate: false,
+            }],
+            0,
+        ),
+        vec![Box::new(src)],
+    );
+
+    // Wait until the engine has finished: its signal_done parks the ring in
+    // the drainable Stopping state, so is_running() goes false with the whole
+    // composed output still buffered (nobody has read yet).
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while harness.stream.is_running() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "engine never finished"
+        );
+        std::thread::sleep(Duration::from_millis(1));
+    }
+
+    // Route through the real public handle so the PUBLIC gate is what's under
+    // test: a device-free composition with the harness view attached.
+    let mut composition = CompositionBuilder::new()
+        .group(
+            Group::new("g")
+                .source(crate::core::config::CaptureTarget::SystemDefault)
+                .mixdown(GroupLayout::Mono),
+        )
+        .build()
+        .expect("device-free build");
+    composition.attach_stream_for_tests(Arc::clone(&harness.stream));
+    assert!(
+        !composition.is_running(),
+        "precondition: the engine already finished (Stopping window)"
+    );
+
+    let rx = composition
+        .subscribe_with_errors()
+        .expect("subscribe in the Stopping window must be accepted");
+
+    let mut frames = 0usize;
+    let mut saw_terminal = false;
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(Ok(buffer)) => frames += buffer.num_frames(),
+            Ok(Err(e)) => {
+                assert!(
+                    e.is_fatal(),
+                    "the final error must be the clean terminal, got {e:?}"
+                );
+                saw_terminal = true;
+                break;
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    assert_eq!(
+        frames,
+        n * 480,
+        "the entire buffered output must be drained by the late subscription"
+    );
+    assert!(saw_terminal, "clean end delivered after the drained tail");
+    assert_eq!(
+        composition.subscriber_dropped_count(),
+        0,
+        "an attentive subscriber loses nothing"
+    );
+    harness.shutdown();
+}
+
+/// After the composition ends and the ring drains, the async stream yields a
+/// clean `Ready(None)` (end-of-stream), not a hang and not an error.
+#[cfg(feature = "async-stream")]
+#[test]
+fn async_stream_ends_cleanly_after_composition_end() {
+    use futures_core::Stream as _;
+    use std::pin::Pin;
+    use std::task::{Context, Poll, Waker};
+
+    let (src, _) = ScriptedSource::ending(vec![const_buffer(0.25, 1, 48_000, 480)]);
+    let harness = Harness::spawn(
+        cfg(
+            1,
+            vec![GroupSpec {
+                layout: GroupLayout::Mono,
+                offset: 0,
+                width: 1,
+            }],
+            vec![SourceSpec {
+                gain: 1.0,
+                group: 0,
+                channels: 0,
+                clock_candidate: false,
+            }],
+            0,
+        ),
+        vec![Box::new(src)],
+    );
+
+    let mut stream = crate::bridge::AsyncAudioStream::new(&*harness.stream);
+    let waker = Waker::noop();
+    let mut cx = Context::from_waker(waker);
+
+    let mut yielded_frames = 0usize;
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "async stream never reached end-of-stream"
+        );
+        match Pin::new(&mut stream).poll_next(&mut cx) {
+            Poll::Ready(Some(Ok(buffer))) => yielded_frames += buffer.num_frames(),
+            Poll::Ready(Some(Err(e))) => panic!("unexpected stream error: {e:?}"),
+            Poll::Ready(None) => break, // clean end-of-stream
+            // Noop waker never fires; the engine is asynchronous to this
+            // poll loop, so just re-poll after a short sleep.
+            Poll::Pending => std::thread::sleep(Duration::from_millis(1)),
+        }
+    }
+    assert_eq!(
+        yielded_frames, 480,
+        "the composed buffer flowed through async"
+    );
+    harness.shutdown();
+}
+
+// ── Not-started Composition handle behavior (device-free) ──────────────
+
+#[test]
+fn unstarted_composition_reads_error_and_reports_honestly() {
+    let composition = CompositionBuilder::new()
+        .group(
+            Group::new("main")
+                .source(crate::core::config::CaptureTarget::SystemDefault)
+                .mixdown(GroupLayout::Stereo),
+        )
+        .build()
+        .expect("build touches no devices");
+
+    assert!(!composition.is_running());
+    assert!(composition.channel_map().is_none());
+    assert!(composition.stats().is_none());
+    assert!(matches!(
+        composition.read_chunk_nonblocking(),
+        Err(AudioError::StreamReadError { .. })
+    ));
+    // Push + async delivery modes reject a not-started composition uniformly.
+    assert!(matches!(
+        composition.subscribe(),
+        Err(AudioError::StreamReadError { .. })
+    ));
+    assert!(matches!(
+        composition.subscribe_with_errors(),
+        Err(AudioError::StreamReadError { .. })
+    ));
+    #[cfg(feature = "async-stream")]
+    assert!(matches!(
+        composition.audio_data_stream(),
+        Err(AudioError::StreamReadError { .. })
+    ));
+    // Both stop paths tolerate the not-started state identically (no Err).
+    assert!(CapturingStream::stop(&composition).is_ok());
+    // CapturingStream::format falls back to the provisional (2ch stereo grp).
+    let f = CapturingStream::format(&composition);
+    assert_eq!(f.sample_rate, 48_000);
+    assert_eq!(f.channels, 2);
+}

--- a/src/core/capabilities.rs
+++ b/src/core/capabilities.rs
@@ -94,8 +94,10 @@ pub struct PlatformCapabilities {
     /// before any OS resource is touched.
     ///
     /// `false` on all desktop backends (WASAPI / PipeWire / CoreAudio) and on
-    /// the `unsupported` stub; designed to be `true` for the planned mobile
-    /// backends (ADR-0013, `docs/MOBILE_BACKEND_DESIGN.md`).
+    /// the `unsupported` stub. `true` on iOS, where the App Group identifier
+    /// for the ReplayKit broadcast path is the consent artifact (rsac-b3aa);
+    /// Android flips to `true` when its playback-capture tiers land
+    /// (rsac-77f1). ADR-0013, `docs/MOBILE_BACKEND_DESIGN.md`.
     pub requires_user_consent: bool,
     /// Supported sample formats.
     pub supported_sample_formats: Vec<SampleFormat>,
@@ -277,29 +279,42 @@ impl PlatformCapabilities {
         }
     }
 
-    /// Android capabilities — **microphone slice only** (rsac-20cd).
+    /// Android capabilities — AAudio microphone slice (rsac-20cd) +
+    /// `AudioPlaybackCapture` playback tiers (rsac-77f1).
     ///
     /// Honest current state: the compiled backend captures the default audio
-    /// input via AAudio (`CaptureTarget::Device`). The playback-capture tiers
-    /// (`SystemDefault` / `Application*` / `ProcessTree` via
-    /// `AudioPlaybackCapture` + MediaProjection consent) arrive with
-    /// rsac-77f1/rsac-c4b8 — until then those flags stay `false` and
-    /// `requires_user_consent` stays `false` (the mic needs the RECORD_AUDIO
-    /// *runtime permission*, which is axis-2 readiness, not a config-time
-    /// consent artifact; see the field docs). ADR-0013 fixes the target
-    /// mapping; docs/MOBILE_BACKEND_DESIGN.md has the full design.
+    /// input via AAudio (`CaptureTarget::Device`) on every supported API
+    /// level, and the playback-capture tiers (`SystemDefault` /
+    /// `Application*` / `ProcessTree` via `AudioPlaybackCapture` +
+    /// MediaProjection consent, ADR-0013) on **API 29+** — reported via a
+    /// runtime SDK check ([`get_android_sdk_version`]), the same
+    /// version-probing pattern as macOS's Process Tap gate. On API < 29 the
+    /// playback flags are honestly `false` (`AudioPlaybackCaptureConfiguration`
+    /// does not exist there).
+    ///
+    /// `requires_user_consent: true` when the playback tiers are available:
+    /// the [`AndroidProjectionToken`](crate::core::config::AndroidProjectionToken)
+    /// is the config-time consent artifact (`with_android_projection`);
+    /// `Device` (mic) targets never need it — the mic's RECORD_AUDIO
+    /// *runtime permission* is axis-2 readiness, not a consent artifact
+    /// (see the field docs).
     #[cfg(all(target_os = "android", feature = "feat_android"))]
     fn android() -> Self {
+        // API 29 (Android 10) introduced AudioPlaybackCaptureConfiguration.
+        let playback_capture = get_android_sdk_version() >= 29;
         Self {
-            supports_system_capture: false, // rsac-77f1 (AudioPlaybackCapture)
-            supports_application_capture: false, // rsac-77f1 (addMatchingUid)
-            supports_process_tree_capture: false, // rsac-77f1 (PID→UID ≡ app)
-            // Only the default AAudio input is reachable without the Java
-            // AudioManager device list (arrives with the AAR, rsac-c4b8).
+            supports_system_capture: playback_capture, // AudioPlaybackCapture (rsac-77f1)
+            supports_application_capture: playback_capture, // addMatchingUid
+            supports_process_tree_capture: playback_capture, // PID→UID (tree ≡ app)
+            // Only the default AAudio input + the logical playback endpoint
+            // are reachable without the Java AudioManager device list
+            // (arrives with rsac-ad8a).
             supports_device_selection: false,
             supports_device_change_notifications: false,
-            // Flips to true when the playback-capture tiers land (rsac-77f1).
-            requires_user_consent: false,
+            // The MediaProjection token is the config-time consent artifact
+            // for the playback tiers (ADR-0013); meaningless below API 29
+            // where those tiers don't exist.
+            requires_user_consent: playback_capture,
             // AAudio delivers PCM_I16 or PCM_FLOAT natively.
             supported_sample_formats: vec![SampleFormat::I16, SampleFormat::F32],
             sample_rate_range: (8000, 96000),
@@ -308,27 +323,37 @@ impl PlatformCapabilities {
         }
     }
 
-    /// iOS capabilities — **microphone slice only** (rsac-9e02).
+    /// iOS capabilities — microphone (rsac-9e02) + ReplayKit broadcast system
+    /// capture (rsac-b3aa).
     ///
-    /// Honest current state: the compiled backend captures the session's
-    /// audio input via `AVAudioEngine` (`CaptureTarget::Device`).
-    /// `SystemDefault` (ReplayKit broadcast-extension path, rsac-b3aa) is not
-    /// wired yet; `Application*` / `ProcessTree` are **permanently** `false`
+    /// Honest current state: `CaptureTarget::Device` captures the session's
+    /// audio input via `AVAudioEngine`; `CaptureTarget::SystemDefault` is
+    /// served by the ReplayKit Broadcast Upload Extension transport — hence
+    /// `supports_system_capture: true` **with** `requires_user_consent: true`:
+    /// capture is user-initiated (broadcast picker) and the configuration
+    /// must carry the App Group identifier
+    /// (`AudioCaptureBuilder::with_ios_app_group`, the config-time consent
+    /// artifact per ADR-0013; the app must also embed the RsacBroadcastKit
+    /// extension). `Application*` / `ProcessTree` are **permanently** `false`
     /// on iOS — Apple provides no API for capturing another app's audio
-    /// (ADR-0013; never soften this). `requires_user_consent` stays `false`
-    /// for the mic slice (`NSMicrophoneUsageDescription` is an axis-2 runtime
-    /// permission) and flips to `true` when the ReplayKit path lands.
+    /// (ADR-0013; never soften this). The mic path itself needs only the
+    /// `NSMicrophoneUsageDescription` *runtime* permission (axis-2), not the
+    /// consent artifact.
     #[cfg(all(target_os = "ios", feature = "feat_ios"))]
     fn ios() -> Self {
         Self {
-            supports_system_capture: false,       // rsac-b3aa (ReplayKit path)
-            supports_application_capture: false,  // permanent: no iOS API
+            // ReplayKit broadcast transport (rsac-b3aa): user-initiated,
+            // App Group + embedded RsacBroadcastKit extension required.
+            supports_system_capture: true,
+            supports_application_capture: false, // permanent: no iOS API
             supports_process_tree_capture: false, // permanent: no iOS API
             // Input routing on iOS is session-driven (AVAudioSession routes),
             // not free device selection.
             supports_device_selection: false,
             supports_device_change_notifications: false,
-            requires_user_consent: false, // flips with the ReplayKit path (rsac-b3aa)
+            // The App Group id is the config-time consent artifact for
+            // SystemDefault (ADR-0013); Device (mic) targets never need it.
+            requires_user_consent: true,
             supported_sample_formats: vec![SampleFormat::F32],
             sample_rate_range: (8000, 96000),
             max_channels: 2,
@@ -356,6 +381,59 @@ impl PlatformCapabilities {
 }
 
 // ── macOS version detection ──────────────────────────────────────────────
+
+/// Returns the Android API level (SDK version) of the running device, or
+/// `0` when it cannot be determined.
+///
+/// Reads the `ro.build.version.sdk` system property via
+/// `__system_property_get` (a stable libc export on every Android version)
+/// — no JNI, no subprocess; the same in-process version-probing pattern as
+/// [`get_macos_version`]'s sysctl. A read/parse failure returns `0`, so
+/// version-gated capabilities honestly report `false` rather than claiming
+/// an API that may not exist.
+///
+/// Used by [`PlatformCapabilities`] to gate the playback-capture tiers
+/// (`AudioPlaybackCaptureConfiguration` requires API 29+).
+#[cfg(target_os = "android")]
+pub fn get_android_sdk_version() -> u32 {
+    use std::os::raw::c_char;
+
+    // PROP_VALUE_MAX from <sys/system_properties.h>.
+    const PROP_VALUE_MAX: usize = 92;
+
+    extern "C" {
+        /// Stable Android libc API: copies the property value (NUL-terminated,
+        /// at most PROP_VALUE_MAX bytes including the NUL) into `value` and
+        /// returns its length, or 0 when the property does not exist.
+        fn __system_property_get(name: *const c_char, value: *mut c_char) -> i32;
+    }
+
+    let mut buf = [0u8; PROP_VALUE_MAX];
+    // SAFETY: the name is a NUL-terminated literal and `buf` is at least
+    // PROP_VALUE_MAX bytes, which is the documented maximum the call writes.
+    let len = unsafe {
+        __system_property_get(
+            c"ro.build.version.sdk".as_ptr(),
+            buf.as_mut_ptr().cast::<c_char>(),
+        )
+    };
+    if len <= 0 {
+        log::warn!(
+            "Could not read ro.build.version.sdk; reporting API level 0 \
+             (version-gated capabilities will be false)"
+        );
+        return 0;
+    }
+    let text = std::str::from_utf8(&buf[..len as usize]).unwrap_or("");
+    text.trim().parse().unwrap_or_else(|_| {
+        log::warn!(
+            "Unparseable ro.build.version.sdk value {:?}; reporting API \
+             level 0 (version-gated capabilities will be false)",
+            text
+        );
+        0
+    })
+}
 
 /// Returns the macOS version as `(major, minor, patch)`.
 ///
@@ -617,8 +695,15 @@ mod tests {
     // ── Consent requirement (rsac-82d4) ─────────────────────────────
 
     /// Every desktop backend — and the unsupported stub — must report that no
-    /// config-time consent artifact is required. Mobile backends (ADR-0013)
-    /// will be the first to flip this to `true`.
+    /// config-time consent artifact is required.
+    ///
+    /// Gated off the mobile OSes: iOS honestly reports
+    /// `requires_user_consent: true` (rsac-b3aa — the App Group id is the
+    /// consent artifact for the ReplayKit broadcast path), and Android does
+    /// on API 29+ (rsac-77f1 — the MediaProjection token). Mobile
+    /// consent-reporting is covered by the per-OS capability tests below;
+    /// asserting `false` here on those targets would make the test lie.
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     #[test]
     fn desktop_and_stub_require_no_user_consent() {
         let caps = PlatformCapabilities::query();
@@ -628,33 +713,49 @@ mod tests {
         );
     }
 
-    /// rsac-20cd: the Android mic slice must report its honest partial state —
-    /// no playback-capture tiers, no device selection, no consent artifact
-    /// (those all arrive with rsac-77f1/rsac-c4b8).
+    /// rsac-20cd / rsac-77f1: Android must report its honest state — the
+    /// playback-capture tiers are SDK-gated (`AudioPlaybackCapture` needs
+    /// API 29+) and, exactly when available, carry the consent requirement
+    /// (the MediaProjection token, ADR-0013). The three tiers and the
+    /// consent flag always move together: on Android tree ≡ app ≡ system
+    /// transport-wise (one Kotlin pipeline, UID filter optional).
     #[cfg(all(target_os = "android", feature = "feat_android"))]
     #[test]
-    fn android_mic_slice_reports_honest_partial_capabilities() {
+    fn android_reports_sdk_gated_playback_capture_with_consent() {
         let caps = PlatformCapabilities::query();
         assert_eq!(caps.backend_name, "AAudio");
-        assert!(!caps.supports_system_capture);
-        assert!(!caps.supports_application_capture);
-        assert!(!caps.supports_process_tree_capture);
-        assert!(!caps.requires_user_consent);
+        let expect_playback = get_android_sdk_version() >= 29;
+        assert_eq!(caps.supports_system_capture, expect_playback);
+        assert_eq!(caps.supports_application_capture, expect_playback);
+        assert_eq!(caps.supports_process_tree_capture, expect_playback);
+        assert_eq!(
+            caps.requires_user_consent, expect_playback,
+            "the MediaProjection token is required exactly when the playback \
+             tiers exist (ADR-0013)"
+        );
+        assert!(!caps.supports_device_selection, "rsac-ad8a pending");
         assert!(caps.supports_format(SampleFormat::F32));
         assert!(caps.supports_sample_rate(48000));
     }
 
-    /// rsac-9e02: the iOS mic slice must report its honest partial state.
-    /// `Application*`/`ProcessTree` are PERMANENTLY false on iOS (ADR-0013).
+    /// rsac-9e02 / rsac-b3aa: iOS must report its honest state — system
+    /// capture available (ReplayKit broadcast) **with** the consent
+    /// requirement, `Application*`/`ProcessTree` PERMANENTLY false (ADR-0013).
     #[cfg(all(target_os = "ios", feature = "feat_ios"))]
     #[test]
-    fn ios_mic_slice_reports_honest_partial_capabilities() {
+    fn ios_reports_broadcast_system_capture_with_consent() {
         let caps = PlatformCapabilities::query();
         assert_eq!(caps.backend_name, "AVAudioEngine");
-        assert!(!caps.supports_system_capture);
-        assert!(!caps.supports_application_capture);
-        assert!(!caps.supports_process_tree_capture);
-        assert!(!caps.requires_user_consent);
+        assert!(
+            caps.supports_system_capture,
+            "SystemDefault is served by the ReplayKit broadcast path (rsac-b3aa)"
+        );
+        assert!(
+            caps.requires_user_consent,
+            "the App Group id is the config-time consent artifact (ADR-0013)"
+        );
+        assert!(!caps.supports_application_capture, "permanent: no iOS API");
+        assert!(!caps.supports_process_tree_capture, "permanent: no iOS API");
         assert!(caps.supports_format(SampleFormat::F32));
         assert!(caps.supports_sample_rate(48000));
     }

--- a/src/core/capabilities.rs
+++ b/src/core/capabilities.rs
@@ -17,6 +17,37 @@ use super::config::SampleFormat;
 /// [`PlatformCapabilities::query()`] and check before attempting
 /// operations that may not be available on all platforms.
 ///
+/// # Capability vs. readiness
+///
+/// A `PlatformCapabilities` value answers a **static** question: *can this
+/// build, on this OS, do this kind of thing at all?* It is derived from the
+/// target OS + enabled backend feature (and, on macOS, the runtime OS version
+/// for Process-Tap gating). It is **not** a promise that a *specific* capture
+/// will succeed right now. Three separate axes must all hold for a capture to
+/// start:
+///
+/// 1. **Capability** (this type) — e.g. `supports_application_capture`. If
+///    `false`, [`AudioCaptureBuilder::build`](crate::api::AudioCaptureBuilder::build)
+///    fails its preflight with
+///    [`PlatformNotSupported`](crate::core::error::AudioError::PlatformNotSupported)
+///    before touching any device.
+/// 2. **Permission** — a *runtime* grant, distinct from capability. On macOS
+///    per-application capture needs the Audio-Capture TCC permission even when
+///    `supports_application_capture == true`; query it with
+///    [`check_audio_capture_permission`](crate::core::introspection::check_audio_capture_permission).
+/// 3. **Readiness / resolution** — whether the specific
+///    [`CaptureTarget`](crate::core::config::CaptureTarget) resolves *now* (the
+///    device is present, the PID/app exists and is producing audio). A capable,
+///    permitted platform can still fail here with
+///    [`DeviceNotFound`](crate::core::error::AudioError::DeviceNotFound) /
+///    [`ApplicationNotFound`](crate::core::error::AudioError::ApplicationNotFound)
+///    at build/start time.
+///
+/// So `caps.supports_application_capture == true` means "this platform can
+/// capture *some* application" — not "application `X` is capturable right now".
+/// Treat capability as a gate you check first, then handle permission and
+/// per-target resolution errors when they occur.
+///
 /// # Example
 ///
 /// ```
@@ -24,7 +55,9 @@ use super::config::SampleFormat;
 ///
 /// let caps = PlatformCapabilities::query();
 /// if caps.supports_application_capture {
-///     // Safe to use CaptureTarget::Application(..)
+///     // Capability holds — but a specific CaptureTarget::Application(pid) can
+///     // still fail with ApplicationNotFound (readiness) or need a permission
+///     // grant, handled when build()/start() is called.
 /// }
 /// ```
 #[derive(Debug, Clone)]
@@ -46,6 +79,24 @@ pub struct PlatformCapabilities {
     /// wired up. Each platform arm flips this to `true` only once its OS listener
     /// is implemented.
     pub supports_device_change_notifications: bool,
+    /// Whether starting a capture on this platform requires an explicit
+    /// **user-consent artifact** to be supplied to the builder before
+    /// `build()`.
+    ///
+    /// This is distinct from a runtime OS permission grant (axis 2 in
+    /// "Capability vs. readiness" above): consent here is an artifact the
+    /// *configuration* must carry — e.g. Android's `MediaProjection` token
+    /// (obtained from a user dialog and passed via
+    /// `AudioCaptureBuilder::with_android_projection`) or an iOS
+    /// user-initiated broadcast session. When `true` and the artifact is
+    /// missing for a target that needs it, the builder preflight fails with
+    /// [`UserConsentRequired`](crate::core::error::AudioError::UserConsentRequired)
+    /// before any OS resource is touched.
+    ///
+    /// `false` on all desktop backends (WASAPI / PipeWire / CoreAudio) and on
+    /// the `unsupported` stub; designed to be `true` for the planned mobile
+    /// backends (ADR-0013, `docs/MOBILE_BACKEND_DESIGN.md`).
+    pub requires_user_consent: bool,
     /// Supported sample formats.
     pub supported_sample_formats: Vec<SampleFormat>,
     /// Supported sample rate range (min, max) in Hz.
@@ -81,6 +132,18 @@ impl PlatformCapabilities {
         &Self::SUPPORTED_SAMPLE_RATES
     }
 
+    /// Human-readable rendering of [`SUPPORTED_SAMPLE_RATES`](Self::SUPPORTED_SAMPLE_RATES)
+    /// (`"22050, 32000, 44100, 48000, 88200, 96000"`), single-sourced from the
+    /// const so validation error messages (the capture builder's and the
+    /// compose builder's) can never drift from the actual whitelist.
+    pub(crate) fn supported_sample_rates_display() -> String {
+        Self::SUPPORTED_SAMPLE_RATES
+            .iter()
+            .map(|r| r.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
     /// Query the capabilities of the current platform's audio backend.
     ///
     /// Determined at compile time from BOTH the target OS *and* the matching
@@ -106,6 +169,16 @@ impl PlatformCapabilities {
         #[cfg(all(target_os = "linux", feature = "feat_linux"))]
         {
             return Self::linux();
+        }
+
+        #[cfg(all(target_os = "android", feature = "feat_android"))]
+        {
+            return Self::android();
+        }
+
+        #[cfg(all(target_os = "ios", feature = "feat_ios"))]
+        {
+            return Self::ios();
         }
 
         // OS without its backend feature enabled, or an unsupported OS: no
@@ -145,6 +218,8 @@ impl PlatformCapabilities {
             supports_device_selection: true,
             // IMMNotificationClient watch() arm is implemented (rsac-e360).
             supports_device_change_notifications: true,
+            // Desktop loopback needs no consent artifact (rsac-82d4).
+            requires_user_consent: false,
             supported_sample_formats: vec![
                 SampleFormat::I16,
                 SampleFormat::I24,
@@ -171,6 +246,9 @@ impl PlatformCapabilities {
             // CoreAudio AudioObjectPropertyListener watch() arm landed (rsac-3093):
             // device-list + default-output/input change notifications are wired up.
             supports_device_change_notifications: true,
+            // TCC is a runtime permission, not a config-time consent artifact
+            // (see the field docs) — so this stays false on macOS (rsac-82d4).
+            requires_user_consent: false,
             supported_sample_formats: vec![SampleFormat::I16, SampleFormat::I32, SampleFormat::F32],
             sample_rate_range: (8000, 192000),
             max_channels: 8,
@@ -190,10 +268,71 @@ impl PlatformCapabilities {
             // `default` metadata listener thread that delivers DeviceAdded /
             // DeviceRemoved / DefaultChanged.
             supports_device_change_notifications: true,
+            // Desktop loopback needs no consent artifact (rsac-82d4).
+            requires_user_consent: false,
             supported_sample_formats: vec![SampleFormat::I16, SampleFormat::I32, SampleFormat::F32],
             sample_rate_range: (8000, 384000),
             max_channels: 32, // PipeWire supports many channels
             backend_name: "PipeWire",
+        }
+    }
+
+    /// Android capabilities — **microphone slice only** (rsac-20cd).
+    ///
+    /// Honest current state: the compiled backend captures the default audio
+    /// input via AAudio (`CaptureTarget::Device`). The playback-capture tiers
+    /// (`SystemDefault` / `Application*` / `ProcessTree` via
+    /// `AudioPlaybackCapture` + MediaProjection consent) arrive with
+    /// rsac-77f1/rsac-c4b8 — until then those flags stay `false` and
+    /// `requires_user_consent` stays `false` (the mic needs the RECORD_AUDIO
+    /// *runtime permission*, which is axis-2 readiness, not a config-time
+    /// consent artifact; see the field docs). ADR-0013 fixes the target
+    /// mapping; docs/MOBILE_BACKEND_DESIGN.md has the full design.
+    #[cfg(all(target_os = "android", feature = "feat_android"))]
+    fn android() -> Self {
+        Self {
+            supports_system_capture: false, // rsac-77f1 (AudioPlaybackCapture)
+            supports_application_capture: false, // rsac-77f1 (addMatchingUid)
+            supports_process_tree_capture: false, // rsac-77f1 (PID→UID ≡ app)
+            // Only the default AAudio input is reachable without the Java
+            // AudioManager device list (arrives with the AAR, rsac-c4b8).
+            supports_device_selection: false,
+            supports_device_change_notifications: false,
+            // Flips to true when the playback-capture tiers land (rsac-77f1).
+            requires_user_consent: false,
+            // AAudio delivers PCM_I16 or PCM_FLOAT natively.
+            supported_sample_formats: vec![SampleFormat::I16, SampleFormat::F32],
+            sample_rate_range: (8000, 96000),
+            max_channels: 2,
+            backend_name: "AAudio",
+        }
+    }
+
+    /// iOS capabilities — **microphone slice only** (rsac-9e02).
+    ///
+    /// Honest current state: the compiled backend captures the session's
+    /// audio input via `AVAudioEngine` (`CaptureTarget::Device`).
+    /// `SystemDefault` (ReplayKit broadcast-extension path, rsac-b3aa) is not
+    /// wired yet; `Application*` / `ProcessTree` are **permanently** `false`
+    /// on iOS — Apple provides no API for capturing another app's audio
+    /// (ADR-0013; never soften this). `requires_user_consent` stays `false`
+    /// for the mic slice (`NSMicrophoneUsageDescription` is an axis-2 runtime
+    /// permission) and flips to `true` when the ReplayKit path lands.
+    #[cfg(all(target_os = "ios", feature = "feat_ios"))]
+    fn ios() -> Self {
+        Self {
+            supports_system_capture: false,       // rsac-b3aa (ReplayKit path)
+            supports_application_capture: false,  // permanent: no iOS API
+            supports_process_tree_capture: false, // permanent: no iOS API
+            // Input routing on iOS is session-driven (AVAudioSession routes),
+            // not free device selection.
+            supports_device_selection: false,
+            supports_device_change_notifications: false,
+            requires_user_consent: false, // flips with the ReplayKit path (rsac-b3aa)
+            supported_sample_formats: vec![SampleFormat::F32],
+            sample_rate_range: (8000, 96000),
+            max_channels: 2,
+            backend_name: "AVAudioEngine",
         }
     }
 
@@ -207,6 +346,7 @@ impl PlatformCapabilities {
             supports_process_tree_capture: false,
             supports_device_selection: false,
             supports_device_change_notifications: false,
+            requires_user_consent: false,
             supported_sample_formats: vec![],
             sample_rate_range: (0, 0),
             max_channels: 0,
@@ -432,6 +572,7 @@ mod tests {
             supports_process_tree_capture: false,
             supports_device_selection: false,
             supports_device_change_notifications: false,
+            requires_user_consent: false,
             supported_sample_formats: vec![SampleFormat::I16],
             sample_rate_range: (8000, 48000),
             max_channels: 2,
@@ -471,6 +612,51 @@ mod tests {
     fn supports_channels_zero_is_false() {
         let caps = PlatformCapabilities::query();
         assert!(!caps.supports_channels(0));
+    }
+
+    // ── Consent requirement (rsac-82d4) ─────────────────────────────
+
+    /// Every desktop backend — and the unsupported stub — must report that no
+    /// config-time consent artifact is required. Mobile backends (ADR-0013)
+    /// will be the first to flip this to `true`.
+    #[test]
+    fn desktop_and_stub_require_no_user_consent() {
+        let caps = PlatformCapabilities::query();
+        assert!(
+            !caps.requires_user_consent,
+            "no desktop backend (or the unsupported stub) requires a consent artifact"
+        );
+    }
+
+    /// rsac-20cd: the Android mic slice must report its honest partial state —
+    /// no playback-capture tiers, no device selection, no consent artifact
+    /// (those all arrive with rsac-77f1/rsac-c4b8).
+    #[cfg(all(target_os = "android", feature = "feat_android"))]
+    #[test]
+    fn android_mic_slice_reports_honest_partial_capabilities() {
+        let caps = PlatformCapabilities::query();
+        assert_eq!(caps.backend_name, "AAudio");
+        assert!(!caps.supports_system_capture);
+        assert!(!caps.supports_application_capture);
+        assert!(!caps.supports_process_tree_capture);
+        assert!(!caps.requires_user_consent);
+        assert!(caps.supports_format(SampleFormat::F32));
+        assert!(caps.supports_sample_rate(48000));
+    }
+
+    /// rsac-9e02: the iOS mic slice must report its honest partial state.
+    /// `Application*`/`ProcessTree` are PERMANENTLY false on iOS (ADR-0013).
+    #[cfg(all(target_os = "ios", feature = "feat_ios"))]
+    #[test]
+    fn ios_mic_slice_reports_honest_partial_capabilities() {
+        let caps = PlatformCapabilities::query();
+        assert_eq!(caps.backend_name, "AVAudioEngine");
+        assert!(!caps.supports_system_capture);
+        assert!(!caps.supports_application_capture);
+        assert!(!caps.supports_process_tree_capture);
+        assert!(!caps.requires_user_consent);
+        assert!(caps.supports_format(SampleFormat::F32));
+        assert!(caps.supports_sample_rate(48000));
     }
 
     // ── Additional tests ────────────────────────────────────────────

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -454,6 +454,43 @@ pub struct StreamConfig {
     /// Propagated from [`AudioCaptureBuilder`](crate::api::AudioCaptureBuilder) so backends know
     /// whether to do system, application, or process-tree capture.
     pub capture_target: CaptureTarget,
+    /// App Group identifier for iOS system-audio capture *(iOS targets only)*.
+    ///
+    /// [`CaptureTarget::SystemDefault`] on iOS is the ReplayKit Broadcast
+    /// Upload Extension transport (ADR-0013): the extension writes audio into
+    /// a memory-mapped ring in the **shared App Group container**, and the
+    /// host-side consumer needs the group's identifier (e.g.
+    /// `"group.com.example.myapp.rsac"`) to locate that container. The id is
+    /// the config-time **consent artifact** for iOS — the analog of Android's
+    /// [`AndroidProjectionToken`] — set via
+    /// [`AudioCaptureBuilder::with_ios_app_group`](crate::api::AudioCaptureBuilder::with_ios_app_group);
+    /// `SystemDefault` builds without one fail the preflight with
+    /// [`UserConsentRequired`](crate::core::error::AudioError::UserConsentRequired).
+    /// Microphone ([`CaptureTarget::Device`]) targets never need it.
+    ///
+    /// Deliberately a plain `Option<String>` rather than a newtype: an App
+    /// Group id is an opaque, well-known Apple string format with no
+    /// invariants this crate could enforce — the only meaningful validation
+    /// is `containerURLForSecurityApplicationGroupIdentifier:` resolving it
+    /// at stream creation, where failure surfaces as an actionable error.
+    #[cfg(target_os = "ios")]
+    pub ios_app_group: Option<String>,
+    /// MediaProjection consent token for Android playback capture *(Android
+    /// targets only)*.
+    ///
+    /// The playback-capture tiers ([`CaptureTarget::SystemDefault`],
+    /// `Application*`, `ProcessTree`) on Android ride
+    /// `AudioPlaybackCaptureConfiguration`, which requires a user-consented
+    /// `MediaProjection` (ADR-0013). The token is the config-time **consent
+    /// artifact** — the analog of iOS's `ios_app_group` — set via
+    /// [`AudioCaptureBuilder::with_android_projection`](crate::api::AudioCaptureBuilder::with_android_projection)
+    /// and propagated here by `build()` so the backend's `create_stream`
+    /// can resolve it back to the projection object through JNI.
+    /// Playback-target builds without one fail the preflight with
+    /// [`UserConsentRequired`](crate::core::error::AudioError::UserConsentRequired).
+    /// Microphone ([`CaptureTarget::Device`]) targets never need it.
+    #[cfg(target_os = "android")]
+    pub android_projection: Option<AndroidProjectionToken>,
 }
 
 impl Default for StreamConfig {
@@ -465,6 +502,10 @@ impl Default for StreamConfig {
             sample_format: SampleFormat::F32,
             buffer_size: None,
             capture_target: CaptureTarget::default(), // SystemDefault
+            #[cfg(target_os = "ios")]
+            ios_app_group: None,
+            #[cfg(target_os = "android")]
+            android_projection: None,
         }
     }
 }
@@ -1176,6 +1217,10 @@ mod tests {
             sample_format: SampleFormat::I24,
             buffer_size: Some(1024),
             capture_target: CaptureTarget::SystemDefault,
+            #[cfg(target_os = "ios")]
+            ios_app_group: None,
+            #[cfg(target_os = "android")]
+            android_projection: None,
         };
         let fmt = cfg.to_audio_format();
         assert_eq!(fmt.sample_rate, 44100);
@@ -1198,6 +1243,10 @@ mod tests {
             sample_format: SampleFormat::I16,
             buffer_size: Some(512),
             capture_target: CaptureTarget::SystemDefault,
+            #[cfg(target_os = "ios")]
+            ios_app_group: None,
+            #[cfg(target_os = "android")]
+            android_projection: None,
         };
         assert_eq!(cfg.buffer_size, Some(512));
     }
@@ -1221,6 +1270,10 @@ mod tests {
                 sample_format: SampleFormat::F32,
                 buffer_size: Some(2048),
                 capture_target: CaptureTarget::ProcessTree(ProcessId(999)),
+                #[cfg(target_os = "ios")]
+                ios_app_group: None,
+                #[cfg(target_os = "android")]
+                android_projection: None,
             },
         };
         assert_eq!(cfg.target, CaptureTarget::ProcessTree(ProcessId(999)));

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -14,6 +14,24 @@
 // ── ID Newtypes ──────────────────────────────────────────────────────────
 
 /// Opaque identifier for an audio device.
+///
+/// The string is a **platform-specific device identifier**, interpreted by the
+/// backend when a [`CaptureTarget::Device`] is resolved:
+///
+/// - **Windows (WASAPI):** the endpoint ID string (as returned by
+///   [`AudioDevice::id`](crate::core::interface::AudioDevice::id)); an empty
+///   string or `"default"` (case-insensitive) selects the default render
+///   endpoint for loopback capture.
+/// - **Linux (PipeWire):** the node `id` **or** `object.serial` string of an
+///   `Audio/Sink` or `Audio/Source` node.
+/// - **macOS (CoreAudio):** the numeric `AudioDeviceID` rendered as a decimal
+///   string (**not** a device UID). The device must expose input streams.
+///
+/// Always obtain a `DeviceId` from
+/// [`DeviceEnumerator::enumerate_devices`](crate::core::interface::DeviceEnumerator::enumerate_devices)
+/// / [`AudioDevice::id`](crate::core::interface::AudioDevice::id) rather than
+/// hand-constructing one, since the encoding differs per platform. An
+/// unresolvable id yields [`AudioError::DeviceNotFound`](crate::core::error::AudioError::DeviceNotFound).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DeviceId(pub String);
 
@@ -23,7 +41,24 @@ impl std::fmt::Display for DeviceId {
     }
 }
 
-/// Opaque identifier for an application (audio session).
+/// Opaque identifier for an application to capture.
+///
+/// **The string is a numeric OS process id (PID), in decimal, on every
+/// platform** — it is *not* an audio-session GUID, a bundle id, or an
+/// application name. When a [`CaptureTarget::Application`] is resolved the
+/// backend parses `ApplicationId.0` as a `u32` PID:
+///
+/// - **Windows (WASAPI):** process-loopback capture of that single PID
+///   (`include_tree = false`).
+/// - **Linux (PipeWire):** the first `Stream/Output/Audio` node whose
+///   `application.process.id` equals the PID.
+/// - **macOS (CoreAudio):** a Process Tap on that single PID.
+///
+/// A non-numeric string, or a PID with no matching audio, yields
+/// [`AudioError::ApplicationNotFound`](crate::core::error::AudioError::ApplicationNotFound).
+/// To target an application by its human-readable name instead, use
+/// [`CaptureTarget::ApplicationByName`]; to include child processes, use
+/// [`CaptureTarget::ProcessTree`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ApplicationId(pub String);
 
@@ -43,6 +78,49 @@ impl std::fmt::Display for ProcessId {
     }
 }
 
+/// Opaque handle to an Android `MediaProjection` user-consent grant
+/// *(Android targets only)*.
+///
+/// Playback capture on Android (API 29+) is gated behind a user-consent
+/// dialog that yields a `MediaProjection`. The platform glue (the rsac
+/// Android consent helper — see `docs/MOBILE_BACKEND_DESIGN.md`) wraps that
+/// projection in a JNI `GlobalRef` and hands the pointer-sized handle across
+/// as an opaque `i64`. Rust never interprets the value; it is carried to the
+/// (future) Android backend, which resolves it back through JNI.
+///
+/// Supply it to the builder via
+/// [`AudioCaptureBuilder::with_android_projection`](crate::api::AudioCaptureBuilder::with_android_projection);
+/// playback-capture targets without one fail the `build()` preflight with
+/// [`UserConsentRequired`](crate::core::error::AudioError::UserConsentRequired)
+/// once a backend advertises the capability (ADR-0013). Microphone
+/// ([`CaptureTarget::Device`]) targets never need a token.
+///
+/// One token corresponds to one projection session: the backend releases the
+/// underlying `GlobalRef` (and stops the `MediaProjection`) when the owning
+/// capture is dropped. A stale or hand-rolled value is not undefined behavior
+/// at this layer — it surfaces as a backend error when the projection is
+/// first used.
+#[cfg(target_os = "android")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AndroidProjectionToken(i64);
+
+#[cfg(target_os = "android")]
+impl AndroidProjectionToken {
+    /// Wraps a raw consent-token handle produced by the rsac Android consent
+    /// helper (`RsacProjection.request(activity)`).
+    ///
+    /// The value is opaque to Rust; correctness is the producer's contract.
+    pub fn from_raw(raw: i64) -> Self {
+        Self(raw)
+    }
+
+    /// Returns the raw opaque handle (for the backend's JNI layer and the C
+    /// FFI, which carry it as `int64_t`).
+    pub fn as_raw(&self) -> i64 {
+        self.0
+    }
+}
+
 // ── CaptureTarget ────────────────────────────────────────────────────────
 
 /// Unified capture target model covering all capture modes.
@@ -50,6 +128,20 @@ impl std::fmt::Display for ProcessId {
 /// This enum specifies *what* audio should be captured. It replaces the old
 /// combination of `DeviceSelector` + PID/session fields with a single,
 /// explicit discriminated union.
+///
+/// # Target semantics (per platform)
+///
+/// The variants below document the *intended contract*; the exact resolution
+/// mechanism differs per backend but the observable behavior is kept aligned.
+/// A target that cannot be resolved fails at
+/// [`build`](crate::api::AudioCaptureBuilder::build) time (or `start`) with a
+/// specific [`AudioError`](crate::core::error::AudioError) rather than silently
+/// capturing nothing — see each variant. Whether a variant is usable at all on
+/// the current platform is reported by
+/// [`PlatformCapabilities`](crate::core::capabilities::PlatformCapabilities);
+/// **capability** (does the platform support this *kind* of target) is distinct
+/// from **readiness** (does *this specific* device/app/pid resolve right now) —
+/// see the `PlatformCapabilities` docs.
 ///
 /// # Stability
 ///
@@ -62,15 +154,71 @@ impl std::fmt::Display for ProcessId {
 #[non_exhaustive]
 pub enum CaptureTarget {
     /// Capture from the system default audio device / mix.
+    ///
+    /// Captures the default output endpoint via loopback (WASAPI loopback,
+    /// PipeWire default sink monitor, CoreAudio system tap). Supported on all
+    /// three platforms; the one target that never requires per-app/PID
+    /// resolution.
     #[default]
     SystemDefault,
     /// Capture from a specific device identified by [`DeviceId`].
+    ///
+    /// The [`DeviceId`] encoding is platform-specific (see [`DeviceId`]).
+    /// Targeting an output-only device for capture may yield no data on some
+    /// platforms unless loopback applies — prefer [`SystemDefault`](Self::SystemDefault)
+    /// for output loopback. Unresolvable id →
+    /// [`AudioError::DeviceNotFound`](crate::core::error::AudioError::DeviceNotFound)
+    /// (macOS additionally rejects an output-only device with
+    /// [`PlatformNotSupported`](crate::core::error::AudioError::PlatformNotSupported)).
     Device(DeviceId),
-    /// Capture audio from a specific application session identified by [`ApplicationId`].
+    /// Capture audio from a **single application**, identified by its PID carried
+    /// in the [`ApplicationId`] string (see [`ApplicationId`] — the string is a
+    /// decimal PID on every platform, not a name or session id).
+    ///
+    /// This captures **only that one process's** audio, **not** its child
+    /// processes — use [`ProcessTree`](Self::ProcessTree) for the subtree. A
+    /// non-numeric id, or a PID producing no audio, →
+    /// [`AudioError::ApplicationNotFound`](crate::core::error::AudioError::ApplicationNotFound)
+    /// (Windows may report
+    /// [`ApplicationCaptureFailed`](crate::core::error::AudioError::ApplicationCaptureFailed)
+    /// if the loopback client cannot be created). Requires
+    /// `supports_application_capture`.
     Application(ApplicationId),
-    /// Capture audio from the first application whose name matches the given string.
+    /// Capture audio from the **first** application whose name matches the given
+    /// string.
+    ///
+    /// Matching is **exact and case-insensitive** (not substring) on every
+    /// platform; when multiple applications match, the **first** one found wins
+    /// (enumeration order is unspecified — do not rely on which of several
+    /// identically-named processes is chosen). The matched field differs per
+    /// platform:
+    ///
+    /// - **Windows (WASAPI):** the OS process name (with flexible `.exe`
+    ///   handling — `"vlc"`, `"vlc.exe"` both match `vlc.exe`).
+    /// - **Linux (PipeWire):** `application.name` **or** `application.process.binary`.
+    /// - **macOS (CoreAudio):** `NSRunningApplication.localizedName`
+    ///   (e.g. `"Safari"`, `"Music"`).
+    ///
+    /// Resolves to a PID and then behaves like [`Application`](Self::Application)
+    /// (single process). No match →
+    /// [`AudioError::ApplicationNotFound`](crate::core::error::AudioError::ApplicationNotFound).
+    /// Requires `supports_application_capture`.
     ApplicationByName(String),
-    /// Capture audio from a process and its child processes, identified by [`ProcessId`].
+    /// Capture audio from a process **and its descendant processes**, identified
+    /// by [`ProcessId`].
+    ///
+    /// Descendant coverage differs per platform (a documented divergence):
+    ///
+    /// - **Windows (WASAPI):** the OS's full-tree loopback flag
+    ///   (`PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE`) — all descendants.
+    /// - **Linux (PipeWire):** a recursive `/proc` walk collects the full
+    ///   descendant set (all levels).
+    /// - **macOS (CoreAudio):** the parent **plus its direct children only**
+    ///   (one level) — deeper descendants are **not** currently included.
+    ///
+    /// No matching audio node/session →
+    /// [`AudioError::ApplicationNotFound`](crate::core::error::AudioError::ApplicationNotFound).
+    /// Requires `supports_process_tree_capture`.
     ProcessTree(ProcessId),
 }
 
@@ -289,11 +437,14 @@ pub struct StreamConfig {
     ///
     /// # Platform support (current state)
     ///
-    /// **Honored only on Windows (WASAPI) today.** The Linux (PipeWire) and macOS
-    /// (CoreAudio) backends hardcode `calculate_capacity(None, 4)` and ignore this
-    /// field, so setting it has no effect there — they always get the 64-slot default.
-    /// Threading the request (or a period-derived size) through every backend is
-    /// tracked in ADR-0007 (`docs/designs/0007-capacity-period-sizing.md`).
+    /// **Honored on Windows (WASAPI) and Linux (PipeWire) today.** Both pass
+    /// this straight into `calculate_capacity(requested, 4)` when sizing the
+    /// bridge ring, so it controls the ring depth (rounded up to a power of two,
+    /// min 4). The macOS (CoreAudio) backend still hardcodes
+    /// `calculate_capacity(None, 4)` and ignores this field, so setting it has
+    /// no effect there — it always gets the 64-slot default. Threading a
+    /// period-derived size through every backend is tracked in ADR-0007
+    /// (`docs/designs/0007-capacity-period-sizing.md`).
     ///
     /// The [`buffer_size_frames`](crate::api::AudioCaptureBuilder::buffer_size_frames)
     /// builder setter is a backward-compat alias that writes this same field; its
@@ -838,6 +989,107 @@ mod tests {
         assert_eq!(
             "name:Firefox".parse::<CaptureTarget>().unwrap(),
             CaptureTarget::ApplicationByName("Firefox".to_string())
+        );
+    }
+
+    // ── CaptureTarget: documented target semantics (contract) ────────
+    //
+    // These pin the semantics documented on the CaptureTarget variants and the
+    // ID newtypes so a refactor cannot quietly change what a target *means*.
+
+    /// `ApplicationId` carries a **numeric PID string** (not a name/session id),
+    /// and it round-trips losslessly through the `app:<pid>` canonical form —
+    /// the encoding every platform backend parses back into a `u32` PID.
+    #[test]
+    fn application_id_is_a_numeric_pid_string_and_round_trips() {
+        let target = CaptureTarget::Application(ApplicationId("1234".to_string()));
+        assert_eq!(target.to_string(), "app:1234");
+        assert_eq!("app:1234".parse::<CaptureTarget>().unwrap(), target);
+
+        // The carried string parses as a u32 PID (the backend contract).
+        if let CaptureTarget::Application(ApplicationId(s)) = &target {
+            assert_eq!(s.parse::<u32>().unwrap(), 1234);
+        } else {
+            panic!("expected Application variant");
+        }
+    }
+
+    /// `Application(pid)` (single app) is a DISTINCT target from
+    /// `ProcessTree(pid)` (the subtree) for the same PID — the documented
+    /// single-process vs process-tree distinction. `to_capture_target()` on a
+    /// discovered app deliberately picks the narrow `Application` form (see
+    /// introspection tests); this asserts the two are not interchangeable.
+    #[test]
+    fn application_and_process_tree_are_distinct_for_same_pid() {
+        let single = CaptureTarget::Application(ApplicationId("42".to_string()));
+        let tree = CaptureTarget::ProcessTree(ProcessId(42));
+        assert_ne!(single, tree, "single-app capture != process-tree capture");
+        // Their canonical forms differ too, so a string round-trip preserves the
+        // distinction across a CLI/config boundary.
+        assert_eq!(single.to_string(), "app:42");
+        assert_eq!(tree.to_string(), "tree:42");
+        assert_ne!(single.to_string(), tree.to_string());
+    }
+
+    /// `ApplicationByName` carries the raw name verbatim (case preserved in the
+    /// body; only the *scheme* is case-insensitive on parse), and is a distinct
+    /// target from an `Application(pid)` — name resolution happens in the backend,
+    /// not in the type. The name is NOT coerced to a PID at the type level.
+    #[test]
+    fn application_by_name_preserves_name_and_is_distinct_from_application() {
+        let by_name = CaptureTarget::ApplicationByName("Mixed Case App".to_string());
+        assert_eq!(by_name.to_string(), "name:Mixed Case App");
+        assert_eq!(
+            "name:Mixed Case App".parse::<CaptureTarget>().unwrap(),
+            by_name
+        );
+        // A numeric name string is still ApplicationByName, NOT Application —
+        // the type never reinterprets a name as a PID.
+        let numeric_name = "name:1234".parse::<CaptureTarget>().unwrap();
+        assert_eq!(
+            numeric_name,
+            CaptureTarget::ApplicationByName("1234".to_string())
+        );
+        assert_ne!(
+            numeric_name,
+            CaptureTarget::Application(ApplicationId("1234".to_string()))
+        );
+    }
+
+    /// `DeviceId` is opaque and preserved verbatim (including embedded colons),
+    /// so a platform-specific id (`hw:0,0`, a numeric CoreAudio id, a PipeWire
+    /// serial) round-trips unchanged through the `device:<id>` form.
+    #[test]
+    fn device_id_is_opaque_and_round_trips_verbatim() {
+        for id in ["hw:0,0", "63", "alsa_output.pci-0000_00", ""] {
+            let target = CaptureTarget::Device(DeviceId(id.to_string()));
+            let rendered = target.to_string();
+            assert_eq!(rendered, format!("device:{id}"));
+            assert_eq!(rendered.parse::<CaptureTarget>().unwrap(), target);
+        }
+    }
+
+    /// The convenience constructors map to exactly the documented variants,
+    /// keeping `app()` = by-name and `pid()` = process-tree (subtree) — the pair
+    /// that mirrors the `ApplicationByName` / `ProcessTree` distinction.
+    #[test]
+    fn convenience_constructors_match_documented_variants() {
+        assert_eq!(
+            CaptureTarget::app("VLC"),
+            CaptureTarget::ApplicationByName("VLC".to_string())
+        );
+        assert_eq!(
+            CaptureTarget::pid(9),
+            CaptureTarget::ProcessTree(ProcessId(9))
+        );
+        assert_eq!(
+            CaptureTarget::device("hw:1,0"),
+            CaptureTarget::Device(DeviceId("hw:1,0".to_string()))
+        );
+        // app() is by-NAME, never by-pid: it is not Application(ApplicationId).
+        assert_ne!(
+            CaptureTarget::app("9"),
+            CaptureTarget::Application(ApplicationId("9".to_string()))
         );
     }
 

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -31,12 +31,24 @@ use std::fmt;
 /// grow in a way that silently breaks exhaustive matches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ErrorKind {
+    /// Invalid or unsupported capture configuration (bad parameter values,
+    /// unsupported formats).
     Configuration,
+    /// Audio device problems: not found, unavailable, or enumeration failure.
     Device,
+    /// Stream lifecycle and data-flow failures: create/start/stop errors,
+    /// read errors, end-of-stream, and ring-buffer over/underruns.
     Stream,
+    /// Platform backend (WASAPI, PipeWire, CoreAudio) operation or
+    /// initialization failures.
     Backend,
+    /// Application-capture failures: target app not found or its audio
+    /// session could not be captured.
     Application,
+    /// Platform-level constraints: unsupported features on the current OS or
+    /// permission denials.
     Platform,
+    /// Internal invariant violations, unexpected errors, and timeouts.
     Internal,
 }
 
@@ -117,7 +129,7 @@ impl fmt::Display for BackendContext {
 
 /// Represents all errors that can occur during audio operations.
 ///
-/// Organized into 7 categories with 22 total variants.
+/// Organized into 7 categories with 23 total variants.
 /// Each variant carries structured context for diagnostics.
 ///
 /// # Stability
@@ -137,90 +149,190 @@ impl fmt::Display for BackendContext {
 pub enum AudioError {
     // ── Configuration errors ─────────────────────────────────────────
     /// A parameter value is invalid.
-    InvalidParameter { param: String, reason: String },
+    InvalidParameter {
+        /// Name of the offending parameter (e.g. `"sample_rate"`).
+        param: String,
+        /// Why the value was rejected.
+        reason: String,
+    },
     /// The requested audio format is not supported.
     UnsupportedFormat {
+        /// Human-readable description of the rejected format.
         format: String,
+        /// OS-level backend context, when the rejection came from a backend.
         context: Option<BackendContext>,
     },
     /// A general configuration error.
-    ConfigurationError { message: String },
+    ConfigurationError {
+        /// Description of the configuration problem.
+        message: String,
+    },
+    /// A required user-consent artifact is missing from the capture
+    /// configuration.
+    ///
+    /// Mobile platforms gate capture behind an explicit user-consent flow that
+    /// produces an artifact the builder must receive **before** `build()` —
+    /// e.g. Android's `MediaProjection` token (supplied via
+    /// `AudioCaptureBuilder::with_android_projection`, Android targets only)
+    /// or an embedded iOS broadcast extension + App Group. Returned by the
+    /// `build()`/`preflight()` step, before any OS resource is touched
+    /// (ADR-0013, `docs/MOBILE_BACKEND_DESIGN.md`).
+    ///
+    /// Distinct from [`PermissionDenied`](AudioError::PermissionDenied), which
+    /// is the OS *rejecting* an attempted operation at runtime: this variant
+    /// means the consent artifact was never supplied to the configuration at
+    /// all, so nothing was even attempted. Classified as a configuration
+    /// error ([`ErrorKind::Configuration`], `Fatal`) — fix the builder call,
+    /// don't retry.
+    UserConsentRequired {
+        /// The capture facility that requires consent
+        /// (e.g. `"Android playback capture"`).
+        feature: String,
+        /// The concrete missing artifact and how to supply it (e.g.
+        /// `"MediaProjection token — obtain one via the rsac consent helper
+        /// and pass it to AudioCaptureBuilder::with_android_projection()"`).
+        missing: String,
+    },
 
     // ── Device errors ────────────────────────────────────────────────
     /// The requested device was not found.
-    DeviceNotFound { device_id: String },
+    DeviceNotFound {
+        /// Identifier of the device that could not be located.
+        device_id: String,
+    },
     /// The device exists but is not currently available.
-    DeviceNotAvailable { device_id: String, reason: String },
+    DeviceNotAvailable {
+        /// Identifier of the unavailable device.
+        device_id: String,
+        /// Why the device is unavailable (e.g. disconnected, in exclusive use).
+        reason: String,
+    },
     /// Failed to enumerate audio devices.
     DeviceEnumerationError {
+        /// Why enumeration failed.
         reason: String,
+        /// OS-level backend context, when one is available.
         context: Option<BackendContext>,
     },
 
     // ── Stream errors ────────────────────────────────────────────────
     /// Failed to create an audio stream.
     StreamCreationFailed {
+        /// Why stream creation failed.
         reason: String,
+        /// OS-level backend context, when one is available.
         context: Option<BackendContext>,
     },
     /// Failed to start an audio stream.
-    StreamStartFailed { reason: String },
+    StreamStartFailed {
+        /// Why the stream could not be started.
+        reason: String,
+    },
     /// Failed to stop an audio stream.
-    StreamStopFailed { reason: String },
+    StreamStopFailed {
+        /// Why the stream could not be stopped.
+        reason: String,
+    },
     /// An error occurred while reading audio data from a stream.
     ///
     /// This is a **transient/recoverable** read failure (e.g. a momentary
     /// internal hiccup) — NOT end-of-stream. When a read fails because the
     /// stream has reached a terminal state, [`StreamEnded`](AudioError::StreamEnded)
     /// is returned instead, so callers can distinguish "retry" from "done".
-    StreamReadError { reason: String },
+    StreamReadError {
+        /// Why the read failed.
+        reason: String,
+    },
     /// The stream has ended: a read was attempted on a stream that has reached
     /// a terminal state (Stopped / Closed / Error). This is **fatal** for the
     /// read loop — the stream will produce no more data and should not be
     /// retried. Distinct from the recoverable [`StreamReadError`](AudioError::StreamReadError).
-    StreamEnded { reason: String },
+    StreamEnded {
+        /// Which terminal state ended the stream and why.
+        reason: String,
+    },
     /// The ring buffer overflowed — audio frames were dropped.
-    BufferOverrun { dropped_frames: usize },
+    BufferOverrun {
+        /// Number of frames dropped because the consumer fell behind.
+        dropped_frames: usize,
+    },
     /// The ring buffer underran — not enough data was available.
-    BufferUnderrun { requested: usize, available: usize },
+    BufferUnderrun {
+        /// Number of frames the caller asked for.
+        requested: usize,
+        /// Number of frames actually available.
+        available: usize,
+    },
 
     // ── Backend errors ───────────────────────────────────────────────
     /// A platform-specific backend operation failed.
     BackendError {
+        /// Backend name (e.g. `"WASAPI"`, `"PipeWire"`, `"CoreAudio"`).
         backend: String,
+        /// The backend operation that failed (e.g. `"IAudioClient::Initialize"`).
         operation: String,
+        /// Human-readable failure description.
         message: String,
+        /// OS-level backend context, when one is available.
         context: Option<BackendContext>,
     },
     /// The requested backend is not available on this system.
-    BackendNotAvailable { backend: String },
+    BackendNotAvailable {
+        /// Name of the missing backend.
+        backend: String,
+    },
     /// The backend failed to initialize.
-    BackendInitializationFailed { backend: String, reason: String },
+    BackendInitializationFailed {
+        /// Name of the backend that failed to initialize.
+        backend: String,
+        /// Why initialization failed.
+        reason: String,
+    },
 
     // ── Application capture errors ───────────────────────────────────
     /// The target application for capture was not found.
-    ApplicationNotFound { identifier: String },
+    ApplicationNotFound {
+        /// The identifier used to look up the application (PID, name, or
+        /// node id, depending on the [`CaptureTarget`](crate::core::config::CaptureTarget) variant).
+        identifier: String,
+    },
     /// Capturing audio from the target application failed.
-    ApplicationCaptureFailed { app_id: String, reason: String },
+    ApplicationCaptureFailed {
+        /// Identifier of the application whose capture failed.
+        app_id: String,
+        /// Why the capture failed.
+        reason: String,
+    },
 
     // ── Platform errors ──────────────────────────────────────────────
     /// The requested feature is not supported on this platform.
-    PlatformNotSupported { feature: String, platform: String },
+    PlatformNotSupported {
+        /// The unsupported feature (e.g. `"process tree capture"`).
+        feature: String,
+        /// The current platform name (e.g. `"linux"`).
+        platform: String,
+    },
     /// The operation was denied due to insufficient permissions.
     PermissionDenied {
+        /// The operation that was denied.
         operation: String,
+        /// Additional platform-specific detail (e.g. which permission to grant).
         details: Option<String>,
     },
 
     // ── Internal errors ──────────────────────────────────────────────
     /// An internal or unexpected error.
     InternalError {
+        /// Description of the internal failure.
         message: String,
+        /// The underlying error that caused this failure, when one exists.
         source: Option<Box<dyn std::error::Error + Send + Sync>>,
     },
     /// An operation timed out.
     Timeout {
+        /// The operation that timed out.
         operation: String,
+        /// How long the operation ran before timing out.
         duration: std::time::Duration,
     },
 }
@@ -233,7 +345,8 @@ impl AudioError {
         match self {
             AudioError::InvalidParameter { .. }
             | AudioError::UnsupportedFormat { .. }
-            | AudioError::ConfigurationError { .. } => ErrorKind::Configuration,
+            | AudioError::ConfigurationError { .. }
+            | AudioError::UserConsentRequired { .. } => ErrorKind::Configuration,
 
             AudioError::DeviceNotFound { .. }
             | AudioError::DeviceNotAvailable { .. }
@@ -286,6 +399,7 @@ impl AudioError {
             AudioError::InvalidParameter { .. }
             | AudioError::UnsupportedFormat { .. }
             | AudioError::ConfigurationError { .. }
+            | AudioError::UserConsentRequired { .. }
             | AudioError::DeviceNotFound { .. }
             | AudioError::DeviceEnumerationError { .. }
             | AudioError::StreamCreationFailed { .. }
@@ -369,6 +483,13 @@ impl AudioError {
             AudioError::ConfigurationError { message } => (
                 format!("The capture configuration is invalid: {message}."),
                 Some("Review your AudioCaptureBuilder settings and rebuild.".to_string()),
+            ),
+            AudioError::UserConsentRequired { feature, missing } => (
+                format!("'{feature}' requires a user-consent grant that was not provided."),
+                Some(format!(
+                    "Missing: {missing}. Run the platform's consent flow first and pass the \
+                     resulting artifact to the builder before calling build()."
+                )),
             ),
 
             // ── Device ───────────────────────────────────────────────────
@@ -597,6 +718,13 @@ impl fmt::Display for AudioError {
             AudioError::ConfigurationError { message } => {
                 write!(f, "Configuration error: {}", message)
             }
+            AudioError::UserConsentRequired { feature, missing } => {
+                write!(
+                    f,
+                    "User consent required for '{}': missing {}",
+                    feature, missing
+                )
+            }
 
             // Device
             AudioError::DeviceNotFound { device_id } => {
@@ -800,6 +928,10 @@ mod tests {
             AudioError::ConfigurationError {
                 message: "bad config".into(),
             },
+            AudioError::UserConsentRequired {
+                feature: "Android playback capture".into(),
+                missing: "MediaProjection token".into(),
+            },
             AudioError::DeviceNotFound {
                 device_id: "hw:0".into(),
             },
@@ -876,8 +1008,9 @@ mod tests {
     #[test]
     fn all_variants_constructible() {
         let variants = make_all_variants();
-        // 22 variants since ADR-0003 added StreamEnded (was 21).
-        assert_eq!(variants.len(), 22, "Must have exactly 22 variants");
+        // 23 variants since UserConsentRequired joined for the mobile consent
+        // preflight (rsac-82d4; was 22 since ADR-0003 added StreamEnded).
+        assert_eq!(variants.len(), 23, "Must have exactly 23 variants");
     }
 
     // ── ErrorKind: Configuration ─────────────────────────────────────
@@ -903,6 +1036,14 @@ mod tests {
         assert_eq!(
             AudioError::ConfigurationError {
                 message: "x".into()
+            }
+            .kind(),
+            ErrorKind::Configuration
+        );
+        assert_eq!(
+            AudioError::UserConsentRequired {
+                feature: "x".into(),
+                missing: "y".into()
             }
             .kind(),
             ErrorKind::Configuration
@@ -1164,6 +1305,10 @@ mod tests {
             },
             AudioError::ConfigurationError {
                 message: "x".into(),
+            },
+            AudioError::UserConsentRequired {
+                feature: "x".into(),
+                missing: "y".into(),
             },
             AudioError::DeviceNotFound {
                 device_id: "x".into(),

--- a/src/core/interface.rs
+++ b/src/core/interface.rs
@@ -182,6 +182,30 @@ pub trait AudioDevice: Send + Sync {
 /// or [`try_read_chunk()`](Self::try_read_chunk) to retrieve audio data. Internally, the OS
 /// pushes audio into a lock-free SPSC ring buffer; these methods read from the consumer side.
 ///
+/// # Terminal semantics (ADR-0003)
+///
+/// Both read methods share one end-of-stream contract, so a blocking loop and a
+/// non-blocking poll loop can be written the same way:
+///
+/// - Buffered data is always **drained first**. While the stream is `Stopping`,
+///   reads keep yielding the queued tail.
+/// - Once the ring is empty **and** the stream has reached a terminal state
+///   (`Stopped`/`Closed`/`Error`), both methods return the **fatal**
+///   [`AudioError::StreamEnded`] (`is_fatal() == true`) — the single, clean
+///   end-of-stream signal. [`try_read_chunk`](Self::try_read_chunk) does **not**
+///   collapse this into `Ok(None)`; `Ok(None)` means only "no data right now,
+///   still live".
+/// - A genuinely transient failure surfaces as the **recoverable**
+///   [`AudioError::StreamReadError`] and must be retried, never treated as the
+///   end.
+///
+/// This is the authoritative contract; the public
+/// [`AudioCapture`](crate::api::AudioCapture) read methods that preserve it
+/// (`read_chunk_nonblocking` / `read_chunk_blocking`) delegate straight to these
+/// two, while the legacy `read_buffer` / `read_buffer_blocking` pair intentionally
+/// downgrade the terminal signal to a recoverable one for the simple pull API —
+/// see their rustdoc.
+///
 /// # Example
 ///
 /// ```rust,ignore
@@ -235,8 +259,26 @@ pub trait CapturingStream: Send + Sync {
     /// # Returns
     ///
     /// * `Ok(Some(buffer))` — Data was available.
-    /// * `Ok(None)` — No data currently available (try again later).
-    /// * `Err(...)` — Stream error.
+    /// * `Ok(None)` — No data currently available *and the stream is still
+    ///   live* (Running, or Stopping with a not-yet-drained ring) — try again
+    ///   later.
+    /// * `Err(`[`AudioError::StreamEnded`]`)` — **fatal/terminal**. The ring is
+    ///   empty *and* the stream has reached a terminal state
+    ///   (`Stopped`/`Closed`/`Error`); no more data will ever arrive. This
+    ///   mirrors [`read_chunk`](Self::read_chunk)'s terminal signal so a poll
+    ///   loop can end on `is_fatal()` exactly like a blocking loop (ADR-0003).
+    /// * `Err(`[`AudioError::StreamReadError`]`)` — a genuinely transient
+    ///   (recoverable) read failure; retrying may succeed.
+    ///
+    /// # Terminal-vs-drain ordering
+    ///
+    /// Buffered data is drained **before** the terminal signal: while the
+    /// stream is `Stopping`, this keeps returning `Ok(Some(..))` for the tail
+    /// already in the ring, and only returns `StreamEnded` once the ring is
+    /// empty *and* the state is terminal. Consumers must therefore treat
+    /// `Ok(None)` as "not yet" and only [`is_fatal()`](AudioError::is_fatal)
+    /// as "done" — never discard buffered tail data on a bare `is_running()`
+    /// check.
     fn try_read_chunk(&self) -> AudioResult<Option<AudioBuffer>>;
 
     /// Stops the audio stream. OS audio callbacks are halted.

--- a/src/core/introspection.rs
+++ b/src/core/introspection.rs
@@ -58,14 +58,22 @@ pub enum AudioSourceKind {
     /// fallible (e.g. a backend that cannot determine the direction returns an
     /// error, which is mapped to `None` here via `.ok()`).
     Device {
+        /// Platform device identifier, suitable for [`CaptureTarget::device`].
         device_id: String,
+        /// Whether this is the platform's current default device.
         is_default: bool,
+        /// Endpoint direction (input/output), or `None` when it could not be
+        /// resolved (see the variant docs above).
         kind: Option<DeviceKind>,
     },
     /// An application producing audio.
     Application {
+        /// OS process id of the application.
         pid: u32,
+        /// Human-readable application name.
         app_name: String,
+        /// Platform bundle/application identifier (e.g. a macOS bundle id),
+        /// when the platform exposes one.
         bundle_id: Option<String>,
     },
 }
@@ -301,17 +309,36 @@ pub enum PermissionStatus {
 ///
 /// On other platforms, audio capture typically doesn't require special
 /// permissions, so this returns `PermissionStatus::NotRequired`.
+///
+/// ## macOS: real answer requires the `macos-tcc-spi` feature
+///
+/// There is **no public API** to query the `kTCCServiceAudioCapture` status
+/// (`AVCaptureDevice.authorizationStatus(for: .audio)` reports the *microphone*
+/// service, not the Process Tap). With the opt-in `macos-tcc-spi` feature
+/// (ADR-0015), this preflights the private `TCCAccessPreflight` SPI and returns
+/// a real `Granted`/`Denied`/`NotDetermined`. With the feature **off** (the
+/// default), it honestly returns `NotDetermined` — matching `insidegui/AudioCap`'s
+/// no-SPI build. Note the preflight is *advisory*: a `Granted` result does not
+/// guarantee non-silent capture (a terminal-launched or unbundled process is
+/// denied at runtime regardless of the TCC DB); the runtime silent-zeros guard
+/// (ADR-0016) is the authoritative backstop.
 pub fn check_audio_capture_permission() -> PermissionStatus {
-    #[cfg(target_os = "macos")]
+    #[cfg(all(target_os = "macos", feature = "macos-tcc-spi"))]
     {
-        // On macOS, Process Tap / per-application capture requires the Audio
-        // Capture TCC service (kTCCServiceAudioCapture). This is distinct from
-        // the Screen Recording service (kTCCServiceScreenCapture) that
-        // ScreenCaptureKit / CGWindowList use. Reporting NotDetermined until
-        // the OS prompt has been answered matches the behavior documented in
-        // `insidegui/AudioCap`. A future improvement can port AudioCap's
-        // `AudioRecordingPermission.swift` via the private AudioHardware
-        // preflight SPI.
+        // DAG note: this is the same documented core→audio deviation as the
+        // discovery calls elsewhere in this file (see the allowlist in
+        // scripts/check-module-dag.sh). ADR-0015.
+        crate::audio::macos::permission::audio_capture_permission()
+    }
+
+    #[cfg(all(target_os = "macos", not(feature = "macos-tcc-spi")))]
+    {
+        // Process Tap / per-application capture requires the Audio Capture TCC
+        // service (kTCCServiceAudioCapture), distinct from Screen Recording
+        // (kTCCServiceScreenCapture). Without the `macos-tcc-spi` feature we
+        // have no public way to query it, so we honestly report NotDetermined
+        // (matching `insidegui/AudioCap`'s no-SPI build). Enable `macos-tcc-spi`
+        // for a real preflight (ADR-0015).
         PermissionStatus::NotDetermined
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::result_large_err)]
 #![deny(rustdoc::broken_intra_doc_links)]
+#![warn(missing_docs)]
 //! # rsac — cross-platform audio capture
 //!
 //! Streaming-first audio capture for Rust. Captures system audio,
@@ -92,6 +93,11 @@
 pub mod api;
 pub mod audio;
 pub mod bridge;
+// ADR-0011: opt-in multi-source channel composition. Top layer of the module
+// DAG (core → bridge → audio → api → compose); only compiled with the
+// `compose` feature so the default dependency graph is unchanged.
+#[cfg(feature = "compose")]
+pub mod compose;
 pub mod core;
 pub mod prelude;
 pub mod sink;
@@ -109,6 +115,10 @@ pub use crate::core::config::{
     ApplicationId, AudioCaptureConfig, AudioFormat, CaptureTarget, DeviceId, ProcessId,
     SampleFormat, StreamConfig,
 };
+// Android `MediaProjection` consent token (rsac-82d4 / ADR-0013) — Android
+// targets only; see `AudioCaptureBuilder::with_android_projection`.
+#[cfg(target_os = "android")]
+pub use crate::core::config::AndroidProjectionToken;
 pub use crate::core::error::{
     AudioError, AudioResult, BackendContext, ErrorKind, Recoverability, UserFacingError,
 };
@@ -127,7 +137,9 @@ pub use crate::core::introspection::{
 };
 
 // API types
-pub use crate::api::{AudioCapture, AudioCaptureBuilder, RunningCapture};
+pub use crate::api::{
+    AudioBufferIterator, AudioCapture, AudioCaptureBuilder, DrainHandle, RunningCapture,
+};
 
 /// Construct an [`AudioCaptureBuilder`] in one expression with named,
 /// order-independent fields.
@@ -314,6 +326,13 @@ pub use crate::sink::WavFileSink;
 // Async stream support
 #[cfg(feature = "async-stream")]
 pub use crate::bridge::AsyncAudioStream;
+
+// Multi-source channel composition (ADR-0011).
+#[cfg(feature = "compose")]
+pub use crate::compose::{
+    ChannelMap, ChannelOrigin, Composition, CompositionBuilder, CompositionStats, Group,
+    GroupLayout, SourceStats,
+};
 
 // Optional `tracing` integration: best-effort default subscriber installer for
 // binaries/examples. The `rsac_event!`/`rsac_span!` macros are always available

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -32,7 +32,9 @@
 //! ```
 
 // ── Capture lifecycle: the builder/handle facade ───────────────────────────
-pub use crate::api::{AudioCapture, AudioCaptureBuilder, RunningCapture};
+pub use crate::api::{
+    AudioBufferIterator, AudioCapture, AudioCaptureBuilder, DrainHandle, RunningCapture,
+};
 
 // The `capture!` one-line builder macro. `#[macro_export]` places it at the
 // crate root; re-exporting it here makes `use rsac::prelude::*;` bring it into
@@ -65,3 +67,7 @@ pub use crate::sink::WavFileSink;
 // ── Async stream support (feature-gated, mirrors the crate root) ───────────
 #[cfg(feature = "async-stream")]
 pub use crate::bridge::AsyncAudioStream;
+
+// ── Multi-source channel composition (feature-gated; ADR-0011) ─────────────
+#[cfg(feature = "compose")]
+pub use crate::compose::{ChannelMap, Composition, CompositionBuilder, Group, GroupLayout};

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -14,6 +14,7 @@
 //! [`crate::bridge::mock::MockDeviceEnumerator`] instead, which drives the
 //! real ring-buffer bridge with a synthetic 440 Hz sine producer.
 
+/// Placeholder audio-generation helpers (see the module docs above).
 pub mod generation {
     /// Placeholder for audio generation utilities
     pub fn create_sine_wave(_frequency: f32, _duration_ms: u32, _sample_rate: u32) -> Vec<f32> {
@@ -21,6 +22,7 @@ pub mod generation {
     }
 }
 
+/// Placeholder audio-validation helpers (see the module docs above).
 pub mod validation {
     /// Placeholder for audio validation utilities
     pub fn validate_audio_data(_data: &[f32]) -> bool {

--- a/tests/ci_audio/app_capture.rs
+++ b/tests/ci_audio/app_capture.rs
@@ -7,12 +7,14 @@
 
 use std::time::{Duration, Instant};
 
-use rsac::{ApplicationId, AudioCaptureBuilder, CaptureTarget, ProcessId};
+use rsac::{ApplicationId, AudioCaptureBuilder, CaptureTarget};
 
 use crate::helpers;
 
-/// Test: Spawn audio player, capture by process tree (PID).
-/// Uses `CaptureTarget::ProcessTree(ProcessId(pid))`.
+/// Test: Spawn audio player and capture by application PID.
+///
+/// `ApplicationId` is a cross-platform numeric PID string. Process-tree
+/// behavior is covered separately in `process_tree_capture.rs`.
 #[test]
 fn test_app_capture_by_process_id() {
     require_app_capture!();
@@ -32,9 +34,9 @@ fn test_app_capture_by_process_id() {
     // Wait for player to start producing audio
     std::thread::sleep(Duration::from_millis(500));
 
-    // Build capture targeting the spawned process
+    // Build capture targeting exactly the spawned process.
     let capture_result = AudioCaptureBuilder::new()
-        .with_target(CaptureTarget::ProcessTree(ProcessId(pid)))
+        .with_target(CaptureTarget::Application(ApplicationId(pid.to_string())))
         .sample_rate(48000)
         .channels(2)
         .build();
@@ -128,11 +130,15 @@ fn test_app_capture_by_process_id() {
     }
 }
 
-/// Test: Capture with `Application(ApplicationId)` variant using PipeWire node ID.
-/// Linux-only — discovers the PipeWire node for the spawned player process.
+/// Linux regression: `Application(ApplicationId)` uses a numeric PID string.
+///
+/// Older tests treated the Linux `ApplicationId` as a PipeWire node ID. The
+/// backend contract is now aligned with Windows/macOS: `ApplicationId` is the
+/// application process ID, and the PipeWire backend resolves PID -> node
+/// internally.
 #[test]
 #[cfg(target_os = "linux")]
-fn test_app_capture_by_pipewire_node_id() {
+fn test_app_capture_by_pid_string_linux() {
     require_app_capture!();
 
     let wav_path = helpers::generate_test_wav(5.0, 48000, 2);
@@ -145,22 +151,19 @@ fn test_app_capture_by_pipewire_node_id() {
         }
     };
 
-    // Wait for PipeWire to register the node
+    // Wait for PipeWire to register the player's stream node.
     std::thread::sleep(Duration::from_millis(1000));
 
-    // Discover PipeWire node ID for the player process
-    let node_id = match helpers::find_pipewire_node_for_pid(pid) {
-        Some(id) => id,
-        None => {
-            eprintln!("[ci_audio] Could not find PipeWire node for PID {pid}, skipping");
-            helpers::stop_player(child);
-            return;
-        }
-    };
-    eprintln!("[ci_audio] Found PipeWire node {node_id} for PID {pid}");
+    // Only used to decide whether to skip: if PipeWire never registered a node
+    // for this player, app capture cannot possibly route audio here in CI.
+    if helpers::find_pipewire_node_for_pid(pid).is_none() {
+        eprintln!("[ci_audio] No PipeWire node for PID {pid}; skipping (CI routing limitation)");
+        helpers::stop_player(child);
+        return;
+    }
 
     let capture_result = AudioCaptureBuilder::new()
-        .with_target(CaptureTarget::Application(ApplicationId(node_id.clone())))
+        .with_target(CaptureTarget::Application(ApplicationId(pid.to_string())))
         .sample_rate(48000)
         .channels(2)
         .build();
@@ -169,7 +172,7 @@ fn test_app_capture_by_pipewire_node_id() {
         Ok(c) => c,
         Err(e) => {
             eprintln!(
-                "[ci_audio] Failed to build app capture for node {node_id}: {:?}",
+                "[ci_audio] Failed to build app capture for PID {pid}: {:?}",
                 e
             );
             helpers::stop_player(child);
@@ -216,28 +219,28 @@ fn test_app_capture_by_pipewire_node_id() {
     helpers::stop_player(child);
 
     eprintln!(
-        "[ci_audio] App capture by node: total_samples={}, got_audio={}",
+        "[ci_audio] Linux app capture by PID string: total_samples={}, got_audio={}",
         total_samples, got_audio
     );
 
     if helpers::deterministic_audio_env() {
         assert!(
             got_audio,
-            "deterministic source: app capture via PW node {node_id} received only silence"
+            "deterministic source: app capture via PID {pid} received only silence"
         );
         assert!(
             rms_ok,
-            "deterministic source: app capture RMS below 0.01 floor for node {node_id}"
+            "deterministic source: app capture RMS below 0.01 floor for PID {pid}"
         );
         assert!(
             tone_present,
-            "deterministic source: 440 Hz tone not detected via PW node {node_id}"
+            "deterministic source: 440 Hz tone not detected via PID {pid}"
         );
-        eprintln!("[ci_audio] ✅ App capture via PW node {node_id} received the 440 Hz tone");
+        eprintln!("[ci_audio] ✅ App capture via PID {pid} received the 440 Hz tone");
     } else if got_audio {
-        eprintln!("[ci_audio] ✅ App capture via PW node {node_id} received non-silent audio");
+        eprintln!("[ci_audio] ✅ App capture via PID {pid} received non-silent audio");
     } else {
-        eprintln!("[ci_audio] ⚠ App capture via PW node did not receive audio (CI routing)");
+        eprintln!("[ci_audio] ⚠ App capture via PID did not receive audio (CI routing)");
     }
 
     // Clean up temp file
@@ -253,7 +256,7 @@ fn test_app_capture_by_pipewire_node_id() {
 fn test_app_capture_nonexistent_target() {
     require_app_capture!();
 
-    // A node ID / PID string that cannot correspond to any real audio source.
+    // A PID string that cannot correspond to any real audio source.
     let bogus_id = "99999999";
     let result = AudioCaptureBuilder::new()
         .with_target(CaptureTarget::Application(ApplicationId(

--- a/tests/ci_audio/application_by_name.rs
+++ b/tests/ci_audio/application_by_name.rs
@@ -1,13 +1,25 @@
 //! `CaptureTarget::ApplicationByName` integration tests (macOS).
 //!
 //! The macOS backend enumerates running applications via
-//! `NSWorkspace.runningApplications` and performs a case-insensitive
-//! substring match on the app's localized name. See
-//! `src/audio/macos/thread.rs::resolve_capture_target` and
-//! `src/audio/macos/coreaudio.rs::enumerate_audio_applications`.
+//! `NSWorkspace.runningApplications` and performs an **exact,
+//! case-insensitive** match on the app's localized name (via
+//! `app_name_matches` → `str::eq_ignore_ascii_case`). It deliberately does
+//! **not** do substring matching — that historically diverged from the
+//! Windows/Linux backends and could resolve `"Music"` to `"Apple Music"`
+//! (audit L3). See `src/audio/macos/thread.rs::resolve_capture_target` /
+//! `app_name_matches` and `src/audio/macos/coreaudio.rs::enumerate_audio_applications`.
 //!
-//! These tests are `#[ignore]` by default because they exercise
-//! CoreAudio Process Taps (macOS 14.4+) and need TCC permission for
+//! # When resolution happens: `start()`, not `build()`
+//!
+//! Name resolution (NSWorkspace enumeration → PID → Process Tap) runs on the
+//! capture path inside `create_macos_capture` → `resolve_capture_target`,
+//! which is reached at **`start()`** — NOT at `build()`. `build()` only
+//! validates capability and resolves the default output device; it does not
+//! look up the named application. Tests therefore assert name-resolution
+//! outcomes against `start()`, not `build()`.
+//!
+//! These tests are `#[ignore]` by default because the happy-path ones
+//! exercise CoreAudio Process Taps (macOS 14.4+) and need TCC permission for
 //! audio capture. Developers can run them manually with:
 //!
 //! ```text
@@ -44,11 +56,14 @@ fn skip_if_unsupported() -> bool {
     false
 }
 
-/// Asserts the builder successfully resolves an `ApplicationByName`
-/// target when the named app is currently running. A successful `build()`
-/// means the macOS backend found the PID via NSWorkspace, created the
-/// Process Tap, and bound the source — the full happy-path for the
-/// name-based selection code.
+/// Asserts the pipeline resolves an `ApplicationByName` target when the named
+/// app is currently running, using the app's **exact** localized name. A
+/// successful `start()` means the macOS backend found the PID via NSWorkspace
+/// (exact, case-insensitive name match), created the Process Tap, and started
+/// the AudioUnit — the full happy-path for the name-based selection code.
+///
+/// Resolution happens at `start()` (see the module doc), so `build()` is
+/// expected to succeed and the source binding is verified after `start()`.
 ///
 /// Ignored by default: requires macOS 14.4+, TCC audio permission, and
 /// for Finder to be running (always true in a normal user session, but
@@ -60,26 +75,30 @@ fn select_by_exact_name_binds_source() {
         return;
     }
 
-    let result = AudioCaptureBuilder::new()
+    // build() only validates capability + resolves the default output device;
+    // the NSWorkspace name lookup + Process Tap happen at start().
+    let mut capture = AudioCaptureBuilder::new()
         .with_target(CaptureTarget::ApplicationByName(KNOWN_APP_NAME.to_string()))
         .sample_rate(48000)
         .channels(2)
-        .build();
+        .build()
+        .expect("build() should succeed (it does not resolve the app name)");
 
-    match result {
-        Ok(capture) => {
+    match capture.start() {
+        Ok(()) => {
             eprintln!(
-                "[ci_audio] ✅ ApplicationByName('{}') bound source: {:?}",
+                "[ci_audio] ✅ ApplicationByName('{}') resolved + started: {:?}",
                 KNOWN_APP_NAME,
                 capture.config().target
             );
+            let _ = capture.stop();
         }
         Err(e) => {
             // In a sandboxed/headless CI Finder may not be listed, or
             // Process Tap creation may fail due to TCC. Surface the
             // error so developers see why the test skipped locally.
             panic!(
-                "Expected ApplicationByName('{}') to resolve; got: {:?}",
+                "Expected ApplicationByName('{}') to resolve at start(); got: {:?}",
                 KNOWN_APP_NAME, e
             );
         }
@@ -90,11 +109,11 @@ fn select_by_exact_name_binds_source() {
 /// with the unknown name embedded in the error's `identifier` field when
 /// no running app matches. This exercises the error path inside
 /// `resolve_capture_target` — `enumerate_audio_applications()` succeeds
-/// (possibly with zero apps) but the `.find()` returns `None`.
+/// (possibly with zero apps) but the exact-match `.find()` returns `None`.
 ///
 /// # Where the error surfaces
 ///
-/// Name resolution happens on the capture thread inside
+/// Name resolution happens on the capture path inside
 /// `create_macos_capture` → `resolve_capture_target`, which runs at
 /// `start()` — NOT at `build()` (build only validates capability and
 /// resolves the default output device). So the `ApplicationNotFound`
@@ -102,10 +121,10 @@ fn select_by_exact_name_binds_source() {
 ///
 /// # Gating
 ///
-/// Runs on capable runners (was `#[ignore]`). This path short-circuits at
+/// Runs on capable runners (not `#[ignore]`). This path short-circuits at
 /// the `.find()` failure BEFORE any `CoreAudioProcessTap::new` call, so it
 /// does NOT touch the `kTCCServiceAudioCapture` gate and cannot hang on the
-/// 10-minute Process Tap path. It only needs NSWorkspace, which returns an
+/// Process Tap path. It only needs NSWorkspace, which returns an
 /// (possibly empty) list in any session. We still skip on backends without
 /// application-capture capability via `skip_if_unsupported()`.
 #[test]
@@ -157,10 +176,14 @@ fn select_by_missing_name_returns_error() {
     }
 }
 
-/// The macOS backend matches names with `to_lowercase().contains(...)`,
-/// so `"finder"` (lowercase) must resolve to the same app as `"Finder"`.
-/// This test locks in that contract — if a future change switches to
-/// exact-match, this test will fail and force an explicit decision.
+/// The macOS backend matches names **case-insensitively** (via
+/// `app_name_matches` → `str::eq_ignore_ascii_case`), so `"finder"`
+/// (lowercase) must resolve to the same app as `"Finder"`. This test locks
+/// in that contract — if a future change breaks case-insensitivity, it fails
+/// and forces an explicit decision.
+///
+/// Resolution happens at `start()` (see the module doc), so this asserts
+/// against `start()`, not `build()`.
 ///
 /// Ignored by default for the same reasons as
 /// `select_by_exact_name_binds_source`.
@@ -172,49 +195,92 @@ fn case_insensitive_match() {
     }
 
     let lower = KNOWN_APP_NAME.to_lowercase();
-    let result = AudioCaptureBuilder::new()
+    let mut capture = AudioCaptureBuilder::new()
         .with_target(CaptureTarget::ApplicationByName(lower.clone()))
         .sample_rate(48000)
         .channels(2)
-        .build();
+        .build()
+        .expect("build() should succeed (it does not resolve the app name)");
 
-    match result {
-        Ok(_) => {
+    match capture.start() {
+        Ok(()) => {
             eprintln!(
                 "[ci_audio] ✅ Case-insensitive match: '{}' resolved to '{}'",
                 lower, KNOWN_APP_NAME
             );
+            let _ = capture.stop();
         }
         Err(e) => panic!(
-            "Expected case-insensitive match for '{}' to succeed; got: {:?}",
+            "Expected case-insensitive match for '{}' to resolve at start(); got: {:?}",
             lower, e
         ),
     }
 }
 
-/// Substring matching is explicit in the impl
-/// (`a.name.to_lowercase().contains(&name.to_lowercase())`), so a
-/// unique prefix of a known app's name should resolve. "Find" is a
-/// unique prefix of "Finder" that is unlikely to collide with another
-/// running application's localized name.
+/// Matching is **exact** (not substring): the macOS backend uses
+/// `app_name_matches` (`str::eq_ignore_ascii_case`), NOT
+/// `to_lowercase().contains(...)`. A unique *prefix* of a running app's name
+/// must therefore **fail** to resolve, returning `AudioError::ApplicationNotFound`.
+///
+/// `"Find"` is a prefix of `"Finder"`; under the old (removed) substring
+/// algorithm it would have resolved, but exact matching rejects it. This
+/// test guards against a regression back to substring matching, mirroring
+/// the `app_name_matches_rejects_substrings` unit test in
+/// `src/audio/macos/thread.rs`.
+///
+/// # Gating
+///
+/// Not `#[ignore]`: like `select_by_missing_name_returns_error`, this
+/// short-circuits at the exact-match `.find()` failure BEFORE any
+/// `CoreAudioProcessTap::new` call, so it needs only NSWorkspace and does not
+/// touch the TCC Process-Tap gate. (In the astronomically unlikely event a
+/// running app is literally named `"Find"`, resolution would succeed at
+/// start(); we tolerate that below rather than assert a false negative.)
 #[test]
-#[ignore = "requires macOS 14.4+ with audio capture permission and Finder running"]
-fn substring_match_resolves() {
+fn substring_prefix_does_not_resolve() {
     if skip_if_unsupported() {
         return;
     }
 
-    let result = AudioCaptureBuilder::new()
+    // A prefix of "Finder". Exact matching must NOT resolve this to Finder.
+    let mut capture = match AudioCaptureBuilder::new()
         .with_target(CaptureTarget::ApplicationByName("Find".to_string()))
         .sample_rate(48000)
         .channels(2)
-        .build();
+        .build()
+    {
+        Ok(c) => c,
+        Err(AudioError::ApplicationNotFound { identifier }) => {
+            assert!(
+                identifier.contains("Find"),
+                "error identifier should contain the queried name, got: {identifier}"
+            );
+            eprintln!("[ci_audio] ✅ prefix 'Find' rejected at build(): {identifier}");
+            return;
+        }
+        Err(other) => panic!("build() must succeed or return ApplicationNotFound; got: {other:?}"),
+    };
 
-    match result {
-        Ok(_) => eprintln!("[ci_audio] ✅ Substring 'Find' resolved (likely Finder)"),
-        Err(e) => panic!(
-            "Expected substring 'Find' to match a running app; got: {:?}",
-            e
+    match capture.start() {
+        Err(AudioError::ApplicationNotFound { identifier }) => {
+            assert!(
+                identifier.contains("Find"),
+                "error identifier should contain the queried name, got: {identifier}"
+            );
+            eprintln!(
+                "[ci_audio] ✅ exact matching rejected prefix 'Find' (no substring match): {identifier}"
+            );
+        }
+        Err(other) => panic!(
+            "Expected ApplicationNotFound for prefix 'Find' under exact matching, got: {other:?}"
         ),
+        Ok(()) => {
+            // Only reachable if a running app is literally named "Find".
+            let _ = capture.stop();
+            eprintln!(
+                "[ci_audio] ⚠ a running app is exactly named 'Find'; exact match resolved it \
+                 (not a substring match — acceptable)"
+            );
+        }
     }
 }

--- a/tests/ci_audio/application_by_name_windows.rs
+++ b/tests/ci_audio/application_by_name_windows.rs
@@ -1,0 +1,282 @@
+//! `CaptureTarget::ApplicationByName` integration tests (Windows / WASAPI).
+//!
+//! The Windows backend resolves an application *name* to a PID via `sysinfo`
+//! (case-insensitive, with/without a `.exe` suffix) and then opens a WASAPI
+//! Process Loopback client on that PID. See
+//! `src/audio/windows/thread.rs::resolve_process_name_to_pid` and the
+//! `CaptureTarget::ApplicationByName` arm of `create_audio_client`.
+//!
+//! These tests complement the macOS-only `application_by_name` module (which is
+//! `#![cfg(target_os = "macos")]`): before this module there was **zero**
+//! integration coverage of the Windows name-resolution path, even though it is
+//! a supported first-class capture mode on Windows.
+//!
+//! The CI audio player on Windows is a `powershell` host running
+//! `SoundPlayer.PlayLooping` (see `helpers::spawn_audio_player_get_pid`), so a
+//! `powershell` process is guaranteed to be running while a test tone plays.
+//! We therefore use `"powershell"` as the known-running target name. Name
+//! resolution matches the *first* process with that name, which — on a headless
+//! CI runner whose only audible powershell is the one we just spawned — is our
+//! player in practice; but because the OS may host other powershell instances,
+//! the content assertions stay soft even under a deterministic source (the
+//! resolver's first-match is not guaranteed to be *our* PID). What we hard-pin
+//! is the resolution + lifecycle contract: a known-running name resolves and the
+//! full build → start → read → stop pipeline runs without error or panic, and a
+//! nonexistent name fails with the documented `ApplicationNotFound` variant.
+#![cfg(target_os = "windows")]
+
+use std::time::{Duration, Instant};
+
+use rsac::{AudioCaptureBuilder, AudioError, CaptureTarget, PlatformCapabilities};
+
+use crate::helpers;
+
+/// Skip helper mirroring the other ci_audio application modules.
+fn skip_if_unsupported() -> bool {
+    let caps = PlatformCapabilities::query();
+    if !caps.supports_application_capture {
+        eprintln!(
+            "[ci_audio] SKIP: backend '{}' does not support application capture",
+            caps.backend_name
+        );
+        return true;
+    }
+    false
+}
+
+/// A name that cannot plausibly match any real running process.
+const MISSING_APP_NAME: &str = "ThisApplicationDefinitelyDoesNotExist_rsac_12345";
+
+/// End-to-end: spawn the CI audio player (a `powershell` host), then capture by
+/// its process *name* via `CaptureTarget::ApplicationByName("powershell")`.
+///
+/// Exercises the full Windows name path:
+/// `resolve_process_name_to_pid` → `new_application_loopback_client(pid)` →
+/// WASAPI init (explicit f32 `desired_format`, autoconvert off) → capture loop →
+/// `BridgeStream` reads.
+///
+/// Hard-pinned: the name resolves to a PID and the build → start → read → stop
+/// lifecycle completes without error or panic. Content (non-silence / 440 Hz
+/// tone) is asserted only *softly* even under a deterministic source, because
+/// the resolver's first-match `powershell` is not guaranteed to be the exact
+/// child we spawned (the runner may host other powershell instances).
+#[test]
+fn select_by_name_of_running_player_binds_and_reads() {
+    require_app_capture!();
+    if skip_if_unsupported() {
+        return;
+    }
+
+    let wav_path = helpers::generate_test_wav(5.0, 48000, 2);
+
+    let (child, pid) = match helpers::spawn_audio_player_get_pid(&wav_path) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[ci_audio] Could not spawn audio player: {e}");
+            let _ = std::fs::remove_file(&wav_path);
+            return;
+        }
+    };
+    eprintln!("[ci_audio] Spawned powershell audio player PID={pid}");
+
+    // Give the player a moment to start streaming.
+    std::thread::sleep(Duration::from_millis(500));
+
+    // The CI player is a powershell host (helpers::spawn_audio_player_get_pid).
+    let mut capture = match AudioCaptureBuilder::new()
+        .with_target(CaptureTarget::ApplicationByName("powershell".to_string()))
+        .sample_rate(48000)
+        .channels(2)
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            // A build failure here means name resolution or loopback-client
+            // creation failed. On a healthy runner with our player running this
+            // should not happen, but we surface it rather than hard-fail so a
+            // pure environment gap (no powershell audible) doesn't false-RED.
+            eprintln!(
+                "[ci_audio] ⚠ ApplicationByName('powershell') build failed \
+                 (name resolution or loopback client): {e:?}"
+            );
+            helpers::stop_player(child);
+            let _ = std::fs::remove_file(&wav_path);
+            return;
+        }
+    };
+
+    if let Err(e) = capture.start() {
+        eprintln!("[ci_audio] ⚠ ApplicationByName capture start failed: {e:?}");
+        helpers::stop_player(child);
+        let _ = std::fs::remove_file(&wav_path);
+        return;
+    }
+
+    let timeout = helpers::capture_timeout();
+    let start = Instant::now();
+    let mut buffers_read = 0usize;
+    let mut got_audio = false;
+
+    while start.elapsed() < timeout {
+        match capture.read_buffer() {
+            Ok(Some(buf)) => {
+                buffers_read += 1;
+                // Self-consistency invariant holds on every host.
+                helpers::assert_buffer_format(&buf, 48000, 2);
+                if helpers::verify_non_silence(&buf, 0.001) {
+                    got_audio = true;
+                    break;
+                }
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+            Err(e) => {
+                eprintln!("[ci_audio] read error: {e:?}");
+                if e.is_fatal() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+    }
+
+    let _ = capture.stop();
+    helpers::stop_player(child);
+
+    eprintln!(
+        "[ci_audio] ApplicationByName('powershell'): buffers_read={buffers_read}, got_audio={got_audio}"
+    );
+
+    // Hard contract: resolution + lifecycle succeeded (we got here without
+    // error). Content stays soft — the resolver's first-match powershell may
+    // not be our exact player, so silence is not necessarily a regression.
+    if got_audio {
+        eprintln!("[ci_audio] ✅ ApplicationByName received non-silent audio");
+    } else {
+        eprintln!(
+            "[ci_audio] ⚠ ApplicationByName received only silence \
+             (first-match powershell may differ from our player) — lifecycle still verified"
+        );
+    }
+
+    let _ = std::fs::remove_file(&wav_path);
+    if let Some(parent) = wav_path.parent() {
+        let _ = std::fs::remove_dir(parent);
+    }
+}
+
+/// A name that matches no running process must fail with the documented
+/// `AudioError::ApplicationNotFound` variant, with the requested name embedded
+/// in the `identifier` field.
+///
+/// This pins the parse/resolution error *shape* on Windows: callers can rely on
+/// `ApplicationNotFound` being the "no such app name" signal. The failure
+/// happens inside `resolve_process_name_to_pid` before any WASAPI client is
+/// created, so it needs no audio hardware — but we still gate on
+/// `require_app_capture!()` for consistency with the rest of the suite.
+#[test]
+fn select_by_missing_name_returns_application_not_found() {
+    require_app_capture!();
+    if skip_if_unsupported() {
+        return;
+    }
+
+    // Resolution/loopback-client creation happens on the capture thread at
+    // start(); build() may already surface it if a precheck is added later.
+    let build = AudioCaptureBuilder::new()
+        .with_target(CaptureTarget::ApplicationByName(
+            MISSING_APP_NAME.to_string(),
+        ))
+        .sample_rate(48000)
+        .channels(2)
+        .build();
+
+    let mut capture = match build {
+        Ok(c) => c,
+        Err(AudioError::ApplicationNotFound { identifier }) => {
+            assert!(
+                identifier.contains(MISSING_APP_NAME),
+                "ApplicationNotFound identifier should embed the missing name, got: {identifier}"
+            );
+            eprintln!("[ci_audio] ✅ Got ApplicationNotFound at build(): {identifier}");
+            return;
+        }
+        Err(other) => panic!(
+            "build() for a missing app name must succeed or return \
+             ApplicationNotFound; got: {other:?}"
+        ),
+    };
+
+    match capture.start() {
+        Err(AudioError::ApplicationNotFound { identifier }) => {
+            assert!(
+                identifier.contains(MISSING_APP_NAME),
+                "ApplicationNotFound identifier should embed the missing name, got: {identifier}"
+            );
+            eprintln!("[ci_audio] ✅ Got expected ApplicationNotFound at start(): {identifier}");
+        }
+        Err(other) => panic!(
+            "Expected ApplicationNotFound for missing name '{MISSING_APP_NAME}', got: {other:?}"
+        ),
+        Ok(()) => {
+            let _ = capture.stop();
+            panic!("Expected ApplicationNotFound for '{MISSING_APP_NAME}', but start() succeeded");
+        }
+    }
+}
+
+/// Name matching is case-insensitive on Windows (`resolve_process_name_to_pid`
+/// lowercases both sides and also tries a `.exe` suffix). `"POWERSHELL"` (upper)
+/// and `"powershell.exe"` must both resolve to the same running powershell as
+/// `"powershell"`. Locks in the case-insensitive + `.exe`-flexible contract so a
+/// future switch to exact-match forces an explicit decision.
+#[test]
+fn select_by_name_is_case_and_exe_suffix_insensitive() {
+    require_app_capture!();
+    if skip_if_unsupported() {
+        return;
+    }
+
+    // Spawn a powershell player so at least one powershell is guaranteed live.
+    let wav_path = helpers::generate_test_wav(5.0, 48000, 2);
+    let (child, pid) = match helpers::spawn_audio_player_get_pid(&wav_path) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[ci_audio] Could not spawn audio player: {e}");
+            let _ = std::fs::remove_file(&wav_path);
+            return;
+        }
+    };
+    eprintln!("[ci_audio] Spawned powershell audio player PID={pid}");
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Each of these spellings must resolve to the same running powershell.
+    for name in ["POWERSHELL", "powershell.exe"] {
+        let result = AudioCaptureBuilder::new()
+            .with_target(CaptureTarget::ApplicationByName(name.to_string()))
+            .sample_rate(48000)
+            .channels(2)
+            .build();
+
+        match result {
+            Ok(_) => eprintln!("[ci_audio] ✅ '{name}' resolved (case/.exe-insensitive)"),
+            Err(AudioError::ApplicationNotFound { identifier }) => panic!(
+                "case/.exe-insensitive match failed for '{name}': got ApplicationNotFound \
+                 ({identifier}) while a powershell process is running"
+            ),
+            Err(other) => {
+                // A non-resolution backend error (e.g. loopback client creation
+                // hiccup) is an environment issue, not a resolution regression —
+                // report but don't fail the case-insensitivity contract.
+                eprintln!(
+                    "[ci_audio] ⚠ '{name}' resolved but backend rejected client creation: {other:?}"
+                );
+            }
+        }
+    }
+
+    helpers::stop_player(child);
+    let _ = std::fs::remove_file(&wav_path);
+    if let Some(parent) = wav_path.parent() {
+        let _ = std::fs::remove_dir(parent);
+    }
+}

--- a/tests/ci_audio/application_by_pid.rs
+++ b/tests/ci_audio/application_by_pid.rs
@@ -6,9 +6,11 @@
 //! (the `CaptureTarget::Application` arm) and
 //! `src/audio/macos/tap.rs::CoreAudioProcessTap::new`.
 //!
-//! These tests are `#[ignore]` by default because they exercise
+//! The Process Tap tests are `#[ignore]` by default because they exercise
 //! CoreAudio Process Taps (macOS 14.4+) and need TCC permission for
-//! audio capture. Developers can run them manually with:
+//! audio capture. The non-numeric parse test is safe to run because it fails
+//! before Process Tap creation. Developers can run the ignored tests manually
+//! with:
 //!
 //! ```text
 //! cargo test --test ci_audio application_by_pid \
@@ -39,9 +41,9 @@ fn skip_if_unsupported() -> bool {
     false
 }
 
-/// Asserts the builder accepts a numeric PID of a running process and
-/// exercises the full `CaptureTarget::Application` path: parse PID →
-/// `CoreAudioProcessTap::new` → aggregate device → bind source.
+/// Asserts the backend accepts a numeric PID of a running process and
+/// exercises the full `CaptureTarget::Application` path at `start()`:
+/// parse PID → `CoreAudioProcessTap::new` → aggregate device → bind source.
 ///
 /// Uses `std::process::id()` (the test harness's own PID) because it is
 /// guaranteed to be a real, running process. The current process may
@@ -60,19 +62,21 @@ fn select_by_pid_of_running_app_binds_source() {
     }
 
     let pid = std::process::id();
-    let result = AudioCaptureBuilder::new()
+    let mut capture = AudioCaptureBuilder::new()
         .with_target(CaptureTarget::Application(ApplicationId(pid.to_string())))
         .sample_rate(48000)
         .channels(2)
-        .build();
+        .build()
+        .expect("Application(PID) build should validate config before start-time resolution");
 
-    match result {
-        Ok(capture) => {
+    match capture.start() {
+        Ok(()) => {
             eprintln!(
-                "[ci_audio] ✅ Application(PID={}) bound source: {:?}",
+                "[ci_audio] ✅ Application(PID={}) started source: {:?}",
                 pid,
                 capture.config().target
             );
+            let _ = capture.stop();
         }
         Err(AudioError::BackendError { .. }) | Err(AudioError::InternalError { .. }) => {
             // Acceptable: some macOS versions reject Process-Tapping the
@@ -98,8 +102,8 @@ fn select_by_pid_of_running_app_binds_source() {
 ///
 /// We don't pin the exact variant because CoreAudio's error codes for
 /// "unknown process" are undocumented and have shifted across macOS
-/// versions. What we *do* lock in: the builder must surface an error,
-/// not `Ok(_)` and not a panic.
+/// versions. What we *do* lock in: start-time resolution must surface an
+/// error, not silently produce a stream and not panic.
 #[test]
 #[ignore = "requires macOS 14.4+ with audio capture permission"]
 fn select_by_nonexistent_pid_returns_error() {
@@ -107,20 +111,22 @@ fn select_by_nonexistent_pid_returns_error() {
         return;
     }
 
-    let result = AudioCaptureBuilder::new()
+    let mut capture = match AudioCaptureBuilder::new()
         .with_target(CaptureTarget::Application(ApplicationId(
             NONEXISTENT_PID.to_string(),
         )))
         .sample_rate(48000)
         .channels(2)
-        .build();
-
-    match result {
+        .build()
+    {
+        Ok(c) => c,
         Err(AudioError::BackendError { .. }) | Err(AudioError::InternalError { .. }) => {
+            // Acceptable if build() ever grows an eager Process Tap precheck.
             eprintln!(
-                "[ci_audio] ✅ Nonexistent PID {} rejected with expected error variant",
+                "[ci_audio] ✅ Nonexistent PID {} rejected at build() with expected error variant",
                 NONEXISTENT_PID
             );
+            return;
         }
         Err(AudioError::ApplicationNotFound { identifier }) => {
             // Also acceptable if the backend ever adds an existence
@@ -131,18 +137,43 @@ fn select_by_nonexistent_pid_returns_error() {
                 identifier
             );
             eprintln!(
-                "[ci_audio] ✅ Nonexistent PID {} rejected with ApplicationNotFound",
+                "[ci_audio] ✅ Nonexistent PID {} rejected with ApplicationNotFound at build()",
+                NONEXISTENT_PID
+            );
+            return;
+        }
+        Err(other) => panic!(
+            "Unexpected build error type for nonexistent PID {}: {:?}",
+            NONEXISTENT_PID, other
+        ),
+    };
+
+    match capture.start() {
+        Err(AudioError::BackendError { .. }) | Err(AudioError::InternalError { .. }) => {
+            eprintln!(
+                "[ci_audio] ✅ Nonexistent PID {} rejected at start() with expected error variant",
+                NONEXISTENT_PID
+            );
+        }
+        Err(AudioError::ApplicationNotFound { identifier }) => {
+            assert!(
+                identifier.contains(&NONEXISTENT_PID.to_string()),
+                "ApplicationNotFound identifier should embed the PID, got: {}",
+                identifier
+            );
+            eprintln!(
+                "[ci_audio] ✅ Nonexistent PID {} rejected with ApplicationNotFound at start()",
                 NONEXISTENT_PID
             );
         }
         Err(other) => panic!(
-            "Unexpected error type for nonexistent PID {}: {:?}",
+            "Unexpected start error type for nonexistent PID {}: {:?}",
             NONEXISTENT_PID, other
         ),
-        Ok(_) => panic!(
-            "Expected error for nonexistent PID {}, but build succeeded",
-            NONEXISTENT_PID
-        ),
+        Ok(()) => {
+            let _ = capture.stop();
+            panic!("Expected error for nonexistent PID {NONEXISTENT_PID}, but start() succeeded");
+        }
     }
 }
 
@@ -152,24 +183,44 @@ fn select_by_nonexistent_pid_returns_error() {
 /// `map_err`). This locks in the error *shape* so callers can rely on
 /// `ApplicationNotFound` being the parse-failure signal.
 ///
-/// Does not need audio hardware — the parse failure short-circuits
-/// before any CoreAudio call. Kept `#[ignore]` for consistency with
-/// the rest of the file and to match the `feat_macos` gate convention.
+/// Does not need TCC permission: parsing happens before any Process Tap call.
+/// The current backend resolves the target at `start()`, while `build()` only
+/// validates configuration and creates the backend handle.
 #[test]
-#[ignore = "macOS-only path, grouped with other application_by_pid tests"]
 fn select_by_non_numeric_id_returns_application_not_found() {
     if skip_if_unsupported() {
         return;
     }
 
     let bogus = "not-a-pid";
-    let result = AudioCaptureBuilder::new()
+    let mut capture = match AudioCaptureBuilder::new()
         .with_target(CaptureTarget::Application(ApplicationId(bogus.to_string())))
         .sample_rate(48000)
         .channels(2)
-        .build();
+        .build()
+    {
+        Ok(c) => c,
+        Err(AudioError::ApplicationNotFound { identifier }) => {
+            // Acceptable if build() ever grows a PID precheck — still the
+            // documented variant, embedding the raw ID.
+            assert!(
+                identifier.contains(bogus),
+                "ApplicationNotFound identifier should embed the raw id, got: {}",
+                identifier
+            );
+            eprintln!(
+                "[ci_audio] ✅ Non-numeric id '{}' rejected with ApplicationNotFound at build()",
+                bogus
+            );
+            return;
+        }
+        Err(other) => panic!(
+            "build() for non-numeric id '{}' must succeed or return ApplicationNotFound; got: {:?}",
+            bogus, other
+        ),
+    };
 
-    match result {
+    match capture.start() {
         Err(AudioError::ApplicationNotFound { identifier }) => {
             assert!(
                 identifier.contains(bogus),
@@ -177,7 +228,7 @@ fn select_by_non_numeric_id_returns_application_not_found() {
                 identifier
             );
             eprintln!(
-                "[ci_audio] ✅ Non-numeric id '{}' rejected with ApplicationNotFound",
+                "[ci_audio] ✅ Non-numeric id '{}' rejected with ApplicationNotFound at start()",
                 bogus
             );
         }
@@ -185,10 +236,12 @@ fn select_by_non_numeric_id_returns_application_not_found() {
             "Expected ApplicationNotFound for non-numeric id '{}', got: {:?}",
             bogus, other
         ),
-        Ok(_) => panic!(
-            "Expected ApplicationNotFound for non-numeric id '{}', but build succeeded",
-            bogus
-        ),
+        Ok(()) => {
+            let _ = capture.stop();
+            panic!(
+                "Expected ApplicationNotFound for non-numeric id '{bogus}', but start() succeeded"
+            );
+        }
     }
 }
 
@@ -198,8 +251,8 @@ fn select_by_non_numeric_id_returns_application_not_found() {
 /// (dereferencing nil Objective-C objects, panicking on OSStatus
 /// conversions, etc.) when the target process is the caller.
 ///
-/// The test succeeds as long as `build()` returns — `Ok` or `Err` are
-/// both acceptable. We only fail on a panic from inside the builder.
+/// The test succeeds as long as `build()` and `start()` return — `Ok` or `Err`
+/// are both acceptable. We only fail on a panic from inside the backend.
 #[test]
 #[ignore = "requires macOS 14.4+ with audio capture permission"]
 fn select_by_self_pid_does_not_panic() {
@@ -208,21 +261,34 @@ fn select_by_self_pid_does_not_panic() {
     }
 
     let self_pid = std::process::id();
-    let result = AudioCaptureBuilder::new()
+    let mut capture = match AudioCaptureBuilder::new()
         .with_target(CaptureTarget::Application(ApplicationId(
             self_pid.to_string(),
         )))
         .sample_rate(48000)
         .channels(2)
-        .build();
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "[ci_audio] ✅ Self-PID {} rejected cleanly at build() with: {:?}",
+                self_pid, e
+            );
+            return;
+        }
+    };
 
-    match result {
-        Ok(_) => eprintln!(
-            "[ci_audio] ✅ Self-PID {} accepted (no self-tap rejection on this host)",
-            self_pid
-        ),
+    match capture.start() {
+        Ok(()) => {
+            eprintln!(
+                "[ci_audio] ✅ Self-PID {} accepted (no self-tap rejection on this host)",
+                self_pid
+            );
+            let _ = capture.stop();
+        }
         Err(e) => eprintln!(
-            "[ci_audio] ✅ Self-PID {} rejected cleanly with: {:?}",
+            "[ci_audio] ✅ Self-PID {} rejected cleanly at start() with: {:?}",
             self_pid, e
         ),
     }

--- a/tests/ci_audio/compose.rs
+++ b/tests/ci_audio/compose.rs
@@ -1,0 +1,225 @@
+//! Composed multi-source capture integration tests (`compose` feature,
+//! ADR-0011).
+//!
+//! Exercises the `CompositionBuilder → Composition` pipeline against a real
+//! platform backend: two groups over the same `SystemDefault` source family —
+//! one mono mixdown group and one keep-channels group — composed into a single
+//! multi-channel stream.
+//!
+//! Skip policy (mirrors multi_source.rs):
+//! - `require_system_capture!()` skips when no audio infrastructure exists.
+//! - Format/layout assertions (channel count, session rate, map shape) are
+//!   HARD — they are pure data-plane properties, deterministic everywhere.
+//! - Content (non-silence) assertions are hard only under
+//!   `RSAC_CI_AUDIO_DETERMINISTIC=1`, soft-logged elsewhere (helpers policy).
+
+#![cfg(feature = "compose")]
+
+use std::time::{Duration, Instant};
+
+use rsac::compose::{CompositionBuilder, Group, GroupLayout};
+use rsac::CaptureTarget;
+
+use crate::helpers;
+
+/// Setup-failure policy: identical to multi_source.rs — hard-fail under the
+/// deterministic env, soft-skip elsewhere.
+fn fail_or_skip(label: &str, detail: &str, cleanup: impl FnOnce()) {
+    cleanup();
+    if helpers::deterministic_audio_env() {
+        panic!(
+            "deterministic source: {label} failed ({detail}) — the compose \
+             pipeline must work under RSAC_CI_AUDIO_DETERMINISTIC=1"
+        );
+    }
+    eprintln!("[ci_audio] compose: {label} failed (non-deterministic host): {detail}; skipping");
+}
+
+/// Happy path: a mono group + a keep-channels group over system audio compose
+/// into one stream whose layout is exactly `1 + native` channels, delivering
+/// interleaved f32 at the session rate.
+#[test]
+fn composed_system_capture_layout_and_delivery() {
+    require_system_capture!();
+
+    // Play a test tone so the system loopback has audio to compose.
+    let wav_path = helpers::generate_test_wav(6.0, 48000, 2);
+    let player = helpers::spawn_test_tone_player(&wav_path);
+    if player.is_none() {
+        fail_or_skip(
+            "no test-tone player",
+            "spawn_test_tone_player returned None",
+            || {},
+        );
+        return;
+    }
+    std::thread::sleep(Duration::from_millis(500));
+
+    // ── Build + start the composition ────────────────────────────────
+    let mut session = match CompositionBuilder::new()
+        .sample_rate(48000)
+        .group(
+            Group::new("mono_mix")
+                .source(CaptureTarget::SystemDefault)
+                .mixdown(GroupLayout::Mono),
+        )
+        .group(
+            Group::new("native")
+                .source(CaptureTarget::SystemDefault)
+                .keep_channels(),
+        )
+        .build()
+    {
+        Ok(s) => s,
+        Err(e) => {
+            fail_or_skip("composition build", &format!("{e:?}"), || {
+                stop(player);
+            });
+            return;
+        }
+    };
+    if let Err(e) = session.start() {
+        fail_or_skip("composition start", &format!("{e:?}"), || {
+            stop(player);
+        });
+        return;
+    }
+
+    // ── HARD layout assertions (deterministic data-plane contract) ───
+    let map = session
+        .channel_map()
+        .expect("channel_map after start")
+        .clone();
+    let native_width = map
+        .group_range("native")
+        .expect("native group present")
+        .len();
+    assert!(native_width >= 1, "keep-channels width must be >= 1");
+    assert_eq!(
+        usize::from(map.channels()),
+        1 + native_width,
+        "composed width = mono(1) + native({native_width})"
+    );
+    assert_eq!(
+        map.group_range("mono_mix"),
+        Some(0..1),
+        "mono group owns channel 0 (declaration order)"
+    );
+
+    // ── Read composed audio for ~2 s ─────────────────────────────────
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut buffers = 0u64;
+    let mut nonsilent = false;
+    while Instant::now() < deadline {
+        match session.read_chunk_nonblocking() {
+            Ok(Some(buffer)) => {
+                buffers += 1;
+                // HARD: every composed buffer matches the resolved layout.
+                assert_eq!(buffer.channels(), map.channels(), "buffer channel count");
+                assert_eq!(buffer.sample_rate(), 48000, "buffer session rate");
+                assert_eq!(
+                    buffer.data().len() % usize::from(map.channels()),
+                    0,
+                    "whole interleaved frames only"
+                );
+                if buffer.data().iter().any(|s| s.abs() > 1e-4) {
+                    nonsilent = true;
+                }
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(1)),
+            Err(e) if e.is_fatal() => break,
+            Err(e) => {
+                eprintln!("[ci_audio] compose: transient read error (retrying): {e:?}");
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        }
+    }
+
+    // Stats sanity (HARD: counters exist and are coherent).
+    let stats = session.stats().expect("stats after start");
+    assert_eq!(stats.sources.len(), 2, "one stat entry per source");
+
+    let _ = session.stop();
+    stop(player);
+
+    // ── Delivery assertions ──────────────────────────────────────────
+    if buffers == 0 {
+        if helpers::deterministic_audio_env() {
+            panic!("deterministic source: composition produced 0 buffers");
+        }
+        eprintln!("[ci_audio] compose: 0 composed buffers (no working loopback?); soft-skip");
+        return;
+    }
+    // Content is hard only under the deterministic env (helpers policy).
+    if helpers::deterministic_audio_env() {
+        assert!(
+            nonsilent,
+            "deterministic source: composed stream must carry the test tone"
+        );
+    } else if !nonsilent {
+        eprintln!("[ci_audio] compose: composed audio was silent (soft warning)");
+    }
+}
+
+/// Stopping a composition ends the stream terminally: an explicit `stop()`
+/// ends readability immediately (any buffered composed tail is discarded —
+/// the same contract as `AudioCapture::stop`; drain-before-terminal applies
+/// only to the composition's *natural* end), so reads must surface the fatal
+/// `StreamEnded` promptly.
+#[test]
+fn composed_capture_stop_is_terminal() {
+    require_system_capture!();
+
+    let mut session = match CompositionBuilder::new()
+        .group(
+            Group::new("sys")
+                .source(CaptureTarget::SystemDefault)
+                .mixdown(GroupLayout::Stereo),
+        )
+        .build()
+    {
+        Ok(s) => s,
+        Err(e) => {
+            fail_or_skip("composition build", &format!("{e:?}"), || {});
+            return;
+        }
+    };
+    if let Err(e) = session.start() {
+        fail_or_skip("composition start", &format!("{e:?}"), || {});
+        return;
+    }
+
+    std::thread::sleep(Duration::from_millis(300));
+    session.stop().expect("stop is Ok");
+
+    // After stop, reads must reach the fatal terminal within a bounded window
+    // (the tail, if any, is discarded by explicit stop — see Composition::stop).
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match session.read_chunk_nonblocking() {
+            Ok(Some(_)) => continue, // a race-window buffer is tolerated
+            Ok(None) => {
+                assert!(
+                    Instant::now() < deadline,
+                    "stopped composition never reached the terminal StreamEnded"
+                );
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(e) => {
+                assert!(
+                    e.is_fatal(),
+                    "post-stop read error must be the fatal terminal, got {e:?}"
+                );
+                break;
+            }
+        }
+    }
+    assert!(!session.is_running(), "stopped composition is not running");
+}
+
+/// Helper: stop a player if present. Consumes it.
+fn stop(player: Option<std::process::Child>) {
+    if let Some(p) = player {
+        helpers::stop_player(p);
+    }
+}

--- a/tests/ci_audio/helpers.rs
+++ b/tests/ci_audio/helpers.rs
@@ -30,19 +30,18 @@ pub fn audio_infrastructure_available() -> bool {
     // Runtime detection
     runtime_detect_audio()
 }
-
 /// Whether the test environment provides a *deterministic* audio source.
 ///
-/// Set by CI (`RSAC_CI_AUDIO_DETERMINISTIC=1`) on platforms where the audio
-/// path is fully reproducible: the Linux PipeWire null sink with a known
-/// 440 Hz / 0.8-amplitude sine tone player, and the Windows VB-CABLE tier
-/// (which feeds the same deterministic fixture). When this returns `true`,
-/// capture tests upgrade their soft non-silence checks into HARD ASSERTS — a
-/// deterministic source that yields silence is a real regression, not flakiness.
+/// Set by CI (`RSAC_CI_AUDIO_DETERMINISTIC=1`) only for capture tiers where the
+/// audio path is fully reproducible. Today that is Windows system capture, where
+/// VB-CABLE is verified as the active default playback endpoint before tests
+/// run. When this returns `true`, capture tests upgrade their soft non-silence
+/// checks into HARD ASSERTS — a deterministic source that yields silence is a
+/// real regression, not flakiness.
 ///
-/// When unset (e.g. macOS BlackHole/TCC — permission-gated and less
-/// reproducible), tests keep the soft-warn behavior so they do not flake on
-/// non-reproducible hosts.
+/// When unset (Linux Firecracker PipeWire routing, Windows device/process tiers,
+/// or macOS BlackHole/TCC), tests keep the soft-warn behavior so they do not
+/// flake on non-reproducible hosts.
 pub fn deterministic_audio_env() -> bool {
     matches!(
         std::env::var("RSAC_CI_AUDIO_DETERMINISTIC").as_deref(),
@@ -808,7 +807,7 @@ macro_rules! require_process_capture {
 
 /// Spawn a platform-specific audio player and return the child process + its PID.
 /// Unlike `spawn_test_tone_player`, this always returns the PID for use with
-/// `CaptureTarget::ProcessTree` or PipeWire node discovery.
+/// `CaptureTarget::Application(ApplicationId(pid))` or `CaptureTarget::ProcessTree`.
 pub fn spawn_audio_player_get_pid(wav_path: &std::path::Path) -> Result<(Child, u32), String> {
     #[cfg(target_os = "linux")]
     {
@@ -893,53 +892,50 @@ pub fn spawn_audio_player_get_pid(wav_path: &std::path::Path) -> Result<(Child, 
     }
 }
 
-/// Discover the PipeWire node ID for a given process PID.
+/// Best-effort lookup of the PipeWire node id registered for a client PID,
+/// via `pw-dump` (matching `info.props["application.process.id"]`).
 ///
-/// Runs `pw-dump` and parses the JSON output to find a node whose
-/// `application.process.id` property matches the given PID.
-/// Returns the node's `id` field as a `String`, or `None` if not found.
+/// Used by the Linux app-capture tests purely as a SKIP gate: if PipeWire
+/// never registered a node for the spawned player, per-application capture
+/// cannot possibly route audio in that environment, so the test skips instead
+/// of failing on a CI routing limitation. Any failure mode (no `pw-dump`
+/// binary, non-zero exit, unparseable output, no matching node) returns
+/// `None` — this helper must never panic a test.
 #[cfg(target_os = "linux")]
-pub fn find_pipewire_node_for_pid(pid: u32) -> Option<String> {
+pub fn find_pipewire_node_for_pid(pid: u32) -> Option<u32> {
     let output = Command::new("pw-dump").output().ok()?;
-
     if !output.status.success() {
-        eprintln!(
-            "[ci_audio] pw-dump failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
         return None;
     }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    // Parse the JSON array from pw-dump
-    let json: serde_json::Value = serde_json::from_str(&stdout).ok()?;
-    let arr = json.as_array()?;
-
-    let pid_str = pid.to_string();
-
-    for obj in arr {
-        // Check that this is a Node type
-        let obj_type = obj.get("type")?.as_str()?;
-        if obj_type != "PipeWire:Interface:Node" {
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    let objects = parsed.as_array()?;
+    for obj in objects {
+        // Only PipeWire node objects can be capture targets.
+        let is_node = obj
+            .get("type")
+            .and_then(|t| t.as_str())
+            .is_some_and(|t| t.ends_with("Node"));
+        if !is_node {
             continue;
         }
-
-        // Look for application.process.id in info.props
-        let props = obj.get("info").and_then(|i| i.get("props"));
-
-        if let Some(props) = props {
-            let app_pid = props.get("application.process.id").and_then(|v| v.as_str());
-
-            if app_pid == Some(&pid_str) {
-                // Return the node's id
-                let node_id = obj.get("id")?.as_u64()?;
-                eprintln!("[ci_audio] Found PipeWire node {} for PID {}", node_id, pid);
-                return Some(node_id.to_string());
+        let Some(props) = obj.pointer("/info/props") else {
+            continue;
+        };
+        // pw-dump emits application.process.id as a number on current
+        // versions but has emitted strings historically — accept both.
+        let matches_pid = match props.get("application.process.id") {
+            Some(v) => {
+                v.as_u64() == Some(u64::from(pid))
+                    || v.as_str().is_some_and(|s| s.trim() == pid.to_string())
             }
+            None => false,
+        };
+        if !matches_pid {
+            continue;
+        }
+        if let Some(id) = obj.get("id").and_then(|i| i.as_u64()) {
+            return Some(id as u32);
         }
     }
-
-    eprintln!("[ci_audio] No PipeWire node found for PID {}", pid);
     None
 }

--- a/tests/ci_audio/lifecycle_terminal.rs
+++ b/tests/ci_audio/lifecycle_terminal.rs
@@ -1,0 +1,294 @@
+//! Terminal read-behavior & `request_stop()` integration tests.
+//!
+//! The unit suite in `src/api.rs` already exercises `request_stop()` and the
+//! terminal-read contract against a `MockCapturingStream`:
+//!   * `request_stop_signals_stream_once` / `_is_idempotent` / `_no_stream_is_noop`
+//!   * `request_stop_unblocks_parked_blocking_read` (parked `read_buffer_blocking`
+//!     returns the fatal `StreamEnded` once `request_stop` flips the mock terminal).
+//!
+//! What the mock cannot prove — and what this file locks in — is the same
+//! contract through a **real** platform backend (PipeWire / WASAPI / CoreAudio):
+//!
+//!   1. `request_stop()` on a live, running capture drives the real bridge to a
+//!      terminal state, so `is_running()` goes false and the *terminal-observable*
+//!      reads (`read_chunk_nonblocking` / `read_buffer_blocking`) surface the
+//!      **fatal** `AudioError::StreamEnded` after the drainable tail — not the
+//!      recoverable `StreamReadError`, and not an infinite block.
+//!   2. `request_stop()` is a no-op-safe unblock primitive: it keeps the stream
+//!      handle alive (unlike `stop()`, which takes it), so it is the path a
+//!      consumer uses to end a blocking read loop cleanly per ADR-0003.
+//!   3. The `stop()` vs `request_stop()` distinction: after the owning `stop()`
+//!      the handle no longer holds a stream, so the reads report
+//!      "not initialized"/"not running" (recoverable) rather than `StreamEnded`.
+//!      This is a deliberate API difference and downstream bindings depend on it.
+//!
+//! Gating: these run under `require_system_capture!()` (audio infra + macOS TCC
+//! gate). On a deterministic source (`RSAC_CI_AUDIO_DETERMINISTIC=1`) the
+//! setup path HARD-FAILS on build/start failure; elsewhere it soft-skips.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use rsac::{AudioCaptureBuilder, AudioError, CaptureTarget};
+
+use crate::helpers;
+
+/// Shared build/start policy: hard-fail under a deterministic source (the
+/// backend is guaranteed present), soft-skip on a non-deterministic host.
+/// Returns `None` when the test should skip (setup failed on a tolerant host).
+fn build_and_start_system() -> Option<rsac::AudioCapture> {
+    let mut capture = match AudioCaptureBuilder::new()
+        .with_target(CaptureTarget::SystemDefault)
+        .sample_rate(48000)
+        .channels(2)
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            if helpers::deterministic_audio_env() {
+                panic!("deterministic source: SystemDefault build failed: {e:?}");
+            }
+            eprintln!(
+                "[ci_audio] lifecycle_terminal: build failed (non-deterministic host): {e:?}"
+            );
+            return None;
+        }
+    };
+
+    if let Err(e) = capture.start() {
+        if helpers::deterministic_audio_env() {
+            panic!("deterministic source: SystemDefault start failed: {e:?}");
+        }
+        eprintln!("[ci_audio] lifecycle_terminal: start failed (non-deterministic host): {e:?}");
+        return None;
+    }
+
+    Some(capture)
+}
+
+/// `request_stop()` on a live capture must flip the real bridge terminal:
+/// `is_running()` becomes false and a subsequent *terminal-observable* read
+/// (`read_chunk_nonblocking`) yields the FATAL `StreamEnded` once the buffered
+/// tail is drained — never an endless `Ok(None)` and never the recoverable
+/// `StreamReadError`.
+///
+/// This is the end-to-end complement to the mock-driven
+/// `request_stop_unblocks_parked_blocking_read` unit test: it proves the real
+/// backend honors ADR-0003's terminal-error contract, not just the mock.
+#[test]
+fn request_stop_drives_real_stream_terminal() {
+    require_system_capture!();
+
+    let capture = match build_and_start_system() {
+        Some(c) => c,
+        None => return,
+    };
+
+    assert!(
+        capture.is_running(),
+        "capture must be running after start()"
+    );
+
+    // Best-effort unblock: signals the stream terminal WITHOUT taking the
+    // handle, so the terminal-observable reads below still have a stream to
+    // consult (that is the whole point of request_stop vs stop).
+    capture.request_stop();
+
+    assert!(
+        !capture.is_running(),
+        "request_stop() must flip is_running() false on the real bridge"
+    );
+
+    // Drain the tail: try_read_chunk (via read_chunk_nonblocking) may yield a
+    // few buffered `Ok(Some)` / `Ok(None)` before the ring empties, then MUST
+    // surface the fatal terminal StreamEnded. Bound the loop so a broken
+    // terminal signal fails as a timeout rather than hanging.
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let mut saw_terminal = false;
+    let mut saw_recoverable_not_running = false;
+
+    while Instant::now() < deadline {
+        match capture.read_chunk_nonblocking() {
+            Ok(Some(_buf)) => {
+                // Drainable tail while Stopping — keep draining.
+            }
+            Ok(None) => {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Err(AudioError::StreamEnded { .. }) => {
+                saw_terminal = true;
+                break;
+            }
+            Err(AudioError::StreamReadError { reason }) => {
+                // Some backends may momentarily report the recoverable
+                // "not running" before the ring drains to terminal; record it
+                // but keep polling for the terminal signal.
+                saw_recoverable_not_running = true;
+                eprintln!("[ci_audio] lifecycle_terminal: transient StreamReadError: {reason}");
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Err(other) => panic!(
+                "read_chunk_nonblocking after request_stop must return StreamEnded \
+                 (fatal) or a transient StreamReadError, got: {other:?}"
+            ),
+        }
+    }
+
+    assert!(
+        saw_terminal,
+        "read_chunk_nonblocking must eventually surface the fatal StreamEnded \
+         after request_stop() (saw_recoverable_not_running={saw_recoverable_not_running}); \
+         the real backend is not honoring ADR-0003's terminal contract"
+    );
+
+    // The terminal error must classify as fatal so a `while !is_fatal()` read
+    // loop actually breaks (the exact busy-wait ADR-0003 fixes).
+    match capture.read_chunk_nonblocking() {
+        Err(e) => assert!(
+            e.is_fatal(),
+            "the terminal read error must be fatal (is_fatal()==true) so consumer \
+             loops break; got a non-fatal {e:?}"
+        ),
+        Ok(_) => panic!("a terminal stream must keep returning the terminal error, not Ok"),
+    }
+
+    eprintln!("[ci_audio] ✅ request_stop() drove the real stream terminal (StreamEnded, fatal)");
+}
+
+/// `request_stop()` must unblock a reader parked in `read_buffer_blocking()`
+/// on a real backend PROMPTLY (well under the blocking-read timeout), returning
+/// the fatal `StreamEnded`. This is the real-backend version of the mock
+/// `request_stop_unblocks_parked_blocking_read` unit test and guards the #28
+/// unblock-primitive contract the C/Go bindings rely on.
+#[test]
+fn request_stop_unblocks_parked_blocking_read_real() {
+    require_system_capture!();
+
+    let capture = match build_and_start_system() {
+        Some(c) => Arc::new(c),
+        None => return,
+    };
+
+    let reader = {
+        let capture = Arc::clone(&capture);
+        std::thread::spawn(move || {
+            // Loop through the drainable tail: recoverable/no-data reads retry,
+            // only the fatal terminal ends the loop. Bounded so a genuine hang
+            // fails the join-timeout below rather than spinning forever.
+            let deadline = Instant::now() + Duration::from_secs(8);
+            loop {
+                match capture.read_buffer_blocking() {
+                    Ok(_buf) => {
+                        // Real audio arrived before we stopped — keep reading.
+                    }
+                    Err(AudioError::StreamEnded { .. }) => return Ok(()),
+                    Err(AudioError::StreamReadError { .. }) => {
+                        // "not running" recoverable — the blocking read short-
+                        // circuits once state leaves Running; retry briefly.
+                        if Instant::now() > deadline {
+                            return Err("timed out without StreamEnded".to_string());
+                        }
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(other) => return Err(format!("unexpected error: {other:?}")),
+                }
+            }
+        })
+    };
+
+    // Let the reader get into the blocking read, then signal the unblock.
+    std::thread::sleep(Duration::from_millis(200));
+    let signalled = Instant::now();
+    capture.request_stop();
+
+    let result = reader.join().expect("reader thread joins without panic");
+    let elapsed = signalled.elapsed();
+
+    match result {
+        Ok(()) => {
+            eprintln!(
+                "[ci_audio] ✅ request_stop() unblocked parked read in {:?} (StreamEnded)",
+                elapsed
+            );
+        }
+        Err(e) => panic!("parked read_buffer_blocking was not unblocked cleanly: {e}"),
+    }
+
+    // The unblock must be prompt — request_stop exists precisely so a blocked
+    // reader does not wait out the full blocking-read timeout. Generous ceiling
+    // (2s) to tolerate headless-VM scheduling jitter while still catching a
+    // "waited out the timeout" regression.
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "request_stop() should unblock a parked read promptly; took {elapsed:?}"
+    );
+}
+
+/// The `stop()` vs `request_stop()` API distinction, on a real backend:
+/// the owning `stop()` TAKES the stream handle, so afterwards the terminal-
+/// observable reads report the recoverable "not initialized"/"not running"
+/// (`StreamReadError`) — NOT `StreamEnded` (there is no stream left to be
+/// terminal). Downstream bindings depend on this difference; lock it in.
+#[test]
+fn stop_takes_stream_reads_report_not_initialized() {
+    require_system_capture!();
+
+    let mut capture = match build_and_start_system() {
+        Some(c) => c,
+        None => return,
+    };
+
+    assert!(capture.is_running());
+
+    capture.stop().expect("stop() should succeed");
+    assert!(!capture.is_running(), "not running after stop()");
+    assert!(capture.uptime().is_none(), "uptime cleared after stop()");
+
+    // stop() dropped the stream handle, so the terminal-observable read reports
+    // the recoverable not-initialized/not-running StreamReadError, not the
+    // fatal StreamEnded.
+    match capture.read_chunk_nonblocking() {
+        Err(AudioError::StreamReadError { reason }) => {
+            let low = reason.to_lowercase();
+            assert!(
+                low.contains("not initialized") || low.contains("not running"),
+                "expected a lifecycle StreamReadError after stop(), got reason: {reason}"
+            );
+            eprintln!("[ci_audio] ✅ read after stop() → recoverable StreamReadError: {reason}");
+        }
+        other => panic!(
+            "read after owning stop() must be a recoverable StreamReadError \
+             (stream handle was taken), got: {other:?}"
+        ),
+    }
+}
+
+/// `stop()` is idempotent on a real backend and safe to interleave with
+/// `request_stop()`: signalling a terminal via `request_stop()` and then
+/// calling the owning `stop()` must both succeed without panic, and a second
+/// `stop()` is a clean no-op.
+#[test]
+fn request_stop_then_stop_is_clean_and_idempotent() {
+    require_system_capture!();
+
+    let mut capture = match build_and_start_system() {
+        Some(c) => c,
+        None => return,
+    };
+
+    // Best-effort unblock first (does not take the handle)...
+    capture.request_stop();
+    // ...then the owning stop must still succeed and be authoritative.
+    capture
+        .stop()
+        .expect("stop() after request_stop() must succeed");
+    assert!(!capture.is_running());
+
+    // Second stop is idempotent (no stream left) — must not panic.
+    capture.stop().expect("second stop() must be a clean no-op");
+
+    // request_stop after everything is torn down is also a no-op.
+    capture.request_stop();
+
+    eprintln!("[ci_audio] ✅ request_stop()/stop() interleave cleanly and idempotently");
+}

--- a/tests/ci_audio/main.rs
+++ b/tests/ci_audio/main.rs
@@ -11,9 +11,14 @@ mod helpers;
 
 mod app_capture;
 mod application_by_name;
+mod application_by_name_windows;
 mod application_by_pid;
+// Composed multi-source capture (ADR-0011). The module is additionally gated
+// on the `compose` feature internally (`#![cfg(feature = "compose")]`).
+mod compose;
 mod device_capture;
 mod device_enumeration;
+mod lifecycle_terminal;
 mod multi_source;
 mod overrun;
 mod platform_caps;

--- a/tests/ci_audio/process_tree.rs
+++ b/tests/ci_audio/process_tree.rs
@@ -25,8 +25,8 @@
 use std::time::Duration;
 
 use rsac::{
-    list_audio_applications, list_audio_sources, AudioCaptureBuilder, AudioSourceKind,
-    CaptureTarget, PlatformCapabilities, ProcessId,
+    list_audio_applications, list_audio_sources, ApplicationId, AudioCaptureBuilder,
+    AudioSourceKind, CaptureTarget, PlatformCapabilities, ProcessId,
 };
 
 use crate::helpers;
@@ -107,11 +107,16 @@ fn capabilities_match_builder_acceptance() {
 
 /// `list_audio_sources()` always includes at least the system default,
 /// and every `AudioSourceKind::Application` entry must round-trip
-/// cleanly through `to_capture_target()` to a `ProcessTree` variant
-/// with the same PID. This is the contract the Tauri app relies on
-/// when building its "application capture" dropdown.
+/// cleanly through `to_capture_target()` to an `Application` variant
+/// carrying the same PID (as the `ApplicationId` string). Single-app
+/// capture — NOT the over-broad `ProcessTree` — is the deliberate
+/// mapping since #27 (see the L17 note on `AudioSource::to_capture_target`
+/// and its unit test in `src/core/introspection.rs`). This is the
+/// contract the Tauri app relies on for its "application capture"
+/// dropdown; callers that want the whole subtree use
+/// `CaptureTarget::pid()` explicitly.
 #[test]
-fn list_audio_sources_applications_roundtrip_to_process_tree() {
+fn list_audio_sources_applications_roundtrip_to_application() {
     require_audio!();
 
     let sources = match list_audio_sources() {
@@ -145,10 +150,11 @@ fn list_audio_sources_applications_roundtrip_to_process_tree() {
         match (&src.kind, src.to_capture_target()) {
             (
                 AudioSourceKind::Application { pid, .. },
-                CaptureTarget::ProcessTree(ProcessId(tp)),
+                CaptureTarget::Application(ApplicationId(id)),
             ) => {
                 assert_eq!(
-                    *pid, tp,
+                    pid.to_string(),
+                    id,
                     "to_capture_target() must preserve PID from Application kind"
                 );
             }
@@ -161,7 +167,7 @@ fn list_audio_sources_applications_roundtrip_to_process_tree() {
     }
 
     eprintln!(
-        "[ci_audio] ✅ all {} application entries round-trip to ProcessTree",
+        "[ci_audio] ✅ all {} application entries round-trip to Application",
         app_sources.len()
     );
 }

--- a/tests/ci_audio/subscribe.rs
+++ b/tests/ci_audio/subscribe.rs
@@ -50,7 +50,12 @@ fn fail_or_skip(label: &str, detail: &str) {
 /// CoreAudio on macOS).
 #[test]
 fn subscribe_delivers_buffers_from_live_capture() {
-    require_audio!();
+    // This test captures CaptureTarget::SystemDefault, which on macOS is a
+    // Process Tap behind the kTCCServiceAudioCapture gate — without the grant
+    // the tap "succeeds" but delivers pure silence, so the #34 content checks
+    // can never pass. Gate like system_capture.rs / lifecycle_terminal.rs do
+    // (no-op on Linux/Windows, where macos_tcc_available() is always true).
+    require_system_capture!();
 
     // #34: feed a known 440 Hz tone through SystemDefault loopback so the
     // subscribe path can be CONTENT-verified (not just liveness-verified) on a
@@ -230,7 +235,9 @@ fn subscribe_errors_when_not_started() {
         Err(AudioError::StreamReadError { reason }) => {
             assert!(
                 reason.to_lowercase().contains("not running")
-                    || reason.to_lowercase().contains("not initialized"),
+                    || reason.to_lowercase().contains("not initialized")
+                    || reason.to_lowercase().contains("no active stream")
+                    || reason.to_lowercase().contains("never started"),
                 "expected lifecycle-related reason, got: {}",
                 reason
             );

--- a/tests/ci_audio/system_capture.rs
+++ b/tests/ci_audio/system_capture.rs
@@ -69,12 +69,29 @@ fn test_system_capture_receives_audio() {
     let mut total_frames: usize = 0;
     let mut got_non_silence = false;
     let mut buffers_read: usize = 0;
+    let mut last_timestamp: Option<std::time::Duration> = None;
 
     while start.elapsed() < timeout {
         match capture.read_buffer() {
             Ok(Some(buffer)) => {
                 buffers_read += 1;
                 total_frames += buffer.num_frames();
+
+                // rsac-ec25 wiring: every backend's RT push now stamps buffers
+                // with a stream-position timestamp, so these are HARD asserts —
+                // they are pure data-plane properties, independent of audio
+                // routing: timestamps must be present and non-decreasing.
+                let ts = buffer.timestamp().expect(
+                    "AudioBuffer::timestamp must be populated by the stamped \
+                     producer push (stream-position wiring, rsac-ec25)",
+                );
+                if let Some(prev) = last_timestamp {
+                    assert!(
+                        ts >= prev,
+                        "buffer timestamps must be non-decreasing: {prev:?} then {ts:?}"
+                    );
+                }
+                last_timestamp = Some(ts);
 
                 if !got_non_silence && helpers::verify_non_silence(&buffer, 0.001) {
                     got_non_silence = true;

--- a/tests/rt_alloc.rs
+++ b/tests/rt_alloc.rs
@@ -1,5 +1,5 @@
 //! Allocation-counting integration test for the real-time bridge producer
-//! (seeds `rsac-e40c`).
+//! (seeds `rsac-e40c`, hardened by `rsac-0940`).
 //!
 //! ADR-0001 (`docs/designs/0001-rt-allocation-guarantee.md`) claims
 //! [`BridgeProducer::push_samples_or_drop`] is **allocation-free in steady
@@ -10,11 +10,19 @@
 //!
 //! A [`CountingAllocator`] wraps the standard [`System`] allocator and bumps an
 //! [`AtomicUsize`] on every `alloc`/`realloc`/`dealloc`. It is installed as the
-//! process-wide `#[global_allocator]`. Because that counter is global and libtest
-//! runs the `#[test]` fns in this binary **in parallel by default**, each test
-//! holds a shared `MEASURE_LOCK` mutex across its entire measured region so no two
-//! measurements ever overlap — the tests therefore pass under a plain
-//! `cargo test --test rt_alloc` (no `--test-threads=1` needed). The counting
+//! process-wide `#[global_allocator]`. Because that counter is **process-global**,
+//! *any* thread that allocates during a measured region inflates the count — and
+//! libtest runs `#[test]` fns on freshly spawned threads, so with multiple tests
+//! in this binary even a mutex-serialized measurement could be perturbed by a
+//! parallel test thread's incidental allocations (thread spawn, harness
+//! bookkeeping, panic machinery). The robust fix (`rsac-0940`) is structural:
+//! **all measured scenarios are merged into a single `#[test]`** and run
+//! sequentially on one thread, so no sibling test thread can ever exist during a
+//! measured region — the proofs pass identically with or without
+//! `--test-threads=1`. (Filtering the allocator by thread id was considered and
+//! rejected: `std::thread::current()` uses TLS and can itself allocate inside
+//! the alloc hook — a recursion hazard — and an OS-TID syscall per allocation
+//! would add platform-specific FFI for no additional rigor.) The counting
 //! allocator is test code only and never reaches the shipped library —
 //! `#[global_allocator]` here applies solely to this test executable.
 //!
@@ -24,17 +32,22 @@
 //! to allocate within the measured region (no formatting, no growth) so the count
 //! reflects only the code under test.
 //!
-//! The test:
+//! The merged proof:
 //!   1. Warms the free-list by pushing+popping a fixed 1024-frame stereo period
 //!      until the producer recycles allocations instead of allocating.
 //!   2. Asserts **zero** allocations across >= 1000 steady-state push/pop cycles
-//!      at the constant period.
-//!   3. Asserts a period **increase** beyond the seeded capacity triggers at most
+//!      at the constant period (untimed and stamped variants).
+//!   3. Asserts the **saturated-ring drop path** — every push rejected with
+//!      `Err(Full)`, its `Vec` reclaimed into scratch, the stream position still
+//!      advancing — is also allocation-free (the reclaim path is exactly what a
+//!      stalled consumer exercises on the RT thread).
+//!   4. Asserts a period **increase** beyond the seeded capacity triggers at most
 //!      a *bounded one-time* allocation, after which the larger period is again
 //!      allocation-free (ADR-0001 "bounded one-time growth").
 
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use rsac::bridge::ring_buffer::{create_bridge, BridgeConsumer, BridgeProducer};
 use rsac::core::config::AudioFormat;
@@ -51,9 +64,10 @@ static DEALLOCS: AtomicUsize = AtomicUsize::new(0);
 
 /// A [`GlobalAlloc`] that forwards to [`System`] while counting every operation.
 ///
-/// Counting uses `Relaxed` atomics: this test is single-threaded, so the only
-/// requirement is that the bumps are visible to the same thread in program order,
-/// which `Relaxed` already guarantees. We deliberately do **no** allocation,
+/// Counting uses `Relaxed` atomics: the measured regions run single-threaded (a
+/// single merged `#[test]` — see the module docs), so the only requirement is
+/// that the bumps are visible to the same thread in program order, which
+/// `Relaxed` already guarantees. We deliberately do **no** allocation,
 /// locking, or formatting inside these methods so the allocator itself never
 /// perturbs the count it is measuring.
 struct CountingAllocator(System);
@@ -104,19 +118,6 @@ fn with_alloc_count<F: FnOnce()>(f: F) -> usize {
     after - before
 }
 
-/// Serializes the alloc-measurement tests. The counting allocator is a
-/// **process-wide** `#[global_allocator]`, and libtest runs the `#[test]` fns in
-/// this binary in PARALLEL by default — so without this lock, allocations from
-/// one test's thread would be counted inside another test's measured region,
-/// producing spurious failures. Each test holds this guard across its entire
-/// warm-up + measurement so no two measured regions ever overlap. (A poisoned
-/// lock from a failing test must not mask the others, so we recover the guard.)
-static MEASURE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-fn measure_guard() -> std::sync::MutexGuard<'static, ()> {
-    MEASURE_LOCK.lock().unwrap_or_else(|p| p.into_inner())
-}
-
 // ── Fixtures ───────────────────────────────────────────────────────────────
 
 const CHANNELS: u16 = 2;
@@ -131,10 +132,12 @@ const STEADY_SAMPLES: usize = STEADY_FRAMES * CHANNELS as usize; // 2048
 /// path ADR-0001 governs), returning `(allocs, pushed)`.
 ///
 /// Only the producer call is inside the measured region. `pop` is deliberately
-/// **not** measured here: by design [`BridgeConsumer::pop`] clones a fresh owned
-/// buffer for the user (`original.clone()` in `ring_buffer.rs`) — that allocation
-/// is intentional and happens on the non-RT consumer thread. The RT guarantee is
-/// solely about the producer, so the test isolates it.
+/// **not** measured here: by design [`BridgeConsumer::pop`] *moves* the ring's
+/// buffer to the user with no clone (`rsac-17d1`) and recycles a spare
+/// `Vec<f32>` back to the producer's free-list — allocating that spare on the
+/// consumer side when its pool runs dry. That allocation is intentional and
+/// happens on the non-RT consumer thread. The RT guarantee is solely about the
+/// producer, so the test isolates it.
 fn measure_push(producer: &mut BridgeProducer, slice: &[f32]) -> (usize, bool) {
     let mut pushed = false;
     let allocs = with_alloc_count(|| {
@@ -146,7 +149,7 @@ fn measure_push(producer: &mut BridgeProducer, slice: &[f32]) -> (usize, bool) {
 /// Drive the free-list to steady state: enough push/pop cycles that the producer
 /// reuses recycled allocations rather than allocating. The seed is `min(cap, 8)`
 /// buffers; a few hundred cycles is far more than enough to converge. `pop`
-/// recycles each drained `Vec` back to the producer's free-list.
+/// recycles a spare `Vec` back to the producer's free-list on every cycle.
 fn warm_up(producer: &mut BridgeProducer, consumer: &mut BridgeConsumer, slice: &[f32]) {
     for _ in 0..512 {
         producer.push_samples_or_drop(slice, CHANNELS, SAMPLE_RATE);
@@ -154,18 +157,18 @@ fn warm_up(producer: &mut BridgeProducer, consumer: &mut BridgeConsumer, slice: 
     }
 }
 
-// ── Tests ────────────────────────────────────────────────────────────────
+// ── Proof scenarios ────────────────────────────────────────────────────────
+//
+// Each scenario is a plain fn (not a `#[test]`): the single merged test at the
+// bottom runs them sequentially on one thread so the process-global allocation
+// counter is never perturbed by a sibling test thread (see the module docs).
 
 /// Steady-state `push_samples_or_drop` at a constant 1024-frame stereo period
 /// performs **zero** heap allocations once the free-list is warm (ADR-0001).
 ///
 /// The measured region covers only the producer's push (`pop` recycles the
 /// allocation back between measurements, outside the count — see [`measure_push`]).
-#[test]
 fn push_samples_or_drop_is_alloc_free_in_steady_state() {
-    // Hold the process-wide measurement lock for the whole test so a parallel
-    // test's allocations can't leak into our counted region.
-    let _guard = measure_guard();
     // The slice and bridge are built BEFORE any measured region, so their
     // allocations are not counted.
     let slice: Vec<f32> = (0..STEADY_SAMPLES).map(|i| (i as f32) * 1e-4).collect();
@@ -184,8 +187,9 @@ fn push_samples_or_drop_is_alloc_free_in_steady_state() {
         if pushed {
             pushes_ok += 1;
         }
-        // Recycle the buffer back to the producer's free-list (allocates a user
-        // copy on the consumer side by design — outside the measured region).
+        // Recycle a spare back to the producer's free-list (the pop hands the
+        // user the ring's buffer moved, not cloned, and may allocate the spare
+        // on the consumer side — by design, outside the measured region).
         let _ = consumer.pop();
     }
 
@@ -204,14 +208,126 @@ fn push_samples_or_drop_is_alloc_free_in_steady_state() {
     );
 }
 
+/// The stream-position-stamping variants (`push_samples_or_drop_stamped` /
+/// `push_samples_guarded_stamped`) are what the platform backends now run on
+/// the RT path (rsac-ec25 wiring), so ADR-0001's zero-allocation guarantee is
+/// proved for them too: the stamp is pure integer math over a plain `u64`
+/// nanosecond accumulator (rsac-1b8c) — no clock syscall, no allocation.
+fn stamped_push_is_alloc_free_in_steady_state() {
+    let slice: Vec<f32> = (0..STEADY_SAMPLES).map(|i| (i as f32) * 1e-4).collect();
+    let (mut producer, mut consumer) = create_bridge(64, AudioFormat::default());
+
+    warm_up(&mut producer, &mut consumer, &slice);
+
+    const CYCLES: usize = 2000;
+    let mut total_push_allocs = 0usize;
+    let mut pushes_ok = 0u64;
+    for i in 0..CYCLES {
+        // Alternate between the plain and panic-guarded stamped variants so
+        // both RT entry points (Windows thread / PipeWire+CoreAudio callbacks)
+        // are covered by the same proof.
+        let mut pushed = false;
+        let allocs = with_alloc_count(|| {
+            pushed = if i % 2 == 0 {
+                producer.push_samples_or_drop_stamped(&slice, CHANNELS, SAMPLE_RATE)
+            } else {
+                producer.push_samples_guarded_stamped(&slice, CHANNELS, SAMPLE_RATE)
+            };
+        });
+        total_push_allocs += allocs;
+        if pushed {
+            pushes_ok += 1;
+        }
+        let _ = consumer.pop();
+    }
+
+    assert_eq!(
+        total_push_allocs, 0,
+        "stamped pushes must be allocation-free across {CYCLES} steady-state \
+         cycles (ADR-0001); observed {total_push_allocs} allocations on the \
+         producer hot path"
+    );
+    assert_eq!(
+        pushes_ok, CYCLES as u64,
+        "every steady-state stamped push should have succeeded"
+    );
+}
+
+/// The **saturated-ring drop path** is allocation-free too (`rsac-0940`): with
+/// no consumer pops, every stamped push is rejected with `Err(Full)` and its
+/// `Vec` is reclaimed into the producer's scratch slot for reuse — the exact
+/// path a stalled consumer forces onto the RT thread. This was previously
+/// unmeasured; ADR-0001's guarantee covers it just as much as the happy path.
+///
+/// The scenario also proves the stream position keeps advancing through the
+/// drops (rsac-1b8c gap semantics): the first post-drop push must be stamped
+/// past the whole dropped duration.
+fn saturated_ring_drop_path_is_alloc_free() {
+    let slice: Vec<f32> = (0..STEADY_SAMPLES).map(|i| (i as f32) * 1e-4).collect();
+    // Small ring so saturation is immediate; free-list seeded with min(4,8)=4.
+    let (mut producer, mut consumer) = create_bridge(4, AudioFormat::default());
+
+    // Fill the ring WITHOUT popping (unmeasured): 4 successful stamped pushes
+    // consume the seeded free-list vecs and saturate the ring.
+    const WARM_PUSHES: u64 = 4;
+    for _ in 0..WARM_PUSHES {
+        assert!(
+            producer.push_samples_or_drop_stamped(&slice, CHANNELS, SAMPLE_RATE),
+            "warm pushes into an empty ring must succeed"
+        );
+    }
+
+    // Measured: N stamped pushes that ALL drop. Each exercises the
+    // free-list-empty → scratch → Err(Full) → reclaim-into-scratch cycle plus
+    // the position advance, under the allocation counter.
+    const DROPS: u64 = 1000;
+    let mut all_dropped = true;
+    let allocs = with_alloc_count(|| {
+        for _ in 0..DROPS {
+            if producer.push_samples_or_drop_stamped(&slice, CHANNELS, SAMPLE_RATE) {
+                all_dropped = false;
+            }
+        }
+    });
+
+    assert!(
+        all_dropped,
+        "with no consumer pops the saturated ring must reject every push"
+    );
+    assert_eq!(
+        allocs, 0,
+        "the saturated-ring drop path (Err(Full) + scratch reclaim + position \
+         advance) must be allocation-free on the producer (ADR-0001 / rsac-0940); \
+         observed {allocs} allocations across {DROPS} dropped pushes"
+    );
+    assert_eq!(
+        producer.buffers_dropped(),
+        DROPS,
+        "every measured push must have been counted as a drop"
+    );
+
+    // Position advanced through the drops (rsac-1b8c): drain the delivered
+    // buffers, then the next successful push must be stamped past the whole
+    // cumulative gap. Each push advances by the same floored per-period value,
+    // so the expected cumulative stamp is exact.
+    while consumer.pop().is_some() {}
+    assert!(producer.push_samples_or_drop_stamped(&slice, CHANNELS, SAMPLE_RATE));
+    let after = consumer.pop().expect("post-drop buffer must be delivered");
+    let per_push_nanos = (STEADY_FRAMES as u64) * 1_000_000_000 / u64::from(SAMPLE_RATE);
+    let expected = Duration::from_nanos((WARM_PUSHES + DROPS) * per_push_nanos);
+    assert_eq!(
+        after.timestamp(),
+        Some(expected),
+        "the stream position must keep advancing through the dropped pushes \
+         (gap semantics — rsac-1b8c)"
+    );
+}
+
 /// A callback-period **increase** beyond the seeded buffer capacity triggers at
 /// most a *bounded one-time* allocation on the producer; once the recycled buffers
 /// have grown to the new high-water mark, the larger period is allocation-free
 /// again (ADR-0001 "bounded one-time growth").
-#[test]
 fn period_increase_triggers_bounded_one_time_allocation() {
-    // Hold the process-wide measurement lock (see MEASURE_LOCK) for the whole test.
-    let _guard = measure_guard();
     // Start at the seeded steady period (fits the pre-sized buffers).
     let small: Vec<f32> = (0..STEADY_SAMPLES).map(|i| (i as f32) * 1e-4).collect();
     // A larger period — double the frames — exceeds the seeded buffer capacity
@@ -263,4 +379,21 @@ fn period_increase_triggers_bounded_one_time_allocation() {
          period must be allocation-free again (ADR-0001); observed {steady_allocs} \
          allocations on the producer hot path"
     );
+}
+
+// ── The single merged test ─────────────────────────────────────────────────
+
+/// Run every allocation proof sequentially on one thread (`rsac-0940`).
+///
+/// One `#[test]` means libtest never has a sibling test thread alive while a
+/// region is being measured, so the process-global counting allocator observes
+/// ONLY the code under test — the proofs are deterministic with or without
+/// `--test-threads=1`. Scenario names appear in assertion messages, so a
+/// failure still pinpoints which proof broke.
+#[test]
+fn rt_alloc_proofs() {
+    push_samples_or_drop_is_alloc_free_in_steady_state();
+    stamped_push_is_alloc_free_in_steady_state();
+    saturated_ring_drop_path_is_alloc_free();
+    period_increase_triggers_bounded_one_time_allocation();
 }


### PR DESCRIPTION
First layer of the 0.4.1 release stack (epic rsac-4844, decision record rsac-79bc; replaces the monolithic review surface of #35, which shrinks to the mobile-packaging tail as layers merge).

**Scope: the complete library crate** (52 files), cut verbatim from integration snapshot e7335a9:

- **bridge** - nanosecond stream-position timestamps on every backend push path (rate-renegotiation-proof, centralized advance, drops leave measurable gaps), free-list alloc-free RT pushes (ADR-0001 proofs in tests/rt_alloc.rs), terminal state machine (ADR-0010)
- **compose** (ADR-0011, opt-in feature) - multi-source channel composition: groups mixed to Mono/Stereo or native-width, rubato resampling, master-clock pacing, intra-source gap compensation, engine panic containment
- **api** - bounded subscribe pumps with drop accounting (subscriber_dropped_count), drain sinks, async streams, precondition parity between AudioCapture and Composition
- **backends** - WASAPI / PipeWire / CoreAudio through BridgeStream; capture-thread panic containment; RT-safe diagnostics; macOS TCC preflight (ADR-0015, opt-in macos-tcc-spi) + silent-zeros guard (ADR-0016); Android/iOS mic slices (cfg-gated, compile-checked only)
- **tests** - 640-test lib suite, rt_alloc allocation proofs, ci_audio integration suites

**Layer adjustments vs the snapshot:** mobile/android-native workspace member + mobile/ glue ride in the tail PR (rsac-d303). Everything else verbatim.

**Validation:** lib 640/640 (feat_windows,compose,async-stream) - clippy -D warnings (all-targets, feat_windows,compose,cli) - fmt - doctests 20/20 - rt_alloc - bare build - master's rsac-ffi compiles unchanged against this rsac. All content previously validated in #35's CI (35 checks green) and on real Windows + macOS 26 hardware.

**Stack order:** L1 (this) -> L3 bindings (rsac-465b) -> L4 CI/DevEx (rsac-0d0c) -> L5 docs (rsac-f3e7) -> mobile tail (rsac-d303). Squash-merge bottom-up with --delete-branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile audio capture support for Android and iOS, including new system-audio and microphone capture paths.
  * Introduced multi-source composition, letting users combine and mix multiple capture sources into one stream.
  * Added a new composition example to demonstrate grouped capture and channel layout handling.

* **Bug Fixes**
  * Improved stream shutdown, buffering, and terminal error handling across platforms.
  * Added macOS permission preflight and better diagnostics for silent or denied system-audio capture.
  * Expanded CI to run on release branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->