### PR TITLE
ffi+go: capability parity accessors (rsac-a9af)

### DIFF
--- a/bindings/rsac-ffi/include/rsac.h
+++ b/bindings/rsac-ffi/include/rsac.h
@@ -489,6 +489,12 @@ int32_t rsac_capabilities_supports_process_tree(const RsacCapabilities* caps);
 int32_t rsac_capabilities_supports_device_selection(const RsacCapabilities* caps);
 
 /**
+ * Returns 1 if the backend can deliver device hot-plug / default-change
+ * notifications, 0 if not, -1 if null.
+ */
+int32_t rsac_capabilities_supports_device_change_notifications(const RsacCapabilities* caps);
+
+/**
  * Returns 1 if starting a capture requires a config-time user-consent
  * artifact (mobile platforms — e.g. an Android MediaProjection token via
  * rsac_builder_set_android_projection()), 0 if not, -1 if null.
@@ -498,6 +504,52 @@ int32_t rsac_capabilities_requires_user_consent(const RsacCapabilities* caps);
 
 /** Returns the maximum number of channels supported. Returns 0 if null. */
 uint16_t rsac_capabilities_max_channels(const RsacCapabilities* caps);
+
+/**
+ * Returns the number of sample formats the backend supports.
+ * Returns 0 if null.
+ */
+size_t rsac_capabilities_supported_sample_format_count(const RsacCapabilities* caps);
+
+/**
+ * Returns the supported sample format at `index` as one of the
+ * rsac_sample_format_t constants, carried as a plain int32_t (the same
+ * constants-as-int convention as rsac_default_device()'s `kind`). Valid
+ * indices are 0..rsac_capabilities_supported_sample_format_count().
+ * Returns -1 if the handle is null or `index` is out of bounds.
+ */
+int32_t rsac_capabilities_supported_sample_format_at(const RsacCapabilities* caps,
+                                                     size_t index);
+
+/**
+ * Returns the minimum of the backend's device-negotiable sample-rate range,
+ * in Hz. Returns 0 if null.
+ */
+uint32_t rsac_capabilities_min_sample_rate(const RsacCapabilities* caps);
+
+/**
+ * Returns the maximum of the backend's device-negotiable sample-rate range,
+ * in Hz. Returns 0 if null.
+ */
+uint32_t rsac_capabilities_max_sample_rate(const RsacCapabilities* caps);
+
+/**
+ * Returns the number of entries in the builder's config-time sample-rate
+ * whitelist — the exact set rsac_builder_set_sample_rate() values are
+ * validated against at rsac_builder_build(). Intentionally narrower than
+ * the device-negotiable range reported by rsac_capabilities_min_sample_rate()
+ * / rsac_capabilities_max_sample_rate(). Returns 0 if null.
+ */
+size_t rsac_capabilities_supported_sample_rate_count(const RsacCapabilities* caps);
+
+/**
+ * Returns the config-time whitelisted sample rate at `index`, in Hz. Valid
+ * indices are 0..rsac_capabilities_supported_sample_rate_count(). Returns 0
+ * if the handle is null or `index` is out of bounds (0 is never a valid
+ * sample rate).
+ */
+uint32_t rsac_capabilities_supported_sample_rate_at(const RsacCapabilities* caps,
+                                                    size_t index);
 
 /**
  * Returns the backend name (e.g. "WASAPI", "CoreAudio", "PipeWire").

--- a/bindings/rsac-ffi/include/rsac_generated.h
+++ b/bindings/rsac-ffi/include/rsac_generated.h
@@ -844,6 +844,15 @@ enum rsac_error_t rsac_default_device(const struct RsacDeviceEnumerator *enumera
  int32_t rsac_capabilities_supports_device_selection(const struct RsacCapabilities *caps) ;
 
 /**
+ * Returns 1 if the backend can deliver device hot-plug / default-change
+ * notifications (the `DeviceEnumerator::watch` surface), 0 otherwise.
+ * Returns -1 if the handle is null.
+ */
+
+int32_t rsac_capabilities_supports_device_change_notifications(const struct RsacCapabilities *caps)
+;
+
+/**
  * Returns 1 if starting a capture requires a config-time user-consent
  * artifact (mobile platforms — e.g. an Android `MediaProjection` token via
  * `rsac_builder_set_android_projection()`), 0 otherwise. Always 0 on the
@@ -856,6 +865,58 @@ enum rsac_error_t rsac_default_device(const struct RsacDeviceEnumerator *enumera
  * Returns 0 if the handle is null.
  */
  uint16_t rsac_capabilities_max_channels(const struct RsacCapabilities *caps) ;
