### PR TITLE
0.4.1 stack tail: mobile packaging + CI legs (completes the stack; replaces #35)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,6 +478,162 @@ jobs:
           fi
           echo "TOLERATED: aarch64 PipeWire system libraries unavailable (pkg-config failure in the pipewire/libspa -sys build scripts); no rustc compilation errors"
 
+  # ── Android mobile leg (rsac-1a6e): backend cross-check + AAR build ──
+  # Stage-1 mobile CI per docs/MOBILE_BACKEND_DESIGN.md: proves COMPILATION,
+  # not capture. `cargo check` needs no NDK (no linking); the Gradle step
+  # builds mobile/android's rsac.aar sources for real. Emulator/device
+  # runtime verification is a separate, later seed — do not claim "tested
+  # on Android" off the back of this job.
+  mobile-android:
+    name: Android Mobile Leg (cross-check + AAR)
+    timeout-minutes: 25
+    needs: lint
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        with:
+          targets: aarch64-linux-android
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Cross-check the Android backend (feat_android)
+        run: |
+          cargo check --target aarch64-linux-android --no-default-features --features feat_android
+          cargo check --target aarch64-linux-android
+          cargo check --target aarch64-linux-android --tests --no-default-features --features feat_android
+          cargo clippy --target aarch64-linux-android --no-default-features --features feat_android -- -D warnings
+
+      # rsac-7a18: the C FFI is how Flutter/C consumers reach rsac on Android.
+      - name: Cross-check rsac-ffi for Android (feat_android)
+        run: cargo check -p rsac-ffi --target aarch64-linux-android --no-default-features --features feat_android
+
+      # rsac-0aa9: build librsac.so for real with the NDK linker — the first
+      # step that actually LINKS the backend (#[link(name = "aaudio")]);
+      # cargo check never does. Output lands in the AAR's jniLibs so the
+      # Gradle build below packages it (System.loadLibrary("rsac") on the
+      # Kotlin side resolves the JNI surface registered in JNI_OnLoad,
+      # rsac-77f1).
+      - name: Install cargo-ndk
+        run: cargo install --locked cargo-ndk
+
+      - name: Build librsac.so into jniLibs (arm64-v8a + x86_64)
+        run: |
+          # ANDROID_NDK_LATEST_HOME / ANDROID_NDK_ROOT are runner-process env
+          # (visible to the shell, NOT to ${{ env.* }} expressions — first-run
+          # lesson: mapping it via `env:` yielded an empty string and broke
+          # cargo-ndk's NDK detection).
+          export ANDROID_NDK_HOME="${ANDROID_NDK_LATEST_HOME:-$ANDROID_NDK_ROOT}"
+          echo "Using NDK at: $ANDROID_NDK_HOME"
+          rustup target add x86_64-linux-android
+          # --platform 29 matches the AAR's minSdk AND is required for the
+          # link to resolve: libaaudio.so stubs exist in the NDK sysroot only
+          # from API 26+ (cargo-ndk's default platform is lower — second
+          # first-run lesson: ld.lld could not find -laaudio without this).
+          cargo ndk -t arm64-v8a -t x86_64 --platform 29 -o mobile/android/src/main/jniLibs \
+            build --release -p rsac-android-native
+          ls -l mobile/android/src/main/jniLibs/*/librsac.so
+
+      # rsac-77f1: the whole playback path hangs off System.loadLibrary
+      # invoking JNI_OnLoad (RegisterNatives design — deliberately NO Java_*
+      # name-resolved exports). Assert the symbol is really exported from
+      # the cdylib: #[no_mangle] symbols originating in the rsac RLIB must
+      # survive into the rsac-android-native CDYLIB's dynamic symbol table,
+      # which is a linker property no cargo check can prove.
+      - name: Verify JNI_OnLoad is an exported dynamic symbol
+        run: |
+          NM="$(find "${ANDROID_NDK_LATEST_HOME:-$ANDROID_NDK_ROOT}" -name llvm-nm -path '*linux-x86_64*' | head -n1)"
+          for ABI in arm64-v8a x86_64; do
+            SO="mobile/android/src/main/jniLibs/$ABI/librsac.so"
+            "$NM" -D --defined-only "$SO" | grep -q " JNI_OnLoad$" || {
+              echo "FAIL: $SO does not export JNI_OnLoad (RegisterNatives entry point)"
+              "$NM" -D --defined-only "$SO" | head -n 40
+              exit 1
+            }
+          done
+          echo "OK: JNI_OnLoad exported for arm64-v8a and x86_64"
+
+      - name: Select JDK 17 (AGP 8.x requirement)
+        run: echo "JAVA_HOME=${JAVA_HOME_17_X64}" >> "$GITHUB_ENV"
+
+      - name: Install Android SDK platform for compileSdk 35
+        run: |
+          SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+          yes | "$SDKMANAGER" --licenses > /dev/null || true
+          "$SDKMANAGER" "platforms;android-35" "build-tools;35.0.0"
+
+      - uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
+        with:
+          gradle-version: "8.11.1"
+
+      - name: Build rsac.aar (mobile/android glue sources)
+        working-directory: mobile/android
+        run: gradle assembleRelease --no-daemon --stacktrace
+
+      - name: Verify the AAR artifact contains the native library
+        run: |
+          AAR="$(find mobile/android/build/outputs/aar -name '*.aar' | head -n1)"
+          if [ -z "$AAR" ]; then
+            echo "FAIL: no .aar produced by assembleRelease"
+            exit 1
+          fi
+          echo "OK: built $AAR ($(stat -c%s "$AAR") bytes)"
+          # rsac-0aa9: the packaged AAR must carry librsac.so per ABI.
+          for ABI in arm64-v8a x86_64; do
+            unzip -l "$AAR" | grep -q "jni/$ABI/librsac.so" || {
+              echo "FAIL: $AAR is missing jni/$ABI/librsac.so"
+              unzip -l "$AAR"
+              exit 1
+            }
+          done
+          echo "OK: AAR contains librsac.so for arm64-v8a and x86_64"
+
+  # ── iOS mobile leg (rsac-48e7): backend cross-check + SwiftPM build ──
+  # Same stage-1 honesty: compilation only.
+  mobile-ios:
+    name: iOS Mobile Leg (cross-check + SwiftPM)
+    timeout-minutes: 25
+    needs: lint
+    runs-on: blacksmith-6vcpu-macos-15
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        with:
+          targets: aarch64-apple-ios
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Cross-check the iOS backend (feat_ios)
+        run: |
+          cargo check --target aarch64-apple-ios --no-default-features --features feat_ios
+          cargo check --target aarch64-apple-ios
+          cargo check --target aarch64-apple-ios --tests --no-default-features --features feat_ios
+          cargo clippy --target aarch64-apple-ios --no-default-features --features feat_ios -- -D warnings
+
+      # rsac-7a18: the C FFI is how Flutter/C consumers reach rsac on iOS
+      # (staticlib + dart:ffi).
+      - name: Cross-check rsac-ffi for iOS (feat_ios)
+        run: cargo check -p rsac-ffi --target aarch64-apple-ios --no-default-features --features feat_ios
+
+      - name: Build the SwiftPM package for iOS (both products)
+        working-directory: mobile/ios
+        run: |
+          # xcodebuild drives SwiftPM directly; a generic iOS destination needs
+          # no simulator runtime and no signing for library products.
+          xcodebuild build \
+            -scheme RsacAudio \
+            -destination 'generic/platform=iOS' \
+            -skipPackagePluginValidation \
+            CODE_SIGNING_ALLOWED=NO
+          xcodebuild build \
+            -scheme RsacBroadcastKit \
+            -destination 'generic/platform=iOS' \
+            -skipPackagePluginValidation \
+            CODE_SIGNING_ALLOWED=NO
+
+  # ── Binding crates compilation check ─────────────────────────────────
   check-bindings:
     name: Binding Crates
     timeout-minutes: 20

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,6 +1751,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsac-android-native"
+version = "0.4.0"
+dependencies = [
+ "rsac",
+]
+
+[[package]]
 name = "rsac-ffi"
 version = "0.4.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -373,10 +373,10 @@ members = [
     "bindings/rsac-python",
     "bindings/rsac-ffi",
     "bindings/rsac-napi",
-    # NOTE (stack L1, rsac-f86e): the mobile/android-native member rides in
-    # the mobile tail PR of the 0.4.1 stack (rsac-d303) together with the
-    # rest of mobile/. The two Kotlin contract sources ARE in this layer —
-    # the cfg-independent jni_lockstep tests include_str! them.
+    # Android cdylib shim (librsac.so for the AAR's jniLibs; rsac-0aa9).
+    # Lives under /mobile, which is excluded from the crates.io package —
+    # workspace membership is orthogonal to packaging.
+    "mobile/android-native",
 ]
 exclude = ["apps/audio-graph/src-tauri"]
 

--- a/mobile/android-native/Cargo.toml
+++ b/mobile/android-native/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "rsac-android-native"
+version = "0.4.0"
+edition = "2021"
+publish = false
+description = "Android cdylib shim: builds librsac.so (via cargo-ndk) for the rsac AAR's jniLibs (rsac-0aa9)"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/Codeseys-Labs/rust-crossplat-audio-capture"
+
+# Why a wrapper crate instead of adding crate-type = ["cdylib"] to the root
+# rsac manifest (decision recorded per rsac-0aa9):
+# - the root crate stays a pure rlib, so desktop consumers and the existing
+#   bindings don't pay for (or accidentally ship) an extra cdylib artifact;
+# - cargo-ndk gets one unambiguous build target whose [lib] name is `rsac`,
+#   producing exactly the `librsac.so` the Kotlin side loads
+#   (System.loadLibrary("rsac") — mobile/android RsacProjection.kt);
+# - the JNI export surface (rsac-77f1, src/audio/android/jni.rs) is
+#   #[no_mangle] extern symbols in rsac itself (JNI_OnLoad — RegisterNatives
+#   design, no Java_* exports); linking rsac into this cdylib re-exports it,
+#   so this shim never needs code of its own beyond
+#   the keep-alive re-export in src/lib.rs.
+[lib]
+name = "rsac"
+crate-type = ["cdylib"]
+
+[dependencies]
+rsac = { path = "../..", default-features = false, features = ["feat_android"] }

--- a/mobile/android-native/src/lib.rs
+++ b/mobile/android-native/src/lib.rs
@@ -1,0 +1,26 @@
+//! Android cdylib shim producing `librsac.so` (rsac-0aa9).
+//!
+//! This crate intentionally contains no logic. It exists so cargo-ndk can
+//! build a `cdylib` named `rsac` for the Android ABIs without adding a
+//! `cdylib` crate-type to the root rsac manifest (which would bolt an extra
+//! artifact onto every desktop build). See the manifest for the full
+//! decision record.
+//!
+//! The `pub use` below links the rsac rlib into this cdylib. `#[no_mangle]
+//! extern` symbols defined inside rsac — the JNI export surface (rsac-77f1)
+//! — are preserved as exported dynamic symbols of the resulting `.so`,
+//! which is exactly what `System.loadLibrary("rsac")` on the Kotlin side
+//! (mobile/android) resolves against. The surface is deliberately **one
+//! symbol**: `JNI_OnLoad` (src/audio/android/jni.rs), which registers the
+//! `ai.codeseys.rsac` natives via `RegisterNatives` — there are no `Java_*`
+//! name-resolved exports. The CI android mobile leg asserts the export with
+//! llvm-nm after building the `.so`.
+//!
+//! Building this crate in CI has real verification value beyond the export:
+//! it is the step that actually LINKS the Android backend
+//! (`#[link(name = "aaudio")]`) against the NDK, which `cargo check` never
+//! does.
+
+// Link the whole rsac library (and thereby its future no_mangle JNI surface)
+// into this cdylib.
+pub use rsac;

--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -1,0 +1,127 @@
+# rsac Android glue (`rsac.aar`)
+
+> **Status: builds in CI** (compile-verified; no device runtime
+> verification). The `mobile-android` CI job (rsac-1a6e) runs
+> `gradle assembleRelease` (Gradle 8.11.1 / JDK 17 / android-35) and asserts
+> the `.aar` artifact on every code PR — green since 2026-07-06. The Gradle
+> wrapper remains deliberately absent (CI provisions Gradle). The JNI
+> natives this glue calls ship inside `librsac.so`
+> (`src/audio/android/jni.rs`, rsac-77f1), which CI builds into the AAR's
+> jniLibs (rsac-0aa9). In a build without the native library, native calls
+> throw `UnsatisfiedLinkError` — guard with
+> `RsacProjection.isNativeAvailable()`.
+
+First-party Kotlin glue for rsac's Android playback-capture backend
+(ADR-0012 "batteries included"). Per the ownership boundary (ADR-0012 §4.2)
+this module carries **no capture policy**: consent flow, foreground-service
+plumbing, the Java `AudioRecord` read loop, and name/PID→UID lookup only.
+Target resolution, error classification, and stream semantics live in Rust
+(`src/audio/android/`).
+
+## Contents
+
+| File | Role |
+|---|---|
+| `RsacProjection.kt` | MediaProjection consent flow (ActivityResult API) → opaque native token for `AudioCaptureBuilder::with_android_projection` |
+| `RsacCaptureService.kt` | Foreground service (`mediaProjection` type): notification plumbing, start/stop, stops registered bridges on destroy |
+| `CaptureBridge.kt` | Dedicated Java capture thread: `AudioPlaybackCaptureConfiguration` + `AudioRecord` (`ENCODING_PCM_FLOAT`), blocking reads into one reused buffer → `nativePush` per period |
+| `PackageResolver.kt` | `packageName → UID` (PackageManager) and `PID → UID` (`/proc/<pid>/status`) for the ADR-0013 mapping |
+| `src/main/AndroidManifest.xml` | Permissions + the `mediaProjection`-typed service (merged into the host app) |
+
+## JNI symbol contract
+
+**Lockstep with `src/audio/android/jni.rs`** — Rust registers these via
+`RegisterNatives` in `JNI_OnLoad` (there are deliberately **no `Java_*`
+name-resolved exports**; `JNI_OnLoad` is the `.so`'s single JNI entry
+point, asserted by CI's llvm-nm step). Renaming a class, method, or
+signature on either side breaks capture — the host-run `jni_lockstep`
+tests in `src/audio/mod.rs` guard both sides on every `cargo test --lib`.
+
+| Kotlin declaration (class) | Registered as | Direction |
+|---|---|---|
+| `@JvmStatic external fun nativeRetainProjection(projection: MediaProjection): Long` (`ai.codeseys.rsac.RsacProjection`) | `nativeRetainProjection` `(Landroid/media/projection/MediaProjection;)J` | Kotlin → Rust: wrap the consented `MediaProjection` in a JNI `GlobalRef`, return the opaque token |
+| `@JvmStatic external fun nativePush(session: Long, buf: FloatArray, frames: Int, channels: Int, sampleRate: Int)` (`ai.codeseys.rsac.CaptureBridge`) | `nativePush` `(J[FIII)V` | Kotlin → Rust: per-period ingest into the capture's ring buffer (session-lifetime scratch, drop-don't-block) |
+| `@JvmStatic external fun nativeSessionEnded(session: Long)` (`ai.codeseys.rsac.CaptureBridge`) | `nativeSessionEnded` `(J)V` | Kotlin → Rust: terminal handshake — the read thread exited; a still-registered session is treated as spontaneous death (ADR-0010) |
+
+Token lifetime: **one token = one projection session**; release
+(`DeleteGlobalRef` + `MediaProjection.stop()`) is Rust's job, tied to the
+owning capture's drop. There is no process-global token registry.
+
+## Native library
+
+`librsac.so` (the rsac cdylib built with `cargo ndk`, per-ABI under
+`src/main/jniLibs/<abi>/`) is packaged by the CI job — not present in-tree.
+Load name: `System.loadLibrary("rsac")`.
+
+## Integration recipe (non-Tauri hosts: Dioxus / Flutter / native Kotlin)
+
+In-tree consumption works today; Maven/GitHub Packages distribution is a
+follow-up seed.
+
+1. **Depend on the module** — `settings.gradle.kts` of the host app:
+
+   ```kotlin
+   include(":rsac")
+   project(":rsac").projectDir = file("path/to/rsac/mobile/android")
+   ```
+
+   then `implementation(project(":rsac"))` — or drop a built `rsac.aar` into
+   `app/libs` and use `implementation(files("libs/rsac.aar"))`.
+
+2. **Runtime permission** — request `RECORD_AUDIO` (required even for
+   playback capture) before building a capture.
+
+3. **Start the foreground service** (mandatory ordering on API 34+):
+
+   ```kotlin
+   RsacCaptureService.start(context)
+   ```
+
+4. **Run the consent flow** from a `ComponentActivity`:
+
+   ```kotlin
+   RsacProjection.request(activity, object : RsacProjection.Callback {
+       override fun onToken(token: Long) { /* hand `token` to Rust */ }
+       override fun onDenied(reason: String) { /* surface to the user */ }
+   })
+   ```
+
+5. **Hand the token to Rust.**
+   - **Dioxus / direct Rust:** pass the `Long` across your JNI/FFI boundary
+     and call `AudioCaptureBuilder::with_android_projection(AndroidProjectionToken(token))`.
+   - **Flutter / C consumers:** pass it as `int64_t` through rsac-ffi:
+     `rsac_builder_set_android_projection(builder, token)`.
+   - From here Rust owns everything: it constructs/drives `CaptureBridge`
+     over JNI (rsac-77f1), audio flows through the normal
+     `BridgeStream` → `read_chunk()` pipeline.
+
+6. **Stop:** drop the capture on the Rust side (releases the token and stops
+   the bridge), then `RsacCaptureService.stop(context)`.
+
+Mic-only capture (`CaptureTarget::Device("default")`) needs none of the
+projection machinery — only the `RECORD_AUDIO` grant (pure-NDK AAudio path).
+
+## Host-app obligations (documented, not solvable here)
+
+- **Play Store media-projection declaration:** declaring the
+  `mediaProjection` foreground-service type triggers a policy declaration at
+  app submission. Budget for it.
+- **Package visibility (API 30+):** `PackageResolver.uidForPackage` is
+  subject to visibility filtering — add a `<queries>` element for packages
+  you target by name.
+- **What's never capturable:** apps targeting pre-API-29 or setting
+  `android:allowAudioPlaybackCapture="false"`, and
+  `USAGE_VOICE_COMMUNICATION` audio — the OS silently omits them; rsac's
+  streams simply won't contain those apps.
+
+## CI-VERIFY ledger (for rsac-1a6e)
+
+Every uncertain API detail is marked with a `// CI-VERIFY:` comment at the
+use site:
+
+| Location | Question |
+|---|---|
+| `build.gradle.kts` | `kotlin { compilerOptions { } }` DSL vs `kotlinOptions` fallback under the resolved KGP |
+| `RsacProjection.kt` | Does `getMediaProjection()` itself throw on API 34+ without the running FGS, or only capture start? |
+| `RsacProjection.kt` (`NATIVE_LIBRARY_NAME`) | cdylib artifact name from cargo-ndk must be `librsac.so` |
+| `CaptureBridge.kt` (`stop()`) | `AudioRecord.stop()` reliably unblocks `READ_BLOCKING` within the join timeout on-device |