+
+/**
+ * Returns the number of sample formats the backend supports.
+ * Returns 0 if the handle is null.
+ */
+ uintptr_t rsac_capabilities_supported_sample_format_count(const struct RsacCapabilities *caps) ;
+
+/**
+ * Returns the supported sample format at `index` as one of the
+ * [`rsac_sample_format_t`] constants, carried as a plain `int32_t`
+ * (the same constants-as-int convention as [`rsac_default_device`]'s
+ * `kind` parameter). Valid indices are
+ * `0..rsac_capabilities_supported_sample_format_count()`.
+ * Returns -1 if the handle is null or `index` is out of bounds.
+ */
+
+int32_t rsac_capabilities_supported_sample_format_at(const struct RsacCapabilities *caps,
+                                                     uintptr_t index)
+;
+
+/**
+ * Returns the minimum of the backend's device-negotiable sample-rate
+ * range, in Hz. Returns 0 if the handle is null.
+ */
+ uint32_t rsac_capabilities_min_sample_rate(const struct RsacCapabilities *caps) ;
+
+/**
+ * Returns the maximum of the backend's device-negotiable sample-rate
+ * range, in Hz. Returns 0 if the handle is null.
+ */
+ uint32_t rsac_capabilities_max_sample_rate(const struct RsacCapabilities *caps) ;
+
+/**
+ * Returns the number of entries in the builder's **config-time sample-rate
+ * whitelist** — the exact set `rsac_builder_set_sample_rate()` values are
+ * validated against at `rsac_builder_build()`. This is intentionally
+ * narrower than the device-negotiable range reported by
+ * `rsac_capabilities_min_sample_rate()` / `rsac_capabilities_max_sample_rate()`.
+ * Returns 0 if the handle is null.
+ */
+ uintptr_t rsac_capabilities_supported_sample_rate_count(const struct RsacCapabilities *caps) ;
+
+/**
+ * Returns the config-time whitelisted sample rate at `index`, in Hz. Valid
+ * indices are `0..rsac_capabilities_supported_sample_rate_count()`.
+ * Returns 0 if the handle is null or `index` is out of bounds (0 is never
+ * a valid sample rate).
+ */
+
+uint32_t rsac_capabilities_supported_sample_rate_at(const struct RsacCapabilities *caps,
+                                                    uintptr_t index)
+;
 
 /**
  * Returns the backend name (e.g., "WASAPI", "CoreAudio", "PipeWire") as a C string.

--- a/bindings/rsac-ffi/src/lib.rs
+++ b/bindings/rsac-ffi/src/lib.rs
@@ -1576,6 +1576,24 @@ pub unsafe extern "C" fn rsac_capabilities_supports_device_selection(
     }
 }
 
+/// Returns 1 if the backend can deliver device hot-plug / default-change
+/// notifications (the `DeviceEnumerator::watch` surface), 0 otherwise.
+/// Returns -1 if the handle is null.
+#[no_mangle]
+pub unsafe extern "C" fn rsac_capabilities_supports_device_change_notifications(
+    caps: *const RsacCapabilities,
+) -> i32 {
+    if caps.is_null() {
+        return -1;
+    }
+    let c = unsafe { &*caps };
+    if c.inner.supports_device_change_notifications {
+        1
+    } else {
+        0
+    }
+}
+
 /// Returns 1 if starting a capture requires a config-time user-consent
 /// artifact (mobile platforms — e.g. an Android `MediaProjection` token via
 /// `rsac_builder_set_android_projection()`), 0 otherwise. Always 0 on the
@@ -1604,6 +1622,96 @@ pub unsafe extern "C" fn rsac_capabilities_max_channels(caps: *const RsacCapabil
     }
     let c = unsafe { &*caps };
     c.inner.max_channels
+}
+
+/// Returns the number of sample formats the backend supports.
+/// Returns 0 if the handle is null.
+#[no_mangle]
+pub unsafe extern "C" fn rsac_capabilities_supported_sample_format_count(
+    caps: *const RsacCapabilities,
+) -> usize {
+    if caps.is_null() {
+        return 0;
+    }
+    let c = unsafe { &*caps };
+    c.inner.supported_sample_formats.len()
+}
+
+/// Returns the supported sample format at `index` as one of the
+/// [`rsac_sample_format_t`] constants, carried as a plain `int32_t`
+/// (the same constants-as-int convention as [`rsac_default_device`]'s
+/// `kind` parameter). Valid indices are
+/// `0..rsac_capabilities_supported_sample_format_count()`.
+/// Returns -1 if the handle is null or `index` is out of bounds.
+#[no_mangle]
+pub unsafe extern "C" fn rsac_capabilities_supported_sample_format_at(
+    caps: *const RsacCapabilities,
+    index: usize,
+) -> i32 {
+    if caps.is_null() {
+        return -1;
+    }
+    let c = unsafe { &*caps };
+    match c.inner.supported_sample_formats.get(index) {
+        Some(&fmt) => rsac_sample_format_t::from(fmt) as i32,
+        None => -1,
+    }
+}
+
+/// Returns the minimum of the backend's device-negotiable sample-rate
+/// range, in Hz. Returns 0 if the handle is null.
+#[no_mangle]
+pub unsafe extern "C" fn rsac_capabilities_min_sample_rate(caps: *const RsacCapabilities) -> u32 {
+    if caps.is_null() {
+        return 0;
+    }
+    let c = unsafe { &*caps };
+    c.inner.sample_rate_range.0
+}
+
+/// Returns the maximum of the backend's device-negotiable sample-rate
+/// range, in Hz. Returns 0 if the handle is null.
+#[no_mangle]
+pub unsafe extern "C" fn rsac_capabilities_max_sample_rate(caps: *const RsacCapabilities) -> u32 {
+    if caps.is_null() {
+        return 0;
+    }
+    let c = unsafe { &*caps };
+    c.inner.sample_rate_range.1
+}
+
+/// Returns the number of entries in the builder's **config-time sample-rate
+/// whitelist** — the exact set `rsac_builder_set_sample_rate()` values are
+/// validated against at `rsac_builder_build()`. This is intentionally
+/// narrower than the device-negotiable range reported by
+/// `rsac_capabilities_min_sample_rate()` / `rsac_capabilities_max_sample_rate()`.
+/// Returns 0 if the handle is null.
+#[no_mangle]
+pub unsafe extern "C" fn rsac_capabilities_supported_sample_rate_count(
+    caps: *const RsacCapabilities,
+) -> usize {
+    if caps.is_null() {
+        return 0;
+    }
+    PlatformCapabilities::supported_sample_rates().len()
+}
+
+/// Returns the config-time whitelisted sample rate at `index`, in Hz. Valid
+/// indices are `0..rsac_capabilities_supported_sample_rate_count()`.
+/// Returns 0 if the handle is null or `index` is out of bounds (0 is never
+/// a valid sample rate).
+#[no_mangle]
+pub unsafe extern "C" fn rsac_capabilities_supported_sample_rate_at(
+    caps: *const RsacCapabilities,
+    index: usize,
+) -> u32 {
+    if caps.is_null() {
+        return 0;
+    }
+    PlatformCapabilities::supported_sample_rates()
+        .get(index)
+        .copied()
+        .unwrap_or(0)
 }
 
 thread_local! {
@@ -1926,5 +2034,124 @@ mod tests {
         assert_eq!(c_stats.uptime_secs, 0.0);
         assert_eq!(c_stats.dropped_ratio, 0.0);
         assert_eq!(c_stats.is_running, 0);
+    }
+
+    // ── Capability parity accessors (rsac-a9af) ───────────────────────────
+    //
+    // Capabilities are a static, device-free query (PlatformCapabilities is
+    // derived from the target OS + enabled feature, no audio hardware is
+    // touched), so unlike captures these CAN be exercised end-to-end in CI.
+
+    #[test]
+    fn capabilities_new_accessors_reject_null() {
+        assert_eq!(
+            unsafe { rsac_capabilities_supports_device_change_notifications(ptr::null()) },
+            -1
+        );
+        assert_eq!(
+            unsafe { rsac_capabilities_supported_sample_format_count(ptr::null()) },
+            0
+        );
+        assert_eq!(
+            unsafe { rsac_capabilities_supported_sample_format_at(ptr::null(), 0) },
+            -1
+        );
+        assert_eq!(unsafe { rsac_capabilities_min_sample_rate(ptr::null()) }, 0);
+        assert_eq!(unsafe { rsac_capabilities_max_sample_rate(ptr::null()) }, 0);
+        assert_eq!(
+            unsafe { rsac_capabilities_supported_sample_rate_count(ptr::null()) },
+            0
+        );
+        assert_eq!(
+            unsafe { rsac_capabilities_supported_sample_rate_at(ptr::null(), 0) },
+            0
+        );
+    }
+
+    #[test]
+    fn capabilities_new_accessors_round_trip_query() {
+        let rust_caps = PlatformCapabilities::query();
+
+        let mut caps: *mut RsacCapabilities = ptr::null_mut();
+        assert_eq!(
+            unsafe { rsac_capabilities_query(&mut caps) },
+            rsac_error_t::RSAC_OK
+        );
+        assert!(!caps.is_null());
+
+        assert_eq!(
+            unsafe { rsac_capabilities_supports_device_change_notifications(caps) },
+            i32::from(rust_caps.supports_device_change_notifications)
+        );
+        assert_eq!(
+            unsafe { rsac_capabilities_min_sample_rate(caps) },
+            rust_caps.sample_rate_range.0
+        );
+        assert_eq!(
+            unsafe { rsac_capabilities_max_sample_rate(caps) },
+            rust_caps.sample_rate_range.1
+        );
+
+        unsafe { rsac_capabilities_free(caps) };
+    }
+
+    #[test]
+    fn capabilities_sample_format_list_round_trips() {
+        let rust_caps = PlatformCapabilities::query();
+
+        let mut caps: *mut RsacCapabilities = ptr::null_mut();
+        assert_eq!(
+            unsafe { rsac_capabilities_query(&mut caps) },
+            rsac_error_t::RSAC_OK
+        );
+        assert!(!caps.is_null());
+
+        let count = unsafe { rsac_capabilities_supported_sample_format_count(caps) };
+        assert_eq!(count, rust_caps.supported_sample_formats.len());
+        for (i, &fmt) in rust_caps.supported_sample_formats.iter().enumerate() {
+            assert_eq!(
+                unsafe { rsac_capabilities_supported_sample_format_at(caps, i) },
+                rsac_sample_format_t::from(fmt) as i32,
+                "format index {i} must round-trip through the C constant"
+            );
+        }
+        // One past the end is out of bounds → the -1 sentinel, not UB.
+        assert_eq!(
+            unsafe { rsac_capabilities_supported_sample_format_at(caps, count) },
+            -1
+        );
+
+        unsafe { rsac_capabilities_free(caps) };
+    }
+
+    #[test]
+    fn capabilities_sample_rate_whitelist_matches_const() {
+        let mut caps: *mut RsacCapabilities = ptr::null_mut();
+        assert_eq!(
+            unsafe { rsac_capabilities_query(&mut caps) },
+            rsac_error_t::RSAC_OK
+        );
+        assert!(!caps.is_null());
+
+        // The whitelist is single-sourced from the builder's config-time
+        // contract (PlatformCapabilities::SUPPORTED_SAMPLE_RATES) — the C view
+        // must be the same list, in the same order.
+        let whitelist = PlatformCapabilities::supported_sample_rates();
+        let count = unsafe { rsac_capabilities_supported_sample_rate_count(caps) };
+        assert_eq!(count, whitelist.len());
+        for (i, &rate) in whitelist.iter().enumerate() {
+            assert_eq!(
+                unsafe { rsac_capabilities_supported_sample_rate_at(caps, i) },
+                rate,
+                "whitelist index {i} must match the builder's const"
+            );
+        }
+        // Out of bounds → 0 (never a valid sample rate).
+        assert_eq!(
+            unsafe { rsac_capabilities_supported_sample_rate_at(caps, count) },
+            0
+        );
+
+        unsafe { rsac_capabilities_free(caps) };
     }
 }

--- a/bindings/rsac-go/example_test.go
+++ b/bindings/rsac-go/example_test.go
@@ -234,8 +234,12 @@ func ExamplePlatformCapabilities() {
 	fmt.Printf("App capture: %v\n", caps.SupportsAppCapture)
 	fmt.Printf("Process tree: %v\n", caps.SupportsProcessTree)
 	fmt.Printf("Device selection: %v\n", caps.SupportsDeviceSelection)
+	fmt.Printf("Device change notifications: %v\n", caps.SupportsDeviceChangeNotifications)
 	fmt.Printf("Requires user consent: %v\n", caps.RequiresUserConsent)
 	fmt.Printf("Max channels: %d\n", caps.MaxChannels)
+	fmt.Printf("Sample formats: %v\n", caps.SupportedSampleFormats)
+	fmt.Printf("Sample rate range: %d-%d Hz\n", caps.MinSampleRate, caps.MaxSampleRate)
+	fmt.Printf("Config-time rate whitelist: %v\n", caps.SupportedSampleRates)
 }
 
 // ExampleListDevices demonstrates audio device enumeration.

--- a/bindings/rsac-go/rsac.go
+++ b/bindings/rsac-go/rsac.go
@@ -1259,6 +1259,9 @@ type Capabilities struct {
 	SupportsProcessTree bool
 	// SupportsDeviceSelection indicates whether specific device selection is available.
 	SupportsDeviceSelection bool
+	// SupportsDeviceChangeNotifications indicates whether the backend can
+	// deliver device hot-plug / default-change notifications.
+	SupportsDeviceChangeNotifications bool
 	// RequiresUserConsent is true when starting a capture requires a
 	// config-time user-consent artifact (mobile platforms; see
 	// docs/MOBILE_BACKEND_DESIGN.md). Always false on desktop backends.
@@ -1267,6 +1270,19 @@ type Capabilities struct {
 	BackendName string
 	// MaxChannels is the maximum number of audio channels supported.
 	MaxChannels int
+	// SupportedSampleFormats lists the sample wire formats the backend supports.
+	SupportedSampleFormats []SampleFormat
+	// MinSampleRate is the minimum of the backend's device-negotiable
+	// sample-rate range, in Hz.
+	MinSampleRate uint32
+	// MaxSampleRate is the maximum of the backend's device-negotiable
+	// sample-rate range, in Hz.
+	MaxSampleRate uint32
+	// SupportedSampleRates is the config-time sample-rate whitelist — the
+	// exact set CaptureBuilder.SampleRate values are validated against at
+	// Build(). Intentionally narrower than the device-negotiable
+	// MinSampleRate..MaxSampleRate range.
+	SupportedSampleRates []uint32
 }
 
 // PlatformCapabilities queries and returns the audio capabilities of the
@@ -1287,14 +1303,38 @@ func PlatformCapabilities() (Capabilities, error) {
 		backendName = C.GoString(cname)
 	}
 
+	// The indexed getters return -1 (formats) / 0 (rates) for a null handle
+	// or an out-of-bounds index; inside 0..count neither sentinel can occur,
+	// so the loops below take every entry verbatim.
+	formatCount := int(C.rsac_capabilities_supported_sample_format_count(ccaps))
+	formats := make([]SampleFormat, 0, formatCount)
+	for i := 0; i < formatCount; i++ {
+		if f := C.rsac_capabilities_supported_sample_format_at(ccaps, C.size_t(i)); f >= 0 {
+			formats = append(formats, SampleFormat(f))
+		}
+	}
+
+	rateCount := int(C.rsac_capabilities_supported_sample_rate_count(ccaps))
+	rates := make([]uint32, 0, rateCount)
+	for i := 0; i < rateCount; i++ {
+		if r := C.rsac_capabilities_supported_sample_rate_at(ccaps, C.size_t(i)); r != 0 {
+			rates = append(rates, uint32(r))
+		}
+	}
+
 	return Capabilities{
-		SupportsSystemCapture:   C.rsac_capabilities_supports_system_capture(ccaps) == 1,
-		SupportsAppCapture:      C.rsac_capabilities_supports_app_capture(ccaps) == 1,
-		SupportsProcessTree:     C.rsac_capabilities_supports_process_tree(ccaps) == 1,
-		SupportsDeviceSelection: C.rsac_capabilities_supports_device_selection(ccaps) == 1,
-		RequiresUserConsent:     C.rsac_capabilities_requires_user_consent(ccaps) == 1,
-		BackendName:             backendName,
-		MaxChannels:             int(C.rsac_capabilities_max_channels(ccaps)),
+		SupportsSystemCapture:             C.rsac_capabilities_supports_system_capture(ccaps) == 1,
+		SupportsAppCapture:                C.rsac_capabilities_supports_app_capture(ccaps) == 1,
+		SupportsProcessTree:               C.rsac_capabilities_supports_process_tree(ccaps) == 1,
+		SupportsDeviceSelection:           C.rsac_capabilities_supports_device_selection(ccaps) == 1,
+		SupportsDeviceChangeNotifications: C.rsac_capabilities_supports_device_change_notifications(ccaps) == 1,
+		RequiresUserConsent:               C.rsac_capabilities_requires_user_consent(ccaps) == 1,
+		BackendName:                       backendName,
+		MaxChannels:                       int(C.rsac_capabilities_max_channels(ccaps)),
+		SupportedSampleFormats:            formats,
+		MinSampleRate:                     uint32(C.rsac_capabilities_min_sample_rate(ccaps)),
+		MaxSampleRate:                     uint32(C.rsac_capabilities_max_sample_rate(ccaps)),
+		SupportedSampleRates:              rates,
 	}, nil
 }
 

--- a/bindings/rsac-go/rsac.h
+++ b/bindings/rsac-go/rsac.h
@@ -461,6 +461,12 @@ int32_t rsac_capabilities_supports_process_tree(const RsacCapabilities* caps);
 int32_t rsac_capabilities_supports_device_selection(const RsacCapabilities* caps);
 
 /**
+ * Returns 1 if the backend can deliver device hot-plug / default-change
+ * notifications, 0 if not, -1 if null.
+ */
+int32_t rsac_capabilities_supports_device_change_notifications(const RsacCapabilities* caps);
+
+/**
  * Returns 1 if starting a capture requires a config-time user-consent
  * artifact (mobile platforms; see docs/MOBILE_BACKEND_DESIGN.md), 0 if not,
  * -1 if null. Always 0 on the desktop backends.
@@ -469,6 +475,50 @@ int32_t rsac_capabilities_requires_user_consent(const RsacCapabilities* caps);
 
 /** Returns the maximum number of channels supported. Returns 0 if null. */
 uint16_t rsac_capabilities_max_channels(const RsacCapabilities* caps);