--- a/mobile/android/build.gradle.kts
+++ b/mobile/android/build.gradle.kts
@@ -1,0 +1,77 @@
+// rsac Android glue — Android library module producing rsac.aar (ADR-0012).
+//
+// Ownership boundary (ADR-0012 §4.2): this module carries NO capture policy.
+// It is consent flow (RsacProjection), service plumbing (RsacCaptureService),
+// the Java AudioRecord read loop (CaptureBridge), and name/PID→UID resolution
+// helpers (PackageResolver). Target resolution, error classification, and
+// stream semantics live in Rust (src/audio/android/).
+//
+// Source-complete per seed rsac-c4b8; first CI build lands with rsac-1a6e.
+// All version pins are "expected; CI trues up".
+
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    // AGP 8.7.3 — expected; CI trues up (any AGP 8.x with compileSdk 35 works).
+    id("com.android.library") version "8.7.3"
+    // Kotlin 2.1.0 — expected; CI trues up.
+    id("org.jetbrains.kotlin.android") version "2.1.0"
+}
+
+android {
+    namespace = "ai.codeseys.rsac"
+    // compileSdk 35 — expected; CI trues up. Must be >= 34 so
+    // ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION enforcement paths
+    // and the FOREGROUND_SERVICE_MEDIA_PROJECTION permission resolve.
+    compileSdk = 35
+
+    defaultConfig {
+        // API 29 (Android 10): floor for AudioPlaybackCaptureConfiguration.
+        minSdk = 29
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    // The Rust cdylib (librsac.so) is built by cargo-ndk from the
+    // mobile/android-native shim crate (rsac-0aa9) and dropped into
+    // src/main/jniLibs/<abi>/ before assembleRelease — the CI mobile-android
+    // job does exactly that and asserts the .so lands inside the AAR.
+    // jniLibs is picked up by AGP's default sourceSet; nothing to configure.
+    // The JNI surface is registered from librsac.so's JNI_OnLoad (rsac-77f1).
+    // See README.md § Native library.
+
+    publishing {
+        // Maven/GitHub Packages distribution is a follow-up seed; singleVariant
+        // keeps in-tree consumption (`implementation(project(...))` /
+        // local AAR) working from day one.
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
+}
+
+kotlin {
+    // CI-VERIFY: `kotlin { compilerOptions { } }` is the KGP 2.x DSL; if the
+    // resolved KGP rejects it, fall back to
+    // `android { kotlinOptions { jvmTarget = "17" } }`.
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    // Versions expected; CI trues up.
+    implementation("androidx.core:core-ktx:1.15.0")       // NotificationCompat, ContextCompat
+    implementation("androidx.activity:activity-ktx:1.9.3") // ComponentActivity + ActivityResult API
+    implementation("androidx.annotation:annotation:1.9.1")
+}

--- a/mobile/android/consumer-rules.pro
+++ b/mobile/android/consumer-rules.pro
@@ -1,0 +1,12 @@
+# rsac consumer ProGuard/R8 rules — shipped inside the AAR and applied to
+# host apps automatically.
+#
+# The Rust side (src/audio/android/jni.rs, rsac-77f1) reaches this glue via
+# JNI FindClass / GetMethodID and RegisterNatives, which R8 cannot see.
+# Nothing under ai.codeseys.rsac may be renamed or stripped.
+-keep class ai.codeseys.rsac.** { *; }
+
+# Keep native-method names bindable (RegisterNatives matches by name+sig).
+-keepclasseswithmembers class ai.codeseys.rsac.** {
+    native <methods>;
+}

--- a/mobile/android/gradle.properties
+++ b/mobile/android/gradle.properties
@@ -1,0 +1,13 @@
+# rsac Android glue — Gradle properties.
+# Source-complete per seed rsac-c4b8; CI (rsac-1a6e) trues up any flags that
+# the resolved AGP/Gradle versions reject.
+
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+org.gradle.caching=true
+org.gradle.parallel=true
+
+android.useAndroidX=true
+# Library module: no BuildConfig class needed.
+android.defaults.buildfeatures.buildconfig=false
+
+kotlin.code.style=official

--- a/mobile/android/settings.gradle.kts
+++ b/mobile/android/settings.gradle.kts
@@ -1,0 +1,33 @@
+// rsac Android glue — Gradle settings (single-module Android library build).
+//
+// Source-complete per seed rsac-c4b8; NOT yet built in CI (rsac-1a6e adds the
+// Gradle CI job and the wrapper). Version pins below are "expected; CI trues up".
+//
+// The Gradle wrapper (gradlew + gradle-wrapper.jar) is deliberately absent:
+// no Gradle exists on the authoring machine and we do not hand-craft binary
+// jars. rsac-1a6e generates and commits the wrapper (`gradle wrapper
+// --gradle-version 8.11.1` expected; CI trues up).
+
+pluginManagement {
+    repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "rsac-android"

--- a/mobile/android/src/main/AndroidManifest.xml
+++ b/mobile/android/src/main/AndroidManifest.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  rsac Android glue — library manifest (merged into the host app's manifest).
+
+  Requirements per docs/MOBILE_BACKEND_DESIGN.md § "Manifest & service
+  requirements": RECORD_AUDIO (required even for playback capture),
+  FOREGROUND_SERVICE + FOREGROUND_SERVICE_MEDIA_PROJECTION, and a foreground
+  service declared with android:foregroundServiceType="mediaProjection".
+
+  Hosts that do not want a merged permission can strip it with
+  tools:node="remove" in their own manifest.
+
+  Play Store: declaring the mediaProjection foreground-service type triggers
+  a policy declaration at submission — a HOST-APP obligation (documented in
+  README.md, not solvable here).
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Required even for playback (non-mic) capture — API 29+ contract. -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!-- Enforced from API 34 (targetSdk 34+); harmless to declare earlier. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+
+    <application>
+        <!--
+          Capture host service (skeleton — no capture policy). Must be running
+          in the foreground BEFORE MediaProjection capture starts; on API 34+
+          the OS enforces this ordering. Fully-qualified class name so manifest
+          merging never mis-resolves it against the host namespace.
+        -->
+        <service
+            android:name="ai.codeseys.rsac.RsacCaptureService"
+            android:exported="false"
+            android:foregroundServiceType="mediaProjection" />
+    </application>
+
+</manifest>

--- a/mobile/android/src/main/kotlin/ai/codeseys/rsac/PackageResolver.kt
+++ b/mobile/android/src/main/kotlin/ai/codeseys/rsac/PackageResolver.kt
@@ -1,0 +1,87 @@
+package ai.codeseys.rsac
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import java.io.File
+import java.io.IOException
+
+/**
+ * Name/PID → UID resolution helpers for the ADR-0013 target mapping.
+ *
+ * On Android, `AudioPlaybackCaptureConfiguration.addMatchingUid` filters by
+ * **UID**, and all processes of an app share one UID — so both
+ * `ApplicationByName` (package name) and `ProcessTree` (PID) resolve to a
+ * UID before reaching [CaptureBridge]:
+ *
+ * | `CaptureTarget` | Resolution here |
+ * |---|---|
+ * | `ApplicationByName(String)` | [uidForPackage] (PackageManager) |
+ * | `ProcessTree(ProcessId)` | [uidForPid] (`/proc/<pid>/status` `Uid:` line) |
+ *
+ * Pure lookup, **no capture policy** (ADR-0012 §4.2): a `null` return means
+ * "could not resolve" — classification into an `AudioError` happens in Rust.
+ */
+object PackageResolver {
+
+    /**
+     * Resolves an installed package's UID, or `null` when the package is not
+     * found / not visible.
+     *
+     * Note (API 30+): package visibility filtering applies — the host app
+     * may need a `<queries>` declaration (or `QUERY_ALL_PACKAGES`, with its
+     * Play policy implications) for packages it does not otherwise interact
+     * with. Documented in README.md; not solvable in the library.
+     */
+    @JvmStatic
+    fun uidForPackage(context: Context, packageName: String): Int? {
+        if (packageName.isEmpty()) return null
+        val pm = context.packageManager
+        return try {
+            val info = if (Build.VERSION.SDK_INT >= 33) {
+                pm.getApplicationInfo(
+                    packageName,
+                    PackageManager.ApplicationInfoFlags.of(0L),
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                pm.getApplicationInfo(packageName, 0)
+            }
+            info.uid
+        } catch (_: PackageManager.NameNotFoundException) {
+            null
+        }
+    }
+
+    /**
+     * Resolves a PID to its UID by parsing the `Uid:` line of
+     * `/proc/<pid>/status` (first field = real UID), or `null` when the
+     * process does not exist or is not visible.
+     *
+     * Honest limitation: Android mounts `/proc` with `hidepid=2` (since 7.0),
+     * so **other apps' processes are generally not readable** — this works
+     * for the caller's own UID's processes (which covers the tree ≡ app
+     * equivalence of ADR-0013) and for PIDs the platform exposes to the
+     * caller. A `null` here is a resolution failure for Rust to classify.
+     */
+    @JvmStatic
+    fun uidForPid(pid: Int): Int? {
+        if (pid <= 0) return null
+        return try {
+            File("/proc/$pid/status").useLines { lines ->
+                lines.firstOrNull { it.startsWith("Uid:") }
+                    ?.removePrefix("Uid:")
+                    ?.trim()
+                    ?.split(WHITESPACE)
+                    ?.firstOrNull()
+                    ?.toIntOrNull()
+            }
+        } catch (_: IOException) {
+            null
+        } catch (_: SecurityException) {
+            null
+        }
+    }
+
+    private val WHITESPACE = Regex("\\s+")
+}

--- a/mobile/android/src/main/kotlin/ai/codeseys/rsac/RsacCaptureService.kt
+++ b/mobile/android/src/main/kotlin/ai/codeseys/rsac/RsacCaptureService.kt
@@ -1,0 +1,173 @@
+package ai.codeseys.rsac
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Foreground service host for MediaProjection-based capture — the
+ * `android:foregroundServiceType="mediaProjection"` service required by the
+ * OS (docs/MOBILE_BACKEND_DESIGN.md § manifest & service requirements).
+ *
+ * **Skeleton, no capture policy** (ADR-0012 §4.2): this service does not
+ * decide *what* to capture — it provides the foreground context the OS
+ * demands, the notification plumbing, and a lifecycle anchor for
+ * [CaptureBridge] threads. Target resolution and stream semantics live in
+ * Rust (src/audio/android/, seed rsac-77f1).
+ *
+ * ### Lifecycle contract
+ *
+ * - [start] before media-projection capture begins (on API 34+ the OS
+ *   enforces that a mediaProjection FGS is running).
+ * - [CaptureBridge]s register themselves here ([registerBridge]) while
+ *   running; when the service is destroyed — [stop], task removal, or the
+ *   system reclaiming it — every registered bridge is stopped so no capture
+ *   thread outlives its foreground context. The Rust side observes that as
+ *   the producer going quiet and drives its own terminal semantics
+ *   (ADR-0010); this service never signals the bridge state machine itself.
+ *
+ * Notification title/text can be overridden per-start via Intent extras;
+ * hosts needing full notification control can post their own and keep this
+ * service purely as the FGS anchor.
+ */
+class RsacCaptureService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        ensureNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_STOP -> {
+                stopSelf()
+            }
+            else -> {
+                // ACTION_START (or a bare/restart Intent): promote to
+                // foreground with the mediaProjection type immediately —
+                // required within seconds of startForegroundService().
+                val notification = buildNotification(
+                    intent?.getStringExtra(EXTRA_NOTIFICATION_TITLE)
+                        ?: DEFAULT_NOTIFICATION_TITLE,
+                    intent?.getStringExtra(EXTRA_NOTIFICATION_TEXT)
+                        ?: DEFAULT_NOTIFICATION_TEXT,
+                )
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION,
+                )
+            }
+        }
+        // Capture must not restart without a fresh consent token, so never
+        // let the system resurrect this service with a null Intent.
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        // Stop every capture thread anchored to this foreground context.
+        // Idempotent per bridge; see CaptureBridge.stop().
+        for (bridge in bridges) {
+            bridge.stop()
+        }
+        bridges.clear()
+        super.onDestroy()
+    }
+
+    private fun ensureNotificationChannel() {
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                "Audio capture",
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply {
+                description = "Shown while rsac audio capture is running"
+            }
+        )
+    }
+
+    private fun buildNotification(title: String, text: String): Notification =
+        NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_btn_speak_now)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setOngoing(true)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .build()
+
+    companion object {
+        private const val CHANNEL_ID = "ai.codeseys.rsac.capture"
+        private const val NOTIFICATION_ID = 0x52534143 // "RSAC"
+
+        private const val ACTION_START = "ai.codeseys.rsac.action.START"
+        private const val ACTION_STOP = "ai.codeseys.rsac.action.STOP"
+
+        /** Intent extra: notification title override (String). */
+        const val EXTRA_NOTIFICATION_TITLE = "ai.codeseys.rsac.extra.NOTIFICATION_TITLE"
+
+        /** Intent extra: notification body override (String). */
+        const val EXTRA_NOTIFICATION_TEXT = "ai.codeseys.rsac.extra.NOTIFICATION_TEXT"
+
+        private const val DEFAULT_NOTIFICATION_TITLE = "Audio capture active"
+        private const val DEFAULT_NOTIFICATION_TEXT =
+            "Capturing device audio via screen-capture consent"
+
+        /** Bridges anchored to the service lifecycle (stopped in onDestroy). */
+        private val bridges = CopyOnWriteArrayList<CaptureBridge>()
+
+        /**
+         * Starts the service in the foreground (mediaProjection type). Call
+         * before media-projection capture begins — mandatory ordering on
+         * API 34+.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun start(
+            context: Context,
+            notificationTitle: String? = null,
+            notificationText: String? = null,
+        ) {
+            val intent = Intent(context, RsacCaptureService::class.java)
+                .setAction(ACTION_START)
+            notificationTitle?.let { intent.putExtra(EXTRA_NOTIFICATION_TITLE, it) }
+            notificationText?.let { intent.putExtra(EXTRA_NOTIFICATION_TEXT, it) }
+            ContextCompat.startForegroundService(context, intent)
+        }
+
+        /** Stops the service (and thereby every registered [CaptureBridge]). */
+        @JvmStatic
+        fun stop(context: Context) {
+            context.startService(
+                Intent(context, RsacCaptureService::class.java).setAction(ACTION_STOP)
+            )
+        }
+
+        /**
+         * Anchors [bridge] to the service lifecycle: it will be stopped when
+         * the service is destroyed. Called by the capture orchestration
+         * (Rust side via JNI, or a native-Kotlin host).
+         */
+        @JvmStatic
+        fun registerBridge(bridge: CaptureBridge) {
+            bridges.addIfAbsent(bridge)
+        }
+
+        /** Detaches [bridge] (normal stop path, before/after [CaptureBridge.stop]). */
+        @JvmStatic
+        fun unregisterBridge(bridge: CaptureBridge) {
+            bridges.remove(bridge)
+        }
+    }
+}

--- a/mobile/ios/Package.swift
+++ b/mobile/ios/Package.swift
@@ -1,0 +1,45 @@
+// swift-tools-version: 5.9
+// rsac mobile/ios — SwiftPM glue for the iOS backend (ADR-0012, ADR-0013).
+//
+// Two library products:
+//   RsacAudio        — AVAudioSession helpers for the mic path (host app).
+//   RsacBroadcastKit — ReplayKit Broadcast Upload Extension glue: the
+//                      canonical App-Group mmap SPSC ring (RingLayout.swift),
+//                      the producer, and an open RPBroadcastSampleHandler
+//                      template.
+//
+// CRsacRingAtomics is an internal C11 stdatomic shim target (NOT a product):
+// Swift < iOS 18 has no standard-library atomics usable on raw mmap'd memory
+// shared across processes, so the acquire/release u64 cursor operations are
+// implemented in C. It is a dependency of RsacBroadcastKit only.
+//
+// Status: source-complete; not yet built in CI (rsac-48e7 adds the
+// `xcodebuild`/`swift build` CI job). See README.md.
+
+import PackageDescription
+
+let package = Package(
+    name: "RsacMobile",
+    platforms: [
+        .iOS(.v14)
+    ],
+    products: [
+        .library(name: "RsacAudio", targets: ["RsacAudio"]),
+        .library(name: "RsacBroadcastKit", targets: ["RsacBroadcastKit"]),
+    ],
+    targets: [
+        .target(
+            name: "RsacAudio",
+            path: "Sources/RsacAudio"
+        ),
+        .target(
+            name: "CRsacRingAtomics",
+            path: "Sources/CRsacRingAtomics"
+        ),
+        .target(
+            name: "RsacBroadcastKit",
+            dependencies: ["CRsacRingAtomics"],
+            path: "Sources/RsacBroadcastKit"
+        ),
+    ]
+)