+
+/**
+ * Returns the number of sample formats the backend supports.
+ * Returns 0 if null.
+ */
+size_t rsac_capabilities_supported_sample_format_count(const RsacCapabilities* caps);
+
+/**
+ * Returns the supported sample format at `index` as one of the
+ * rsac_sample_format_t constants, carried as a plain int32_t. Valid indices
+ * are 0..rsac_capabilities_supported_sample_format_count(). Returns -1 if
+ * the handle is null or `index` is out of bounds.
+ */
+int32_t rsac_capabilities_supported_sample_format_at(const RsacCapabilities* caps,
+                                                     size_t index);
+
+/**
+ * Returns the minimum of the backend's device-negotiable sample-rate range,
+ * in Hz. Returns 0 if null.
+ */
+uint32_t rsac_capabilities_min_sample_rate(const RsacCapabilities* caps);
+
+/**
+ * Returns the maximum of the backend's device-negotiable sample-rate range,
+ * in Hz. Returns 0 if null.
+ */
+uint32_t rsac_capabilities_max_sample_rate(const RsacCapabilities* caps);
+
+/**
+ * Returns the number of entries in the builder's config-time sample-rate
+ * whitelist (the exact set rsac_builder_set_sample_rate() values are
+ * validated against at rsac_builder_build(); narrower than the min/max
+ * device-negotiable range above). Returns 0 if null.
+ */
+size_t rsac_capabilities_supported_sample_rate_count(const RsacCapabilities* caps);
+
+/**
+ * Returns the config-time whitelisted sample rate at `index`, in Hz. Valid
+ * indices are 0..rsac_capabilities_supported_sample_rate_count(). Returns 0
+ * if the handle is null or `index` is out of bounds (0 is never a valid
+ * sample rate).
+ */
+uint32_t rsac_capabilities_supported_sample_rate_at(const RsacCapabilities* caps,
+                                                    size_t index);
 
 /**
  * Returns the backend name (e.g. "WASAPI", "CoreAudio", "PipeWire").


### PR DESCRIPTION
## Summary
The remaining FFI leg of the Critical capability-parity seed: 7 additive extern C accessors in rsac-ffi (no existing symbol touched) so Go can project the full PlatformCapabilities surface that Python/Node already expose (fdf0854):

- rsac_capabilities_supports_device_change_notifications
- rsac_capabilities_supported_sample_format_count / _supported_sample_format_at
- rsac_capabilities_min_sample_rate / _max_sample_rate
- rsac_capabilities_supported_sample_rate_count / _supported_sample_rate_at (single-sourced from the SUPPORTED_SAMPLE_RATES builder contract)

Go: Capabilities gains SupportsDeviceChangeNotifications / SupportedSampleFormats / Min+MaxSampleRate / SupportedSampleRates, projected in PlatformCapabilities() (compile-unverified locally - MSVC host, no cgo; the CI Go leg is the backstop).

Headers: rsac_generated.h regenerated via build.rs/cbindgen (diff = exactly the 7 new declarations, byte-identical bare vs compose builds); curated rsac.h + Go mirror hand-updated; local replica of ci.yml's symbol extractor shows 112 symbols identical on both sides.

## Verification
- cargo test -p rsac-ffi: 23 passed (4 new accessor tests, device-free)
- cargo build -p rsac-ffi (cdylib+staticlib), fmt, clippy -p rsac-ffi --all-targets -D warnings (bare + compose): clean

## Remaining for full parity (follow-up seeds)
Field-by-field equality harness across bindings; a Go TestCapabilities in the CI test-pure filter.

Seed: rsac-a9af (FFI leg; closes on merge with evidence).