--- a/mobile/ios/README.md
+++ b/mobile/ios/README.md
@@ -1,0 +1,133 @@
+# rsac — iOS SwiftPM package (`RsacAudio` + `RsacBroadcastKit`)
+
+> ## Status: **builds in CI** (compile-verified; no device runtime verification)
+>
+> The `mobile-ios` CI job (rsac-48e7) builds both products with `xcodebuild`
+> against `generic/platform=iOS` on every code PR — green since 2026-07-06.
+> That proves **compilation only**: nothing here has run on a device, so
+> treat runtime-behavior details marked `// CI-VERIFY:` in the sources as
+> compile-confirmed but behavior-unconfirmed (first CI run already caught
+> one: bare `close()` resolving to the instance method). Design provenance:
+> ADR-0012 (packaging), ADR-0013 (transport & CaptureTarget semantics),
+> `docs/MOBILE_BACKEND_DESIGN.md` (iOS sections).
+
+## What this package is
+
+The Swift half of rsac's iOS backend (ADR-0012's "batteries included"
+decision — rsac ships the consent-flow and extension glue so every consumer
+doesn't reinvent it):
+
+| Product | Purpose |
+|---|---|
+| `RsacAudio` | `AVAudioSession` helpers for the **mic path** — configure/activate a record-capable session, request the record permission (async + callback). rsac's Rust backend never touches the session; the host app owns it, with these helpers. |
+| `RsacBroadcastKit` | The **system-audio path** glue: the canonical cross-process mmap SPSC ring (`RingLayout.swift`), the ring producer, and an open `RPBroadcastSampleHandler` template for the consumer app's Broadcast Upload Extension. |
+
+Internal target `CRsacRingAtomics` (not a product) supplies C11 `stdatomic`
+acquire/release u64 operations — Swift on iOS 14+ has no standard-library
+atomics usable on raw cross-process mmap'd memory.
+
+> ### ⚠️ `RingLayout.swift` is CANONICAL — version-gate any change
+>
+> The Rust consumer (`src/audio/ios/broadcast.rs`, seed **rsac-b3aa**)
+> mirrors the ring layout in Rust, byte for byte: header offsets, cursor
+> acquire/release ordering, the offset-0 magic+version publish point, the
+> CLOCK_MONOTONIC heartbeat domain, the ring file name, and the Darwin
+> notification strings. **Any change to `RingLayout.swift` is a
+> cross-process ABI break:** bump `layoutVersion`, update the Rust mirror in
+> lockstep, and make both sides reject a version mismatch.
+
+## Embedding the broadcast extension (system audio, `CaptureTarget::SystemDefault`)
+
+The mic path needs none of this. System capture needs all of it:
+
+1. **Add a Broadcast Upload Extension target** to your app in Xcode
+   (File → New → Target → Broadcast Upload Extension; uncheck "include UI
+   extension" unless you want a picker UI).
+2. **Depend on `RsacBroadcastKit`** from the extension target and replace
+   the generated `SampleHandler.swift` with:
+
+   ```swift
+   import RsacBroadcastKit
+
+   class SampleHandler: RsacBroadcastSampleHandler {
+       override var appGroupIdentifier: String { "group.com.example.myapp.rsac" }
+   }
+   ```
+
+   Keep `NSExtensionPrincipalClass` in the extension's `Info.plist` pointing
+   at your subclass.
+3. **App Group entitlement — on BOTH targets.** Add the *same* App Group
+   (e.g. `group.com.example.myapp.rsac`) to the
+   `com.apple.security.application-groups` entitlement of the **host app
+   AND the extension** (Signing & Capabilities → + App Groups). The ring
+   file lives in that shared container; if either side lacks the
+   entitlement, `containerURL(forSecurityApplicationGroupIdentifier:)`
+   returns nil and setup fails with an actionable error.
+4. **Host side (Rust):** build with `CaptureTarget::SystemDefault` and pass
+   the same App Group identifier to the rsac iOS backend (consumption
+   surface lands with rsac-b3aa). The host drains the ring into a normal
+   `BridgeProducer` — overrun/terminal semantics identical to desktop.
+5. **Starting capture:** offer the user `RPSystemBroadcastPickerView` (you
+   can pre-select your extension via `preferredExtension`), or let them use
+   the Control Center screen-recording long-press. There is no third
+   option — see UX constraints below.
+
+## UX constraints (ADR-0013 — present these honestly to your users)
+
+- **User-initiated only.** iOS provides **no API to start a broadcast
+  programmatically**. The user must tap the picker or Control Center. Your
+  UI must be a *prompt to start*, never a "capturing…" state you set
+  yourself.
+- **The user can stop it at any time** (Control Center, red status bar/pill).
+  The host-side stream then ends with a **fatal terminal** (`finished`
+  Darwin notification, or missed heartbeats if the extension was killed) —
+  design your consumer for streams that end without your code asking.
+- **Captures everything.** ReplayKit app-audio is the mixed output of the
+  whole device — there is **no per-app filter on iOS, permanently**
+  (`Application`/`ApplicationByName`/`ProcessTree` report
+  `PlatformNotSupported`; Apple provides no API).
+- **Extension memory cap (~50 MB).** The ring defaults to ~2 s of audio
+  (768 KiB at 48 kHz stereo). Ring-full ⇒ buffers are **dropped and
+  counted** (`producerDropCount`), never buffered unboundedly.
+- **Mic:** the extension ignores `.audioMic`; microphone capture is the host
+  app's `AVAudioEngine` path (`RsacAudio` helpers +
+  `NSMicrophoneUsageDescription`).
+
+## App Store review notes
+
+- Broadcast Upload Extensions get **elevated review scrutiny**: state
+  clearly in your review notes *why* your app captures system audio and
+  what happens to the data (on-device processing vs upload).
+- The system broadcast consent UI is the only capture trigger — do not
+  attempt to auto-start, hide the system indicators, or imply capture is
+  passive; these are rejection (and policy) territory.
+- `NSMicrophoneUsageDescription` is required if you use the mic path — the
+  string is user-facing; write a real one.
+- Ship the extension **only if you use system capture** — an unused
+  broadcast extension invites review questions.
+
+## Layout
+
+```
+mobile/ios/
+├── Package.swift                     # swift-tools 5.9, iOS 14+, 2 products
+├── README.md                         # this file
+└── Sources/
+    ├── RsacAudio/
+    │   └── AudioSessionHelper.swift  # session config/activation + permission
+    ├── RsacBroadcastKit/
+    │   ├── RingLayout.swift          # ⚠️ CANONICAL ring contract (v1)
+    │   ├── RingProducer.swift        # mmap + publish + drop-not-block writes
+    │   └── SampleHandlerTemplate.swift # open RPBroadcastSampleHandler
+    └── CRsacRingAtomics/             # C11 stdatomic shim (internal target)
+        ├── include/rsac_ring_atomics.h
+        └── rsac_ring_atomics.c
+```
+
+## Related seeds
+
+| Seed | What |
+|---|---|
+| rsac-6d5f | This package (SwiftPM glue sources) |
+| rsac-b3aa | Rust consumer: `src/audio/ios/broadcast.rs` mirrors `RingLayout.swift` |
+| rsac-48e7 | SwiftPM CI build job (macOS runner) — resolves every `// CI-VERIFY:` |

--- a/mobile/ios/Sources/CRsacRingAtomics/include/rsac_ring_atomics.h
+++ b/mobile/ios/Sources/CRsacRingAtomics/include/rsac_ring_atomics.h
@@ -1,0 +1,46 @@
+#ifndef RSAC_RING_ATOMICS_H
+#define RSAC_RING_ATOMICS_H
+
+// C11 stdatomic shim for RsacBroadcastKit.
+//
+// Why this exists: the cross-process mmap SPSC ring (RingLayout.swift) needs
+// acquire/release atomic loads/stores on u64 header fields that live in a
+// memory-mapped file shared between the broadcast extension (producer) and
+// the host app / rsac Rust consumer (rsac-b3aa). Swift has no
+// standard-library atomics that operate on raw shared memory before the
+// iOS 18 `Synchronization` module, and the package targets iOS 14+, so the
+// atomic operations are implemented here in C11 <stdatomic.h>.
+//
+// All pointers passed in MUST be 8-byte aligned (RingLayout guarantees this:
+// every atomic field sits at an 8-byte-aligned header offset).
+//
+// The Rust consumer mirrors these with core::sync::atomic::AtomicU64 +
+// Ordering::{Acquire,Release,Relaxed} on the same mapped bytes.
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Atomic load with acquire ordering.
+uint64_t rsac_atomic_load_u64_acquire(const volatile uint64_t *ptr);
+
+/// Atomic load with relaxed ordering.
+uint64_t rsac_atomic_load_u64_relaxed(const volatile uint64_t *ptr);
+
+/// Atomic store with release ordering.
+void rsac_atomic_store_u64_release(volatile uint64_t *ptr, uint64_t value);
+
+/// Atomic store with relaxed ordering.
+void rsac_atomic_store_u64_relaxed(volatile uint64_t *ptr, uint64_t value);
+
+/// Atomic fetch-add with relaxed ordering. Returns the PREVIOUS value.
+uint64_t rsac_atomic_fetch_add_u64_relaxed(volatile uint64_t *ptr,
+                                           uint64_t value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RSAC_RING_ATOMICS_H */

--- a/mobile/ios/Sources/CRsacRingAtomics/rsac_ring_atomics.c
+++ b/mobile/ios/Sources/CRsacRingAtomics/rsac_ring_atomics.c
@@ -1,0 +1,36 @@
+#include "rsac_ring_atomics.h"
+
+#include <stdatomic.h>
+
+// The header exposes plain `uint64_t *` (Swift imports that cleanly as
+// UnsafeMutablePointer<UInt64>); the implementations cast to
+// `_Atomic uint64_t *`. On arm64/x86_64, _Atomic uint64_t has the same size
+// and alignment as uint64_t, and the caller guarantees 8-byte alignment
+// (RingLayout header offsets), so the cast is well-behaved in practice.
+// This is the same pattern the Linux kernel and rtrb's FFI mirrors use.
+
+uint64_t rsac_atomic_load_u64_acquire(const volatile uint64_t *ptr) {
+    return atomic_load_explicit((const volatile _Atomic uint64_t *)ptr,
+                                memory_order_acquire);
+}
+
+uint64_t rsac_atomic_load_u64_relaxed(const volatile uint64_t *ptr) {
+    return atomic_load_explicit((const volatile _Atomic uint64_t *)ptr,
+                                memory_order_relaxed);
+}
+
+void rsac_atomic_store_u64_release(volatile uint64_t *ptr, uint64_t value) {
+    atomic_store_explicit((volatile _Atomic uint64_t *)ptr, value,
+                          memory_order_release);
+}
+
+void rsac_atomic_store_u64_relaxed(volatile uint64_t *ptr, uint64_t value) {
+    atomic_store_explicit((volatile _Atomic uint64_t *)ptr, value,
+                          memory_order_relaxed);
+}
+
+uint64_t rsac_atomic_fetch_add_u64_relaxed(volatile uint64_t *ptr,
+                                           uint64_t value) {
+    return atomic_fetch_add_explicit((volatile _Atomic uint64_t *)ptr, value,
+                                     memory_order_relaxed);
+}

--- a/mobile/ios/Sources/RsacAudio/AudioSessionHelper.swift
+++ b/mobile/ios/Sources/RsacAudio/AudioSessionHelper.swift
@@ -1,0 +1,127 @@
+import AVFAudio
+import Foundation
+
+/// `AVAudioSession` helpers for rsac's iOS **microphone path**.
+///
+/// rsac's Rust backend (`src/audio/ios/`, the AVAudioEngine mic slice)
+/// deliberately does **NOT** touch the shared `AVAudioSession` — session
+/// configuration is app-global policy that only the host application can
+/// own. Before building a mic capture
+/// (`CaptureTarget::Device(DeviceId("default"))`), the host app must:
+///
+/// 1. declare `NSMicrophoneUsageDescription` in its `Info.plist` (the app
+///    crashes on first mic access without it),
+/// 2. obtain the record permission (``requestRecordPermission()``), and
+/// 3. configure + activate a record-capable session
+///    (``configureForRecording(category:mode:options:)`` + ``activate()``).
+///
+/// These helpers wrap exactly that flow. They are conveniences over
+/// `AVAudioSession.sharedInstance()` — apps with existing session management
+/// can keep it and skip this type entirely.
+public enum RsacAudioSession {
+
+    /// Errors thrown by the helpers (beyond what AVAudioSession itself throws).
+    public enum SessionError: Error, CustomStringConvertible {
+        /// The requested category cannot record; rsac's mic capture would
+        /// receive silence or fail to start.
+        case categoryCannotRecord(AVAudioSession.Category)
+
+        public var description: String {
+            switch self {
+            case let .categoryCannotRecord(cat):
+                return "AVAudioSession category '\(cat.rawValue)' cannot record — "
+                    + "use .record, .playAndRecord, or .multiRoute"
+            }
+        }
+    }
+
+    /// The shared session these helpers operate on.
+    public static var session: AVAudioSession { .sharedInstance() }
+
+    // ── Configuration ─────────────────────────────────────────────────────
+
+    /// Configures the shared session with a record-capable category.
+    ///
+    /// - Parameters:
+    ///   - category: must be one of `.record`, `.playAndRecord`, or
+    ///     `.multiRoute`; anything else throws
+    ///     ``SessionError/categoryCannotRecord(_:)`` instead of silently
+    ///     producing a session rsac cannot capture from.
+    ///   - mode: session mode; `.default` unless you know you need
+    ///     `.measurement` (raw, unprocessed input) or `.voiceChat`.
+    ///   - options: e.g. `[.allowBluetooth]` to admit BT headset input, or
+    ///     `[.defaultToSpeaker]` (valid only with `.playAndRecord`). Defaults
+    ///     to none — pick deliberately; options are app UX policy.
+    ///
+    /// Does NOT activate the session — call ``activate()`` when ready (order
+    /// matters for route negotiation).
+    public static func configureForRecording(
+        category: AVAudioSession.Category = .playAndRecord,
+        mode: AVAudioSession.Mode = .default,
+        options: AVAudioSession.CategoryOptions = []
+    ) throws {
+        guard category == .record || category == .playAndRecord || category == .multiRoute
+        else {
+            throw SessionError.categoryCannotRecord(category)
+        }
+        try session.setCategory(category, mode: mode, options: options)
+    }
+
+    /// Activates the shared session. Call after
+    /// ``configureForRecording(category:mode:options:)`` and before building
+    /// the rsac capture — stream creation fails with an actionable error if
+    /// no input route is active.
+    public static func activate() throws {
+        try session.setActive(true)
+    }
+
+    /// Deactivates the shared session (e.g. after stopping capture).
+    ///
+    /// - Parameter notifyOthersOnDeactivation: pass `true` (default) so
+    ///   other apps' interrupted audio can resume.
+    public static func deactivate(notifyOthersOnDeactivation: Bool = true) throws {
+        try session.setActive(
+            false,
+            options: notifyOthersOnDeactivation ? [.notifyOthersOnDeactivation] : [])
+    }
+
+    // ── Record permission ─────────────────────────────────────────────────
+
+    /// Whether the user has already granted the record permission.
+    public static var hasRecordPermission: Bool {
+        if #available(iOS 17.0, *) {
+            // CI-VERIFY: AVAudioApplication.shared.recordPermission == .granted
+            // (iOS 17 replacement API; enum case name spelled `granted`).
+            return AVAudioApplication.shared.recordPermission == .granted
+        } else {
+            return session.recordPermission == .granted
+        }
+    }
+
+    /// Requests the record permission (callback form). The FIRST request
+    /// shows the system prompt (with the app's
+    /// `NSMicrophoneUsageDescription` text); later calls report the stored
+    /// decision immediately. The completion runs on an arbitrary queue —
+    /// dispatch to the main queue yourself for UI work.
+    public static func requestRecordPermission(
+        _ completion: @escaping @Sendable (Bool) -> Void
+    ) {
+        if #available(iOS 17.0, *) {
+            // CI-VERIFY: iOS 17 renamed the API to
+            // AVAudioApplication.requestRecordPermission(completionHandler:) —
+            // confirm the static-method spelling against the SDK.
+            AVAudioApplication.requestRecordPermission(completionHandler: completion)
+        } else {
+            session.requestRecordPermission(completion)
+        }
+    }
+
+    /// Requests the record permission (async form).
+    public static func requestRecordPermission() async -> Bool {
+        await withCheckedContinuation { continuation in
+            requestRecordPermission { granted in
+                continuation.resume(returning: granted)
+            }
+        }
+    }
+}

--- a/mobile/ios/Sources/RsacBroadcastKit/RingLayout.swift
+++ b/mobile/ios/Sources/RsacBroadcastKit/RingLayout.swift
@@ -1,0 +1,203 @@
+import Foundation
+
+// ═══════════════════════════════════════════════════════════════════════════
+// RingLayout.swift — THE CANONICAL cross-process mmap SPSC ring contract.
+//
+//   ┌─────────────────────────────────────────────────────────────────────┐
+//   │  ⚠️  THIS FILE IS THE CONTRACT.                                      │
+//   │                                                                     │
+//   │  The Rust consumer in src/audio/ios/broadcast.rs (seed rsac-b3aa)   │
+//   │  MUST mirror this layout EXACTLY — every offset, every ordering,    │
+//   │  every constant. Any change here is a breaking cross-process ABI    │
+//   │  change: bump `layoutVersion`, and make BOTH sides reject a         │
+//   │  mismatched version. Never change the layout without a version      │
+//   │  bump.                                                              │
+//   └─────────────────────────────────────────────────────────────────────┘
+//
+// One producer (the ReplayKit Broadcast Upload Extension), one consumer (the
+// host app's rsac Rust backend). The ring is a fixed-size file in the shared
+// App Group container, memory-mapped by both processes.
+//
+// ── File layout (all multi-byte fields LITTLE-ENDIAN) ─────────────────────
+//
+//   offset  size  field               type          notes
+//   ──────  ────  ─────────────────   ───────────   ─────────────────────────
+//        0     4  magic               u32           ASCII "RSAC" (bytes
+//                                                   52 53 41 43); read as a
+//                                                   little-endian u32 this is
+//                                                   0x4341_5352
+//        4     4  layoutVersion       u32           = 1
+//        8     4  sampleRate          u32           frames per second (Hz)
+//       12     4  channels            u32           interleaved channel count
+//       16     4  capacityFrames      u32           ring capacity in FRAMES
+//       20     4  reserved            u32           = 0 in v1; consumer must
+//                                                   ignore
+//       24     8  writeCursor         atomic u64    monotonic frame count,
+//                                                   producer-owned
+//       32     8  readCursor          atomic u64    monotonic frame count,
+//                                                   consumer-owned
+//       40     8  heartbeatMillis     atomic u64    producer liveness stamp
+//       48     8  producerDropCount   atomic u64    buffers dropped ring-full
+//       56     8  (padding)           —             = 0; aligns data to 64
+//       64     …  data                f32[]         interleaved little-endian
+//                                                   IEEE-754 f32 frames;
+//                                                   region length =
+//                                                   capacityFrames * channels
+//                                                   * 4 bytes
+//
+// Header size is 56 bytes; the data region starts at byte 64 so it is
+// 64-byte (cache-line) aligned. Total file size =
+// 64 + capacityFrames * channels * 4.
+//
+// ── Cursor semantics ───────────────────────────────────────────────────────
+//
+// Cursors are MONOTONIC frame counts, never wrapped: the slot of cursor `c`
+// is `c % capacityFrames`. Fill level = writeCursor − readCursor (always
+// ≤ capacityFrames). u64 at 48 kHz overflows after ~12 million years — wrap
+// is a non-concern.
+//
+//   producer:  free = capacityFrames − (writeCursor − readCursor)
+//              if frames > free → drop the WHOLE buffer, producerDropCount+1
+//              (drop-not-block: the sample handler must never stall)
+//              else: copy frames (two segments on wrap), then
+//              RELEASE-store writeCursor += frames
+//   consumer:  ACQUIRE-load writeCursor; frames in [readCursor, writeCursor)
+//              are safe to read; after copying out, RELEASE-store
+//              readCursor += consumed
+//
+// ── Torn-read defense ──────────────────────────────────────────────────────
+//
+// The release-store of writeCursor happens-after the frame bytes are written;
+// the consumer's acquire-load of writeCursor therefore observes fully-written
+// frames — never torn f32 data. Symmetrically, the producer acquire-loads
+// readCursor before reusing slots. Non-atomic header fields (sampleRate,
+// channels, capacityFrames) are written once by the producer BEFORE the
+// publish point and are immutable afterwards. The publish point: the producer
+// zero-fills the file, writes all non-atomic fields and initial atomic values
+// while magic is still 0, then commits magic+layoutVersion as a SINGLE
+// release-store of the u64 at offset 0 (little-endian
+// (layoutVersion << 32) | magic). The consumer acquire-loads offset 0 and
+// only trusts the header once it equals that committed value.
+//
+// ── Heartbeat ──────────────────────────────────────────────────────────────
+//
+// heartbeatMillis is milliseconds derived from CLOCK_MONOTONIC
+// (clock_gettime_nsec_np(CLOCK_MONOTONIC) / 1_000_000). CLOCK_MONOTONIC is
+// shared by all processes on the device within one boot, so the Rust
+// consumer compares against its own CLOCK_MONOTONIC reading. The producer
+// stamps at least every `heartbeatIntervalMillis`; a stamp older than
+// `heartbeatTimeoutMillis` means the extension was killed or the broadcast
+// ended without a Darwin notification ⇒ producer terminal signal (ADR-0010)
+// ⇒ the host stream ends with the fatal terminal (ADR-0003).
+//
+// ── Sizing guidance ────────────────────────────────────────────────────────
+//
+// The broadcast extension is hard-capped at ~50 MB of memory. The ring must
+// stay in the low single-digit MB: 2 seconds of 48 kHz stereo f32 is
+// 48_000 * 2 * 2 * 4 = 768 KiB — the default. Do not exceed a few seconds;
+// ring-full is handled by drop + producerDropCount, never by growing.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Canonical constants of the rsac cross-process broadcast ring (layout v1).
+///
+/// Mirrored byte-for-byte by the Rust consumer (rsac-b3aa). Version-gate any
+/// change: bump ``layoutVersion`` and update both sides in lockstep.
+public enum RsacRingLayout {
+    // ── Identity ──────────────────────────────────────────────────────────
+
+    /// ASCII "RSAC" read as a little-endian u32 (bytes `52 53 41 43`).
+    public static let magic: UInt32 = 0x4341_5352
+
+    /// Layout version this file describes. Bump on ANY layout change.
+    public static let layoutVersion: UInt32 = 1
+
+    /// The u64 committed at offset 0 as the header publish point:
+    /// little-endian `(layoutVersion << 32) | magic`.
+    public static let publishedMagicVersion: UInt64 =
+        (UInt64(layoutVersion) << 32) | UInt64(magic)
+
+    /// Default file name of the ring inside the App Group container. Part of
+    /// the contract: the Rust consumer opens the same name.
+    public static let ringFileName = "rsac_broadcast_ring_v1"
+
+    // ── Header field offsets (bytes) ──────────────────────────────────────
+
+    /// Offset of `magic` (u32).
+    public static let offsetMagic = 0
+    /// Offset of `layoutVersion` (u32).
+    public static let offsetLayoutVersion = 4
+    /// Offset of `sampleRate` (u32).
+    public static let offsetSampleRate = 8
+    /// Offset of `channels` (u32).
+    public static let offsetChannels = 12
+    /// Offset of `capacityFrames` (u32).
+    public static let offsetCapacityFrames = 16
+    /// Offset of `reserved` (u32, = 0 in v1).
+    public static let offsetReserved = 20
+    /// Offset of `writeCursor` (atomic u64, producer-owned, monotonic frames).
+    public static let offsetWriteCursor = 24
+    /// Offset of `readCursor` (atomic u64, consumer-owned, monotonic frames).
+    public static let offsetReadCursor = 32
+    /// Offset of `heartbeatMillis` (atomic u64, CLOCK_MONOTONIC ms).
+    public static let offsetHeartbeatMillis = 40
+    /// Offset of `producerDropCount` (atomic u64).
+    public static let offsetProducerDropCount = 48
+
+    /// Header size in bytes (fields only, excluding pad-to-data).
+    public static let headerSize = 56
+
+    /// Byte offset where interleaved f32 frame data begins (64-byte aligned).
+    public static let dataOffset = 64
+
+    // ── Heartbeat contract ────────────────────────────────────────────────
+
+    /// The producer stamps `heartbeatMillis` at least this often.
+    public static let heartbeatIntervalMillis: UInt64 = 500
+
+    /// A stamp older than this ⇒ the consumer treats the producer as dead
+    /// (terminal, ADR-0010/ADR-0003).
+    public static let heartbeatTimeoutMillis: UInt64 = 2_000
+
+    // ── Sizing helpers ────────────────────────────────────────────────────
+
+    /// Total ring file size in bytes for a given geometry.
+    public static func totalFileSize(capacityFrames: UInt32, channels: UInt32) -> Int {
+        dataOffset + Int(capacityFrames) * Int(channels) * MemoryLayout<Float32>.size
+    }
+
+    /// Default capacity: ~2 seconds of audio at the given rate (768 KiB at
+    /// 48 kHz stereo — far below the ~50 MB extension cap).
+    public static func defaultCapacityFrames(sampleRate: UInt32) -> UInt32 {
+        sampleRate * 2
+    }
+
+    /// Current CLOCK_MONOTONIC time in milliseconds — the clock domain of
+    /// `heartbeatMillis`. The Rust consumer uses
+    /// `libc::clock_gettime(CLOCK_MONOTONIC)` for the same domain.
+    public static func monotonicNowMillis() -> UInt64 {
+        clock_gettime_nsec_np(CLOCK_MONOTONIC) / 1_000_000
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Darwin notification names — the signaling half of the contract.
+//
+// Posted on CFNotificationCenterGetDarwinNotifyCenter() by the extension;
+// observed by the host app / Rust consumer (rsac-b3aa listens for the same
+// strings). Darwin notifications carry NO payload — state lives in the ring
+// header. Defined here, in one place, so the producer template and any
+// future Swift consumer share them; the Rust side mirrors the literals.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Darwin notification names posted by the broadcast extension.
+public enum RsacDarwinNotification {
+    /// Broadcast started; the ring file exists and its header is published.
+    public static let started = "ai.codeseys.rsac.broadcast.started"
+    /// Broadcast paused by the user (heartbeat continues while paused).
+    public static let paused = "ai.codeseys.rsac.broadcast.paused"
+    /// Broadcast resumed.
+    public static let resumed = "ai.codeseys.rsac.broadcast.resumed"
+    /// Broadcast finished — producer terminal signal (ADR-0010): the host
+    /// stream must end with the fatal terminal (ADR-0003).
+    public static let finished = "ai.codeseys.rsac.broadcast.finished"
+}

--- a/mobile/ios/Sources/RsacBroadcastKit/RingProducer.swift
+++ b/mobile/ios/Sources/RsacBroadcastKit/RingProducer.swift
@@ -1,0 +1,266 @@
+import Foundation
+import CRsacRingAtomics
+
+/// Producer side of the rsac cross-process broadcast ring (see
+/// `RingLayout.swift` — THE canonical contract; the Rust consumer in
+/// rsac-b3aa mirrors it exactly).
+///
+/// Lives inside the ReplayKit Broadcast Upload Extension. Creates (or
+/// truncates) the ring file in the shared App Group container, memory-maps
+/// it, publishes the header, and writes interleaved f32 frames with
+/// **drop-not-block** semantics: if the consumer is slow and the ring fills,
+/// whole buffers are dropped and `producerDropCount` is incremented — the
+/// sample handler thread is never stalled (the extension budget and
+/// ReplayKit's delivery cadence both forbid blocking).
+///
+/// Single-producer: exactly one `RsacRingProducer` may exist per ring file.
+/// All `write`/`stampHeartbeat` calls must come from one thread at a time
+/// (ReplayKit delivers sample buffers serially; the heartbeat timer in
+/// `SampleHandlerTemplate` stamps via the atomic store, which is safe from
+/// any thread).
+public final class RsacRingProducer {
+
+    /// Errors surfaced during ring creation.
+    public enum ProducerError: Error, CustomStringConvertible {
+        /// `containerURL(forSecurityApplicationGroupIdentifier:)` returned
+        /// nil — the App Group entitlement is missing or the identifier is
+        /// wrong (must be present in BOTH the host app and the extension).
+        case appGroupUnavailable(String)
+        /// open(2)/ftruncate(2) on the ring file failed (errno attached).
+        case fileCreationFailed(String, errno: Int32)
+        /// mmap(2) failed (errno attached).
+        case mmapFailed(errno: Int32)
+        /// Zero channels / zero capacity / zero sample rate.
+        case invalidConfiguration(String)
+
+        public var description: String {
+            switch self {
+            case let .appGroupUnavailable(group):
+                return "App Group container unavailable for '\(group)' — check the "
+                    + "com.apple.security.application-groups entitlement on the extension"
+            case let .fileCreationFailed(path, errno):
+                return "failed to create/size ring file at \(path) (errno \(errno))"
+            case let .mmapFailed(errno):
+                return "mmap of ring file failed (errno \(errno))"
+            case let .invalidConfiguration(why):
+                return "invalid ring configuration: \(why)"
+            }
+        }
+    }
+
+    /// Delivered sample rate (Hz), as published in the header.
+    public let sampleRate: UInt32
+    /// Interleaved channel count, as published in the header.
+    public let channels: UInt32
+    /// Ring capacity in frames, as published in the header.
+    public let capacityFrames: UInt64
+
+    private let base: UnsafeMutableRawPointer
+    private let fileSize: Int
+    private let fd: Int32
+    /// Start of the interleaved f32 data region (base + dataOffset).
+    private let data: UnsafeMutablePointer<Float32>
+
+    // Atomic header fields (8-byte aligned by RingLayout construction).
+    private let publishPtr: UnsafeMutablePointer<UInt64>       // offset 0
+    private let writeCursorPtr: UnsafeMutablePointer<UInt64>   // offset 24
+    private let readCursorPtr: UnsafeMutablePointer<UInt64>    // offset 32
+    private let heartbeatPtr: UnsafeMutablePointer<UInt64>     // offset 40
+    private let dropCountPtr: UnsafeMutablePointer<UInt64>     // offset 48
+
+    /// Creates the ring file in the App Group container, maps it, and
+    /// publishes the v1 header. Any pre-existing file with the same name is
+    /// re-initialized from scratch (a new broadcast supersedes a dead one).
+    ///
+    /// - Parameters:
+    ///   - appGroupIdentifier: e.g. `"group.com.example.myapp.rsac"`. Must be
+    ///     an App Group both the host app and the extension are entitled to.
+    ///   - sampleRate: delivered rate in Hz (from the first CMSampleBuffer).
+    ///   - channels: interleaved channel count.
+    ///   - capacityFrames: ring depth in frames; default ≈ 2 s
+    ///     (`RsacRingLayout.defaultCapacityFrames`). Keep single-digit MB —
+    ///     the extension is capped at ~50 MB total.
+    ///   - fileName: defaults to the contract name `RsacRingLayout.ringFileName`.
+    public init(
+        appGroupIdentifier: String,
+        sampleRate: UInt32,
+        channels: UInt32,
+        capacityFrames: UInt32? = nil,
+        fileName: String = RsacRingLayout.ringFileName
+    ) throws {
+        guard sampleRate > 0, channels > 0 else {
+            throw ProducerError.invalidConfiguration(
+                "sampleRate=\(sampleRate) channels=\(channels)")
+        }
+        let capacity = capacityFrames ?? RsacRingLayout.defaultCapacityFrames(sampleRate: sampleRate)
+        guard capacity > 0 else {
+            throw ProducerError.invalidConfiguration("capacityFrames == 0")
+        }
+
+        guard let container = FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)
+        else {
+            throw ProducerError.appGroupUnavailable(appGroupIdentifier)
+        }
+        let url = container.appendingPathComponent(fileName, isDirectory: false)
+        let path = url.path
+
+        let size = RsacRingLayout.totalFileSize(capacityFrames: capacity, channels: channels)
+
+        // open + size the backing file. O_TRUNC deliberately NOT used: we
+        // zero the header through the mapping instead, so a live consumer
+        // mapping the old generation never sees the file shrink under it.
+        let fd = open(path, O_CREAT | O_RDWR, 0o644)
+        guard fd >= 0 else {
+            throw ProducerError.fileCreationFailed(path, errno: errno)
+        }
+        guard ftruncate(fd, off_t(size)) == 0 else {
+            let e = errno
+            Darwin.close(fd) // bare close() resolves to RingProducer.close()
+            throw ProducerError.fileCreationFailed(path, errno: e)
+        }
+
+        guard let mapped = mmap(nil, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0),
+              mapped != MAP_FAILED
+        else {
+            let e = errno
+            Darwin.close(fd) // bare close() resolves to RingProducer.close()
+            throw ProducerError.mmapFailed(errno: e)
+        }
+
+        self.fd = fd
+        self.fileSize = size
+        self.base = mapped
+        self.sampleRate = sampleRate
+        self.channels = channels
+        self.capacityFrames = UInt64(capacity)
+        self.data = mapped
+            .advanced(by: RsacRingLayout.dataOffset)
+            .assumingMemoryBound(to: Float32.self)
+        self.publishPtr = mapped.assumingMemoryBound(to: UInt64.self)
+        self.writeCursorPtr = mapped
+            .advanced(by: RsacRingLayout.offsetWriteCursor)
+            .assumingMemoryBound(to: UInt64.self)
+        self.readCursorPtr = mapped
+            .advanced(by: RsacRingLayout.offsetReadCursor)
+            .assumingMemoryBound(to: UInt64.self)
+        self.heartbeatPtr = mapped
+            .advanced(by: RsacRingLayout.offsetHeartbeatMillis)
+            .assumingMemoryBound(to: UInt64.self)
+        self.dropCountPtr = mapped
+            .advanced(by: RsacRingLayout.offsetProducerDropCount)
+            .assumingMemoryBound(to: UInt64.self)
+
+        publishHeader(capacity: capacity)
+    }
+
+    /// Header publish protocol (see RingLayout "Torn-read defense"):
+    /// 1. zero offset 0 (un-publishes any previous generation),
+    /// 2. write all non-atomic fields + initial atomic values,
+    /// 3. RELEASE-store (layoutVersion << 32) | magic at offset 0.
+    private func publishHeader(capacity: UInt32) {
+        rsac_atomic_store_u64_relaxed(publishPtr, 0)
+
+        // Non-atomic u32 fields, written little-endian. iOS targets are
+        // little-endian (arm64), so a plain store IS the little-endian
+        // representation; `littleEndian` makes the intent explicit and keeps
+        // this correct even on a hypothetical BE host.
+        func storeU32(_ value: UInt32, at offset: Int) {
+            base.advanced(by: offset)
+                .assumingMemoryBound(to: UInt32.self)
+                .pointee = value.littleEndian
+        }
+        storeU32(sampleRate, at: RsacRingLayout.offsetSampleRate)
+        storeU32(channels, at: RsacRingLayout.offsetChannels)
+        storeU32(capacity, at: RsacRingLayout.offsetCapacityFrames)
+        storeU32(0, at: RsacRingLayout.offsetReserved)
+        // Pad bytes 56..64 (zeroed).
+        base.advanced(by: RsacRingLayout.headerSize)
+            .assumingMemoryBound(to: UInt64.self)
+            .pointee = 0
+
+        rsac_atomic_store_u64_relaxed(writeCursorPtr, 0)
+        rsac_atomic_store_u64_relaxed(readCursorPtr, 0)
+        rsac_atomic_store_u64_relaxed(dropCountPtr, 0)
+        rsac_atomic_store_u64_relaxed(heartbeatPtr, RsacRingLayout.monotonicNowMillis())
+
+        // Publish point.
+        rsac_atomic_store_u64_release(publishPtr, RsacRingLayout.publishedMagicVersion)
+    }
+
+    // ── Write path (drop-not-block) ───────────────────────────────────────
+
+    /// Writes `frameCount` interleaved f32 frames (`frameCount * channels`
+    /// samples) into the ring.
+    ///
+    /// All-or-nothing: if the ring lacks space for the WHOLE buffer, nothing
+    /// is written, `producerDropCount` is incremented by 1 (one drop = one
+    /// buffer, matching the desktop bridge's overrun accounting), and `false`
+    /// is returned. Never blocks.
+    @discardableResult
+    public func write(interleavedSamples samples: UnsafePointer<Float32>, frameCount: Int) -> Bool {
+        guard frameCount > 0 else { return true }
+
+        // Producer owns writeCursor (relaxed); readCursor needs acquire so
+        // the consumer's release-store happens-before we reuse its slots.
+        let write = rsac_atomic_load_u64_relaxed(writeCursorPtr)
+        let read = rsac_atomic_load_u64_acquire(readCursorPtr)
+        let free = capacityFrames - (write - read)
+        guard UInt64(frameCount) <= free else {
+            _ = rsac_atomic_fetch_add_u64_relaxed(dropCountPtr, 1)
+            return false
+        }
+
+        let ch = Int(channels)
+        let startSlot = Int(write % capacityFrames)
+        let firstFrames = min(frameCount, Int(capacityFrames) - startSlot)
+        let firstSamples = firstFrames * ch
+
+        // Segment 1: up to the physical end of the ring.
+        memcpy(data.advanced(by: startSlot * ch), samples, firstSamples * 4)
+        // Segment 2 (wraparound): remainder at the physical start.
+        if firstFrames < frameCount {
+            let restFrames = frameCount - firstFrames
+            memcpy(data, samples.advanced(by: firstSamples), restFrames * ch * 4)
+        }
+
+        // Release: frame bytes above happen-before the cursor becomes
+        // visible to the consumer's acquire-load (torn-read defense).
+        rsac_atomic_store_u64_release(writeCursorPtr, write + UInt64(frameCount))
+        return true
+    }
+
+    /// Buffers dropped so far because the ring was full.
+    public var dropCount: UInt64 {
+        rsac_atomic_load_u64_relaxed(dropCountPtr)
+    }
+
+    // ── Heartbeat ─────────────────────────────────────────────────────────
+
+    /// Stamps `heartbeatMillis` with the current CLOCK_MONOTONIC time.
+    /// Atomic; safe to call from the heartbeat timer's queue while the
+    /// sample-handler thread is writing.
+    public func stampHeartbeat() {
+        rsac_atomic_store_u64_relaxed(heartbeatPtr, RsacRingLayout.monotonicNowMillis())
+    }
+
+    // ── Teardown ──────────────────────────────────────────────────────────
+
+    /// Stamps a final heartbeat and unmaps/closes the ring. The FILE is
+    /// deliberately left in place: the consumer may still drain remaining
+    /// frames after the `finished` Darwin notification; the *absence of
+    /// heartbeats* plus the notification are the terminal signal, not file
+    /// deletion.
+    public func close() {
+        stampHeartbeat()
+        munmap(base, fileSize)
+        Darwin.close(fd)
+    }
+
+    deinit {
+        // Idempotence: munmap/close on already-closed resources is avoided by
+        // convention — SampleHandlerTemplate calls close() exactly once, in
+        // broadcastFinished. If the extension is killed hard, the OS reclaims
+        // the mapping and fd anyway.
+    }
+}

--- a/mobile/ios/Sources/RsacBroadcastKit/SampleHandlerTemplate.swift
+++ b/mobile/ios/Sources/RsacBroadcastKit/SampleHandlerTemplate.swift
@@ -1,0 +1,313 @@
+import ReplayKit
+import CoreMedia
+import AudioToolbox
+import Foundation
+
+/// Open template for the consumer app's Broadcast Upload Extension.
+///
+/// Subclass this in the extension target, override ``appGroupIdentifier``,
+/// and set the subclass as the extension's principal
+/// `RPBroadcastSampleHandler` (`NSExtensionPrincipalClass`). Everything else
+/// — ring creation, f32 conversion, drop-not-block writes, Darwin
+/// notifications, heartbeat — is handled here.
+///
+/// ```swift
+/// // In the extension target:
+/// class SampleHandler: RsacBroadcastSampleHandler {
+///     override var appGroupIdentifier: String { "group.com.example.myapp.rsac" }
+/// }
+/// ```
+///
+/// Data path: `processSampleBuffer(.audioApp)` → `CMSampleBuffer` →
+/// `AudioBufferList` → interleaved f32 → ``RsacRingProducer/write``. The ring
+/// contract is `RingLayout.swift` (canonical; mirrored by the Rust consumer,
+/// rsac-b3aa). `.audioMic` and `.video` buffers are ignored: the mic path is
+/// the host app's `AVAudioEngine` slice (`src/audio/ios/`), and rsac never
+/// touches video.
+open class RsacBroadcastSampleHandler: RPBroadcastSampleHandler {
+
+    // ── Subclass surface ──────────────────────────────────────────────────
+
+    /// REQUIRED override: the App Group shared by the host app and this
+    /// extension (both targets need the `com.apple.security.application-groups`
+    /// entitlement listing it).
+    open var appGroupIdentifier: String {
+        // Overriding is mandatory; the base class cannot know your group.
+        // Returning "" fails fast in broadcastStarted with a user-facing error.
+        ""
+    }
+
+    /// Ring depth in seconds (default 2.0 — 768 KiB at 48 kHz stereo, far
+    /// below the ~50 MB extension memory cap). Override to tune.
+    open var ringSeconds: Double { 2.0 }
+
+    // ── State (extension-side only) ───────────────────────────────────────
+
+    private let lock = NSLock()
+    private var producer: RsacRingProducer?
+    private var heartbeatTimer: DispatchSourceTimer?
+    /// Grow-only scratch for format conversion (reused across buffers; the
+    /// sample-handler path allocates only when a larger buffer arrives).
+    private var scratch: [Float32] = []
+    /// Reusable AudioBufferList storage, sized for up to 8 planar channel
+    /// buffers — allocated once, freed on deinit.
+    private static let ablMaxBuffers = 8
+    private static let ablBytes = MemoryLayout<AudioBufferList>.size
+        + (ablMaxBuffers - 1) * MemoryLayout<AudioBuffer>.size
+    private lazy var ablRaw = UnsafeMutableRawPointer.allocate(
+        byteCount: Self.ablBytes,
+        alignment: MemoryLayout<AudioBufferList>.alignment)
+
+    deinit {
+        ablRaw.deallocate()
+    }
+    /// One-shot warning latch for unsupported sample formats.
+    private var warnedUnsupportedFormat = false
+
+    // ── RPBroadcastSampleHandler lifecycle ────────────────────────────────
+
+    override open func broadcastStarted(withSetupInfo setupInfo: [String: NSObject]?) {
+        guard !appGroupIdentifier.isEmpty else {
+            finishBroadcastWithError(NSError(
+                domain: "ai.codeseys.rsac",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey:
+                    "RsacBroadcastSampleHandler subclass must override appGroupIdentifier"]))
+            return
+        }
+        // The ring is created lazily on the FIRST .audioApp buffer — only
+        // then are the delivered sample rate and channel count known (from
+        // the CMSampleBuffer's ASBD). Until then only the heartbeat concept
+        // exists; the `started` notification tells the host to begin
+        // watching for the ring header publish.
+        postDarwinNotification(RsacDarwinNotification.started)
+    }
+
+    override open func broadcastPaused() {
+        // Heartbeat continues while paused (the extension is alive; the host
+        // must not declare it dead) — see RingLayout heartbeat contract.
+        postDarwinNotification(RsacDarwinNotification.paused)
+    }
+
+    override open func broadcastResumed() {
+        postDarwinNotification(RsacDarwinNotification.resumed)
+    }
+
+    override open func broadcastFinished() {
+        lock.lock()
+        heartbeatTimer?.cancel()
+        heartbeatTimer = nil
+        let p = producer
+        producer = nil
+        lock.unlock()
+
+        // Final heartbeat + unmap; the file stays for the consumer to drain.
+        p?.close()
+        postDarwinNotification(RsacDarwinNotification.finished)
+    }
+
+    override open func processSampleBuffer(
+        _ sampleBuffer: CMSampleBuffer,
+        with sampleBufferType: RPSampleBufferType
+    ) {
+        switch sampleBufferType {
+        case .audioApp:
+            handleAppAudio(sampleBuffer)
+        case .audioMic, .video:
+            break // mic = host-app AVAudioEngine slice; video = out of scope
+        @unknown default:
+            break
+        }
+    }
+
+    // ── App-audio path ────────────────────────────────────────────────────
+
+    private func handleAppAudio(_ sampleBuffer: CMSampleBuffer) {
+        guard CMSampleBufferDataIsReady(sampleBuffer),
+              let formatDesc = CMSampleBufferGetFormatDescription(sampleBuffer),
+              let asbdPtr = CMAudioFormatDescriptionGetStreamBasicDescription(formatDesc)
+        else { return }
+        let asbd = asbdPtr.pointee
+        let frameCount = CMSampleBufferGetNumSamples(sampleBuffer)
+        guard frameCount > 0, asbd.mChannelsPerFrame > 0 else { return }
+
+        let p: RsacRingProducer
+        do {
+            p = try ensureProducer(asbd: asbd)
+        } catch {
+            finishBroadcastWithError(NSError(
+                domain: "ai.codeseys.rsac",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey:
+                    "rsac broadcast ring setup failed: \(error)"]))
+            return
+        }
+
+        // Extract the AudioBufferList backed by a retained block buffer,
+        // into the reusable instance storage (no per-buffer allocation).
+        let ablPtr = ablRaw.assumingMemoryBound(to: AudioBufferList.self)
+
+        var blockBuffer: CMBlockBuffer?
+        // CI-VERIFY: exact Swift signature/argument labels of
+        // CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer on the iOS 14 SDK.
+        let status = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
+            sampleBuffer,
+            bufferListSizeNeededOut: nil,
+            bufferListOut: ablPtr,
+            bufferListSize: Self.ablBytes,
+            blockBufferAllocator: kCFAllocatorDefault,
+            blockBufferMemoryAllocator: kCFAllocatorDefault,
+            flags: kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment,
+            blockBufferOut: &blockBuffer)
+        guard status == noErr, blockBuffer != nil else { return }
+
+        let abl = UnsafeMutableAudioBufferListPointer(ablPtr)
+        convertAndWrite(abl: abl, asbd: asbd, frameCount: frameCount, producer: p)
+    }
+
+    /// Converts whatever LPCM layout ReplayKit delivered into interleaved
+    /// f32 and writes it to the ring. Handles the common cases: f32/i16/i32,
+    /// interleaved and non-interleaved. Anything else is dropped (counted
+    /// once in the log, never crashes the broadcast).
+    ///
+    /// CI-VERIFY: on-device, ReplayKit .audioApp is typically 44.1 kHz stereo
+    /// signed 16-bit interleaved LPCM — confirm and, if it is the ONLY format
+    /// ever delivered, the f32/i32 branches are just safety margin.
+    private func convertAndWrite(
+        abl: UnsafeMutableAudioBufferListPointer,
+        asbd: AudioStreamBasicDescription,
+        frameCount: Int,
+        producer p: RsacRingProducer
+    ) {
+        let channels = Int(asbd.mChannelsPerFrame)
+        let isFloat = asbd.mFormatFlags & kAudioFormatFlagIsFloat != 0
+        let isSignedInt = asbd.mFormatFlags & kAudioFormatFlagIsSignedInteger != 0
+        let isNonInterleaved = asbd.mFormatFlags & kAudioFormatFlagIsNonInterleaved != 0
+        let bits = Int(asbd.mBitsPerChannel)
+
+        // Fast path: interleaved f32 — write straight from the block buffer.
+        if isFloat, bits == 32, !isNonInterleaved, let buf = abl.first,
+           let raw = buf.mData {
+            let samples = raw.assumingMemoryBound(to: Float32.self)
+            p.write(interleavedSamples: samples, frameCount: frameCount)
+            p.stampHeartbeat()
+            return
+        }
+
+        // Everything else converts into the grow-only scratch buffer.
+        let needed = frameCount * channels
+        if scratch.count < needed {
+            scratch = [Float32](repeating: 0, count: needed)
+        }
+
+        let ok: Bool = scratch.withUnsafeMutableBufferPointer { out -> Bool in
+            guard let outBase = out.baseAddress else { return false }
+            switch (isFloat, isSignedInt, bits, isNonInterleaved) {
+            case (true, _, 32, true): // f32 planar → interleave
+                for (ch, buf) in abl.enumerated() where ch < channels {
+                    guard let raw = buf.mData else { return false }
+                    let src = raw.assumingMemoryBound(to: Float32.self)
+                    for f in 0..<frameCount { outBase[f * channels + ch] = src[f] }
+                }
+                return true
+            case (false, true, 16, false): // i16 interleaved
+                guard let raw = abl.first?.mData else { return false }
+                let src = raw.assumingMemoryBound(to: Int16.self)
+                for i in 0..<needed { outBase[i] = Float32(src[i]) / 32768.0 }
+                return true
+            case (false, true, 16, true): // i16 planar
+                for (ch, buf) in abl.enumerated() where ch < channels {
+                    guard let raw = buf.mData else { return false }
+                    let src = raw.assumingMemoryBound(to: Int16.self)
+                    for f in 0..<frameCount {
+                        outBase[f * channels + ch] = Float32(src[f]) / 32768.0
+                    }
+                }
+                return true
+            case (false, true, 32, false): // i32 interleaved
+                guard let raw = abl.first?.mData else { return false }
+                let src = raw.assumingMemoryBound(to: Int32.self)
+                for i in 0..<needed { outBase[i] = Float32(src[i]) / 2147483648.0 }
+                return true
+            case (false, true, 32, true): // i32 planar
+                for (ch, buf) in abl.enumerated() where ch < channels {
+                    guard let raw = buf.mData else { return false }
+                    let src = raw.assumingMemoryBound(to: Int32.self)
+                    for f in 0..<frameCount {
+                        outBase[f * channels + ch] = Float32(src[f]) / 2147483648.0
+                    }
+                }
+                return true
+            default:
+                return false
+            }
+        }
+
+        guard ok else {
+            if !warnedUnsupportedFormat {
+                warnedUnsupportedFormat = true
+                NSLog("[rsac] unsupported .audioApp LPCM layout: flags=0x%x bits=%d — dropping audio",
+                      asbd.mFormatFlags, bits)
+            }
+            return
+        }
+
+        scratch.withUnsafeBufferPointer { buf in
+            if let base = buf.baseAddress {
+                p.write(interleavedSamples: base, frameCount: frameCount)
+            }
+        }
+        p.stampHeartbeat()
+    }
+
+    /// Creates the ring producer on first use, geometry taken from the
+    /// delivered ASBD, and starts the heartbeat timer.
+    private func ensureProducer(asbd: AudioStreamBasicDescription) throws -> RsacRingProducer {
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = producer { return existing }
+
+        let sampleRate = UInt32(asbd.mSampleRate.rounded())
+        let channels = asbd.mChannelsPerFrame
+        let capacity = UInt32((Double(sampleRate) * ringSeconds).rounded())
+        let created = try RsacRingProducer(
+            appGroupIdentifier: appGroupIdentifier,
+            sampleRate: sampleRate,
+            channels: channels,
+            capacityFrames: capacity)
+        producer = created
+        startHeartbeatTimer(for: created)
+        return created
+    }
+
+    /// Periodic heartbeat, independent of audio delivery, so the host can
+    /// distinguish "paused / silent app audio" from "extension killed".
+    /// Interval is the contract value `RsacRingLayout.heartbeatIntervalMillis`.
+    private func startHeartbeatTimer(for p: RsacRingProducer) {
+        let timer = DispatchSource.makeTimerSource(
+            queue: DispatchQueue(label: "ai.codeseys.rsac.heartbeat", qos: .utility))
+        timer.schedule(
+            deadline: .now(),
+            repeating: .milliseconds(Int(RsacRingLayout.heartbeatIntervalMillis)))
+        // Captures the producer instance directly — no shared mutable state;
+        // stampHeartbeat is a single atomic store, safe from this queue.
+        timer.setEventHandler { p.stampHeartbeat() }
+        timer.resume()
+        heartbeatTimer = timer
+    }
+
+    // ── Darwin notifications ──────────────────────────────────────────────
+
+    /// Posts on the Darwin notify center (names: `RsacDarwinNotification`,
+    /// defined once in RingLayout.swift — the Rust consumer listens for the
+    /// same strings). Darwin notifications cross the extension/app process
+    /// boundary and carry no payload; all state lives in the ring header.
+    private func postDarwinNotification(_ name: String) {
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            CFNotificationName(name as CFString),
+            nil,
+            nil,
+            true) // deliverImmediately
+    }
+}


### PR DESCRIPTION
Final layer of the 0.4.1 release stack (epic rsac-4844; L1 #36, L3 #37, L4 #38, L5 #39 merged). The mobile *delivery* half — the mobile library code landed in L1.

**Scope (21 files):** mobile/android AAR Gradle project (RsacProjection consent helper, CaptureBridge FGS capture loop), mobile/android-native cdylib shim restored as a workspace member (reverting L1's documented manifest adjustment), mobile/ios SwiftPM package + Broadcast Upload Extension template (RingLayout v1 contract), the mobile-android/mobile-ios CI jobs restored exactly as stripped in L4 (release/** triggers + .coderabbit.yaml preserved), frozen-source Cargo.toml/lock restored verbatim.

**Status honesty:** everything mobile is compile-proof only (AGENTS matrix: compiled, unverified); runtime legs are rsac-e6d3 / rsac-97c8.

**Validation:** workspace check incl the shim on host, 644 lib tests, YAML parse; this PR's own CI runs both mobile legs (cargo-ndk .so + llvm-nm JNI_OnLoad assertion + Gradle AAR; xcodebuild SwiftPM).

**After this merges:** release/0.4.1 == the frozen fat branch (ed92b20) modulo exactly: the release/** trigger lines, .coderabbit.yaml, and lockfile-resolution noise — the final identity diff will be posted on the epic. PR #35 will be closed with a pointer to the stack.