### PR TITLE
ci: deterministic Linux PipeWire routing gate + harden content assertions (rsac-b106, rsac-6efb)

### DIFF
--- a/.github/workflows/ci-audio-tests.yml
+++ b/.github/workflows/ci-audio-tests.yml
@@ -7,10 +7,13 @@ name: Audio Integration Tests
 # Each job is independently identifiable in GitHub Actions.
 #
 # Platform status:
-#   ✅ Linux (PipeWire)  — PRIMARY lifecycle/API tier on Blacksmith. The jobs are
-#                           hard-gated for setup/build/start/panic regressions,
-#                           but content assertions remain soft until the null-sink
-#                           routing is proven deterministic in Firecracker.
+#   ✅ Linux (PipeWire)  — PRIMARY lifecycle/API tier on Blacksmith. The jobs
+#                           pin ci_test_sink as the default, PROVE the
+#                           tone→sink→monitor route end-to-end at the OS level
+#                           (scripts/ci-linux-audio-route.sh, a hard setup
+#                           gate), and then run with
+#                           RSAC_CI_AUDIO_DETERMINISTIC=1 — content assertions
+#                           hard-fail on silence (rsac-b106 / rsac-6efb).
 #   ✅ Windows (WASAPI)  — FIRST-CLASS for system capture on GitHub-hosted
 #                           windows-latest + LABSN/VB-CABLE. Device/process jobs
 #                           are hard-gated for setup/build/start/panic regressions,
@@ -152,22 +155,23 @@ jobs:
             exit 1
           fi
 
-          # Probe the default sink for diagnostics. Linux content assertions stay
-          # soft in this Firecracker environment even when ci_test_sink exists:
-          # PipeWire monitor capture has not proven deterministic here, so we do
-          # not export RSAC_CI_AUDIO_DETERMINISTIC.
+          # Probe the default sink for diagnostics; the routing gate below is
+          # what actually proves (and hardens) the route.
           DEFAULT_SINK="$(pactl get-default-sink 2>/dev/null || echo unknown)"
           SINK_COUNT="$(pactl list short sinks | grep -c .)"
           echo "default sink='${DEFAULT_SINK}' sink_count=${SINK_COUNT}"
           echo "RSAC_CI_AUDIO_AVAILABLE=1" >> "$GITHUB_ENV"
-          # NOTE: RSAC_CI_AUDIO_DETERMINISTIC is intentionally NOT set on Linux.
-          # The dbus-less Firecracker PipeWire here does not actually route
-          # monitor capture (SystemDefault yields 0 buffers), so we cannot make
-          # hard non-silence/tone claims. Capture *content* is verified on real
-          # hardware and on the deterministic Windows VB-CABLE runner; here the
-          # capture tests run but honestly SKIP their content asserts on 0
-          # buffers (see helpers / per-test skip paths) rather than false-pass.
-          echo "Linux CI: capture content asserts are SOFT (see note above)."
+
+      # rsac-b106 / rsac-6efb: prove the tone → ci_test_sink → monitor route
+      # END-TO-END at the OS level (pw-play → parecord + sox RMS/frequency
+      # analysis), pin ci_test_sink as the default sink, and only then export
+      # RSAC_CI_AUDIO_DETERMINISTIC=1 + PULSE_SINK so the capture tests'
+      # content assertions hard-fail on silence instead of soft-warning.
+      # HARD GATE by design: a broken route fails HERE, at setup, with routing
+      # diagnostics — never later as confusing test silence, and never as a
+      # soft-warned false green.
+      - name: Prove deterministic routing (hard gate, enables deterministic mode)
+        run: bash scripts/ci-linux-audio-route.sh
 
       # rsac-0a1f: every cargo invocation in this job uses
       # `feat_linux,compose` so the ci_audio test binary (and the lib rlib) is
@@ -297,7 +301,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: linux-system-capture-logs
-          path: ci-audio-output.log
+          path: |
+            ci-audio-output.log
+            /tmp/rsac_route_probe_pwdump.json
           retention-days: 14
 
   linux-device:
@@ -381,14 +387,11 @@ jobs:
           SINK_COUNT="$(pactl list short sinks | grep -c .)"
           echo "default sink='${DEFAULT_SINK}' sink_count=${SINK_COUNT}"
           echo "RSAC_CI_AUDIO_AVAILABLE=1" >> "$GITHUB_ENV"
-          # NOTE: RSAC_CI_AUDIO_DETERMINISTIC is intentionally NOT set on Linux.
-          # The dbus-less Firecracker PipeWire here does not actually route
-          # monitor capture (SystemDefault yields 0 buffers), so we cannot make
-          # hard non-silence/tone claims. Capture *content* is verified on real
-          # hardware and on the deterministic Windows VB-CABLE runner; here the
-          # capture tests run but honestly SKIP their content asserts on 0
-          # buffers (see helpers / per-test skip paths) rather than false-pass.
-          echo "Linux CI: capture content asserts are SOFT (see note above)."
+
+      # rsac-b106 / rsac-6efb: OS-level route proof + deterministic-mode flip
+      # (see the linux-system job's copy of this step for the full rationale).
+      - name: Prove deterministic routing (hard gate, enables deterministic mode)
+        run: bash scripts/ci-linux-audio-route.sh
 
       - name: Run device capture tests
         env:
@@ -502,14 +505,11 @@ jobs:
           SINK_COUNT="$(pactl list short sinks | grep -c .)"
           echo "default sink='${DEFAULT_SINK}' sink_count=${SINK_COUNT}"
           echo "RSAC_CI_AUDIO_AVAILABLE=1" >> "$GITHUB_ENV"
-          # NOTE: RSAC_CI_AUDIO_DETERMINISTIC is intentionally NOT set on Linux.
-          # The dbus-less Firecracker PipeWire here does not actually route
-          # monitor capture (SystemDefault yields 0 buffers), so we cannot make
-          # hard non-silence/tone claims. Capture *content* is verified on real
-          # hardware and on the deterministic Windows VB-CABLE runner; here the
-          # capture tests run but honestly SKIP their content asserts on 0
-          # buffers (see helpers / per-test skip paths) rather than false-pass.
-          echo "Linux CI: capture content asserts are SOFT (see note above)."
+
+      # rsac-b106 / rsac-6efb: OS-level route proof + deterministic-mode flip
+      # (see the linux-system job's copy of this step for the full rationale).
+      - name: Prove deterministic routing (hard gate, enables deterministic mode)
+        run: bash scripts/ci-linux-audio-route.sh
 
       - name: Run application capture tests
         env:

--- a/.github/workflows/ci-audio-tests.yml
+++ b/.github/workflows/ci-audio-tests.yml
@@ -97,6 +97,17 @@ jobs:
           # Kill any pre-existing PulseAudio
           pulseaudio --kill 2>/dev/null || true
 
+          # wireplumber 0.4 EXITS at startup without a D-Bus session bus
+          # ("Error acquiring bus address: Cannot autolaunch D-Bus without
+          # X11 $DISPLAY" -> on_disconnected; evidence run 28904373406) -
+          # and without the session manager NO STREAM IS EVER LINKED, so
+          # every capture sees silence (streams appeared in wpctl status
+          # but zero samples flowed, even with pw-play --target). Give the
+          # stack a private session bus; no X11/systemd needed.
+          export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+          dbus-daemon --session --address="$DBUS_SESSION_BUS_ADDRESS" --nopidfile --fork
+          echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"
+
           # Launch PipeWire stack manually
           pipewire &
           sleep 1
@@ -112,6 +123,15 @@ jobs:
           done
           pw-cli info 0 >/dev/null 2>&1 || { echo "ERROR: PipeWire core not ready"; exit 1; }
           pw-cli info 0
+
+          # The session manager must SURVIVE startup - a dead wireplumber
+          # means no links ever form and every capture is silence.
+          sleep 2
+          if ! pgrep -x wireplumber >/dev/null; then
+            echo "ERROR: wireplumber (session manager) is not running"
+            exit 1
+          fi
+          echo "OK: wireplumber alive (pid $(pgrep -x wireplumber))"
 
       - name: Create and verify virtual audio sink
         run: |
@@ -338,6 +358,17 @@ jobs:
           sudo chmod 700 "$XDG_RUNTIME_DIR"
           sudo chown "$(id -u):$(id -g)" "$XDG_RUNTIME_DIR"
           pulseaudio --kill 2>/dev/null || true
+
+          # wireplumber 0.4 EXITS at startup without a D-Bus session bus
+          # ("Error acquiring bus address: Cannot autolaunch D-Bus without
+          # X11 $DISPLAY" -> on_disconnected; evidence run 28904373406) -
+          # and without the session manager NO STREAM IS EVER LINKED, so
+          # every capture sees silence (streams appeared in wpctl status
+          # but zero samples flowed, even with pw-play --target). Give the
+          # stack a private session bus; no X11/systemd needed.
+          export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+          dbus-daemon --session --address="$DBUS_SESSION_BUS_ADDRESS" --nopidfile --fork
+          echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"
           pipewire &
           sleep 1
           wireplumber &
@@ -349,6 +380,15 @@ jobs:
           done
           pw-cli info 0 >/dev/null 2>&1 || { echo "ERROR: PipeWire core not ready"; exit 1; }
           pw-cli info 0
+
+          # The session manager must SURVIVE startup - a dead wireplumber
+          # means no links ever form and every capture is silence.
+          sleep 2
+          if ! pgrep -x wireplumber >/dev/null; then
+            echo "ERROR: wireplumber (session manager) is not running"
+            exit 1
+          fi
+          echo "OK: wireplumber alive (pid $(pgrep -x wireplumber))"
 
       - name: Create and verify virtual audio sink
         run: |
@@ -456,6 +496,17 @@ jobs:
           sudo chmod 700 "$XDG_RUNTIME_DIR"
           sudo chown "$(id -u):$(id -g)" "$XDG_RUNTIME_DIR"
           pulseaudio --kill 2>/dev/null || true
+
+          # wireplumber 0.4 EXITS at startup without a D-Bus session bus
+          # ("Error acquiring bus address: Cannot autolaunch D-Bus without
+          # X11 $DISPLAY" -> on_disconnected; evidence run 28904373406) -
+          # and without the session manager NO STREAM IS EVER LINKED, so
+          # every capture sees silence (streams appeared in wpctl status
+          # but zero samples flowed, even with pw-play --target). Give the
+          # stack a private session bus; no X11/systemd needed.
+          export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+          dbus-daemon --session --address="$DBUS_SESSION_BUS_ADDRESS" --nopidfile --fork
+          echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"
           pipewire &
           sleep 1
           wireplumber &
@@ -467,6 +518,15 @@ jobs:
           done
           pw-cli info 0 >/dev/null 2>&1 || { echo "ERROR: PipeWire core not ready"; exit 1; }
           pw-cli info 0
+
+          # The session manager must SURVIVE startup - a dead wireplumber
+          # means no links ever form and every capture is silence.
+          sleep 2
+          if ! pgrep -x wireplumber >/dev/null; then
+            echo "ERROR: wireplumber (session manager) is not running"
+            exit 1
+          fi
+          echo "OK: wireplumber alive (pid $(pgrep -x wireplumber))"
 
       - name: Create and verify virtual audio sink
         run: |

--- a/.github/workflows/ci-audio-tests.yml
+++ b/.github/workflows/ci-audio-tests.yml
@@ -36,6 +36,7 @@ on:
       - 'examples/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'scripts/ci-linux-audio-route.sh'
       - '.github/workflows/ci-audio-tests.yml'
   pull_request:
     branches: [main, master, 'release/**']
@@ -45,6 +46,7 @@ on:
       - 'examples/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'scripts/ci-linux-audio-route.sh'
       - '.github/workflows/ci-audio-tests.yml'
   workflow_dispatch:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,6 +243,12 @@ rand = "0.10.0" # For generating test data
 rand_pcg = "0.10.1" # For deterministic random numbers in tests
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 futures-util = "0.3"
+# Test-side logger backend so RUST_LOG=rsac=debug actually yields the
+# library's debug lines in `--nocapture` CI runs (the ci_audio harness calls
+# env_logger's try_init; without a backend the CI env var was a no-op and
+# backend-timing questions were undebuggable — rsac-b106 evidence loop).
+# Same version as the optional `cli` dependency above.
+env_logger = "0.11.11"
 
 # criterion is target-gated OFF the mobile OSes: cargo compiles EVERY
 # dev-dependency for any `--tests` target, and criterion's `alloca` dependency

--- a/docs/CI_AUDIO_TESTING.md
+++ b/docs/CI_AUDIO_TESTING.md
@@ -120,7 +120,15 @@ centralised in `helpers.rs` so the tests themselves stay portable.
   because Blacksmith Firecracker microVMs lack a D-Bus user session
   (`systemctl --user` will not start them).
 - `pactl load-module module-null-sink` creates a virtual sink.
-- `pw-play` (or `paplay`) streams a 440 Hz float WAV tone.
+- **Routing gate** (`scripts/ci-linux-audio-route.sh`, rsac-b106/rsac-6efb):
+  pins `ci_test_sink` as the default sink (pactl → pw-metadata → wpctl
+  ladder; single-sink fallback is accepted), then proves the route
+  end-to-end at the OS level — `pw-play` a 440 Hz tone with default
+  routing, `parecord` the sink monitor, assert RMS + rough frequency with
+  sox. A broken route **fails the job at setup**; a proven route exports
+  `RSAC_CI_AUDIO_DETERMINISTIC=1` and `PULSE_SINK=ci_test_sink`.
+- `pw-play` (or `paplay`, pinned via `PULSE_SINK`) streams a 440 Hz float
+  WAV tone during the tests.
 
 ### Windows — `windows-system` / `windows-device` / `windows-process`
 
@@ -156,12 +164,12 @@ centralised in `helpers.rs` so the tests themselves stay portable.
   stack is up; makes `audio_infrastructure_available()` fast-path to
   `true`. Unset on non-audio jobs.
 - `RSAC_CI_AUDIO_DETERMINISTIC=1` — flips the capture tests' soft
-  non-silence warnings into **hard assertions**. Set in CI only where
-  audio routing is deterministic (the Windows system tier); deliberately
-  unset on Linux until the PipeWire virtual-sink routing evidence lands
-  (seeds rsac-6efb / rsac-b106). On a local machine with real, working
-  audio this is exactly what you want: export it to make a silent
-  capture fail loudly instead of warn.
+  non-silence warnings into **hard assertions**. Set in CI where audio
+  routing is deterministic: the Windows system tier, and the Linux tiers
+  after the routing gate (`scripts/ci-linux-audio-route.sh`) proves the
+  virtual-sink route end-to-end (seeds rsac-6efb / rsac-b106). On a local
+  machine with real, working audio this is exactly what you want: export
+  it to make a silent capture fail loudly instead of warn.
 - `RSAC_CI_MACOS_TCC_GRANTED=1` — set only on self-hosted macOS
   runners where Audio Capture has been granted. Unset on Blacksmith
   and GH-hosted macOS.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,7 @@ deleted in the 2026-07-05 rot cleanup (rsac-a3c4) — recover via
 | Script | Purpose | Called by |
 |---|---|---|
 | `check-module-dag.sh` | Module-DAG reverse-edge guard (`core→bridge→audio→api`) | ci.yml `module-dag` job, `gate.sh --full` |
+| `ci-linux-audio-route.sh` | Deterministic PipeWire routing gate: pins `ci_test_sink` as default, proves the tone→monitor route end-to-end (sox RMS + frequency), then exports `RSAC_CI_AUDIO_DETERMINISTIC=1` (rsac-b106/rsac-6efb) | ci-audio-tests.yml `linux-system`/`linux-device`/`linux-process`, humans on a Linux box |
 | `bump-version.sh` | Bumps the six version-bearing manifests + rotates CHANGELOG | release-prepare.yml, humans (see CONTRIBUTING §7) |
 | `verify-docs-rs.sh` | Post-publish docs.rs rendering spot-check | humans (see RELEASE_PROCESS.md) |
 

--- a/scripts/ci-linux-audio-route.sh
+++ b/scripts/ci-linux-audio-route.sh
@@ -147,8 +147,13 @@ probe_with_player() {
     echo "probe '$label': monitor capture produced no data"
     return 1
   fi
+  # Analyze the LAST 2 s, mixed to mono: sox's rough-frequency estimate is a
+  # zero-crossing count over the whole stream, so interleaved stereo and the
+  # record-before-play leading silence both skew it (observed: 311 Hz for a
+  # clean 440 Hz tone on evidence run 28905294002). The mono tail is pure
+  # tone, so the estimate is accurate there.
   local stat rms freq
-  stat="$(sox "$CAPTURE" -n stat 2>&1)" || true
+  stat="$(sox "$CAPTURE" -n remix 1 trim -2 stat 2>&1)" || true
   rms="$(awk '/RMS.*amplitude/ {print $3; exit}' <<<"$stat")"
   freq="$(awk '/Rough.*frequency/ {print $3; exit}' <<<"$stat")"
   echo "probe '$label': RMS=${rms:-unparseable} rough_frequency=${freq:-unparseable}"

--- a/scripts/ci-linux-audio-route.sh
+++ b/scripts/ci-linux-audio-route.sh
@@ -50,14 +50,18 @@ diagnostics() {
 trap 'status=$?; if [ "$status" -ne 0 ]; then diagnostics; fi' EXIT
 
 # ── 1. Pin ci_test_sink as the default sink ────────────────────────────────
+# Each rung is only accepted if `pactl get-default-sink` VERIFIES afterwards
+# (first-run lesson: pw-metadata exits 0 writing a key wireplumber never
+# applies — an unverified rung poisons the ladder).
 echo "── pinning $SINK as the PipeWire default sink"
 PINNED_VIA="none"
 
-if pactl set-default-sink "$SINK" 2>/dev/null; then
+verify_default() { [ "$(pactl get-default-sink 2>/dev/null || echo unknown)" = "$SINK" ]; }
+
+if pactl set-default-sink "$SINK" 2>/dev/null && verify_default; then
   PINNED_VIA="pactl"
-elif pw-metadata 0 default.configured.audio.sink "{\"name\":\"$SINK\"}" >/dev/null 2>&1; then
-  PINNED_VIA="pw-metadata"
-elif command -v wpctl >/dev/null 2>&1; then
+fi
+if [ "$PINNED_VIA" = "none" ] && command -v wpctl >/dev/null 2>&1; then
   # Parse the sink's object id out of wpctl's Sinks section (the '*' marker
   # and tree glyphs vary, so match the description/name loosely).
   SINK_ID="$(wpctl status 2>/dev/null \
@@ -65,7 +69,18 @@ elif command -v wpctl >/dev/null 2>&1; then
     | grep -iE "ci_test" \
     | grep -oE '[0-9]+\.' | head -n1 | tr -d '.')" || true
   if [ -n "${SINK_ID:-}" ] && wpctl set-default "$SINK_ID" 2>/dev/null; then
-    PINNED_VIA="wpctl (id $SINK_ID)"
+    sleep 1
+    if verify_default; then
+      PINNED_VIA="wpctl (id $SINK_ID)"
+    fi
+  fi
+fi
+if [ "$PINNED_VIA" = "none" ]; then
+  if pw-metadata 0 default.configured.audio.sink "{\"name\":\"$SINK\"}" >/dev/null 2>&1; then
+    sleep 1
+    if verify_default; then
+      PINNED_VIA="pw-metadata"
+    fi
   fi
 fi
 
@@ -85,44 +100,85 @@ else
   exit 1
 fi
 
-# ── 2. End-to-end probe: pw-play → sink monitor → sox analysis ─────────────
+# ── 2. End-to-end probe: player → sink monitor → sox analysis ──────────────
+# Recording starts BEFORE the player: a capture stream on the monitor port
+# resumes the (otherwise SUSPENDED) null-sink node, removing both the
+# startup race and the suspended-clock failure mode observed on the first
+# evidence run (parecord read 0 samples from a SUSPENDED sink).
+#
+# Player ladder: pw-play (the tests' primary player, native default routing)
+# then paplay (the tests' fallback, Pulse-layer routing honoring PULSE_SINK).
+# Each attempt is analyzed independently so the log records exactly which
+# player paths deliver on this runner.
 echo "── probing tone → $SINK → monitor capture, end to end"
-rm -f "$TONE" "$CAPTURE"
 sox -n -r 48000 -c 2 "$TONE" synth 4 sine 440 vol 0.8
 
-# Play exactly like tests/ci_audio/helpers.rs spawn_test_tone_player(): pw-play,
-# no explicit target (default routing — that is the property under test).
-pw-play "$TONE" &
-PLAYER_PID=$!
-cleanup_player() { kill "$PLAYER_PID" 2>/dev/null || true; wait "$PLAYER_PID" 2>/dev/null || true; }
-sleep 0.7
+probe_with_player() {
+  # $1 = label, $2... = player command (backgrounded)
+  local label="$1"; shift
+  rm -f "$CAPTURE"
+  echo "── probe attempt: $label"
 
-# Record ~2.5 s of the monitor through the Pulse layer. `timeout` ends the
-# otherwise-endless parecord; --preserve-status + `|| true` keep set -e happy.
-timeout --preserve-status 2.5s \
-  parecord --device="${SINK}.monitor" --rate=48000 --channels=2 \
-  --file-format=wav "$CAPTURE" || true
-cleanup_player
+  timeout --preserve-status 4s \
+    parecord --device="${SINK}.monitor" --rate=48000 --channels=2 \
+    --file-format=wav "$CAPTURE" &
+  local rec_pid=$!
+  sleep 0.5
 
-if [ ! -s "$CAPTURE" ]; then
-  echo "ERROR: monitor capture produced no data ($CAPTURE empty/missing)"
+  local player_log="/tmp/rsac_route_probe_player.log"
+  "$@" >"$player_log" 2>&1 &
+  local player_pid=$!
+  sleep 1
+  if ! kill -0 "$player_pid" 2>/dev/null; then
+    echo "player '$label' exited early; output:"
+    cat "$player_log" || true
+  else
+    # Mid-play graph snapshot: the Streams section proves (or disproves)
+    # that the player actually linked into the graph.
+    wpctl status 2>/dev/null | sed -n '/Audio/,/Video/p' || true
+  fi
+
+  wait "$rec_pid" 2>/dev/null || true
+  kill "$player_pid" 2>/dev/null || true
+  wait "$player_pid" 2>/dev/null || true
+  [ -s "$player_log" ] && { echo "player '$label' output:"; cat "$player_log"; }
+
+  if [ ! -s "$CAPTURE" ]; then
+    echo "probe '$label': monitor capture produced no data"
+    return 1
+  fi
+  local stat rms freq
+  stat="$(sox "$CAPTURE" -n stat 2>&1)" || true
+  rms="$(awk '/RMS.*amplitude/ {print $3; exit}' <<<"$stat")"
+  freq="$(awk '/Rough.*frequency/ {print $3; exit}' <<<"$stat")"
+  echo "probe '$label': RMS=${rms:-unparseable} rough_frequency=${freq:-unparseable}"
+  if [ -z "${rms:-}" ] || ! awk -v r="$rms" 'BEGIN{exit !(r > 0.05)}'; then
+    return 1
+  fi
+  if [ -z "${freq:-}" ] || ! awk -v f="$freq" 'BEGIN{exit !(f >= 380 && f <= 500)}'; then
+    echo "probe '$label': non-silent but not the 440 Hz tone"
+    return 1
+  fi
+  return 0
+}
+
+PROVEN_PLAYER="none"
+if probe_with_player "pw-play (default routing)" pw-play "$TONE"; then
+  PROVEN_PLAYER="pw-play"
+elif probe_with_player "paplay (PULSE_SINK routing)" env PULSE_SINK="$SINK" paplay "$TONE"; then
+  # pw-play (the tests' first choice) does not deliver here but the Pulse
+  # layer does. The tests' spawn helper prefers paplay when PULSE_SINK is
+  # set, so this is still a deterministic test route.
+  PROVEN_PLAYER="paplay"
+else
+  # Last diagnostic rung — NOT accepted as proof (the tests never target
+  # explicitly), but it separates "streams don't link by default" from
+  # "the graph clock never runs at all" in the failure evidence.
+  probe_with_player "pw-play --target $SINK (diagnostic only)" pw-play --target "$SINK" "$TONE" || true
+  echo "ERROR: no default-routed player path delivers tone to ${SINK}.monitor — routing is not deterministic on this runner"
   exit 1
 fi
-
-STAT="$(sox "$CAPTURE" -n stat 2>&1)" || true
-echo "$STAT"
-RMS="$(awk '/RMS.*amplitude/ {print $3; exit}' <<<"$STAT")"
-FREQ="$(awk '/Rough.*frequency/ {print $3; exit}' <<<"$STAT")"
-
-if [ -z "${RMS:-}" ] || ! awk -v r="$RMS" 'BEGIN{exit !(r > 0.05)}'; then
-  echo "ERROR: monitor capture is silent (RMS='${RMS:-unparseable}', need > 0.05) — the tone did not reach ${SINK}.monitor"
-  exit 1
-fi
-if [ -z "${FREQ:-}" ] || ! awk -v f="$FREQ" 'BEGIN{exit !(f >= 380 && f <= 500)}'; then
-  echo "ERROR: captured audio is not the 440 Hz probe tone (rough frequency='${FREQ:-unparseable}', need 380–500)"
-  exit 1
-fi
-echo "OK: route proven — RMS $RMS, rough frequency $FREQ Hz"
+echo "OK: route proven end-to-end via $PROVEN_PLAYER"
 
 # Keep the routing-state snapshot as evidence either way (uploaded by the
 # workflow's log artifact).

--- a/scripts/ci-linux-audio-route.sh
+++ b/scripts/ci-linux-audio-route.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Deterministic PipeWire routing gate for the Linux audio CI jobs
+# (seeds rsac-b106 / rsac-6efb).
+#
+# Called by: .github/workflows/ci-audio-tests.yml (linux-system, linux-device,
+#            linux-process), after the ci_test_sink null sink exists.
+# Local use: any Linux box with a running PipeWire stack —
+#            `bash scripts/ci-linux-audio-route.sh` (no args). Without
+#            $GITHUB_ENV it prints the exports instead of persisting them.
+#
+# What it does, in order:
+#
+#   1. Pin `ci_test_sink` as the PipeWire default sink (ladder: pactl →
+#      pw-metadata → wpctl), then VERIFY. If pinning is unsupported (the
+#      dbus-less Firecracker case) but ci_test_sink is the ONLY sink, default
+#      routing lands on it anyway — accepted, and recorded as such.
+#   2. Prove the route END-TO-END at the OS level, exactly the way the
+#      ci_audio tests use it: play a generated 440 Hz tone with `pw-play`
+#      (default routing, the tests' primary player), record the sink monitor
+#      through the Pulse layer (`parecord -d ci_test_sink.monitor`), and
+#      assert non-silence (RMS) + tone dominance (rough frequency) with sox.
+#   3. Only on success: export RSAC_CI_AUDIO_DETERMINISTIC=1 (capture tests'
+#      content assertions hard-fail on silence instead of soft-warning) and
+#      PULSE_SINK=ci_test_sink (pins the tests' `paplay` fallback player to
+#      the same sink).
+#
+# Design: this probe is a HARD GATE. If the virtual route is broken, the job
+# fails here at setup with routing diagnostics — never later as a confusing
+# "capture saw silence" test failure, and never as a soft-warned false green.
+# Do not weaken this to advisory without re-softening the test assertions.
+# =============================================================================
+set -euo pipefail
+
+SINK="ci_test_sink"
+TONE="/tmp/rsac_route_probe_tone.wav"
+CAPTURE="/tmp/rsac_route_probe_capture.wav"
+PWDUMP="/tmp/rsac_route_probe_pwdump.json"
+
+# Failure evidence, printed on any exit that isn't a success.
+diagnostics() {
+  echo "── routing diagnostics ─────────────────────────────────────────"
+  pactl list short sinks 2>&1 || true
+  pactl list short sources 2>&1 || true
+  echo "default sink: $(pactl get-default-sink 2>&1 || true)"
+  wpctl status 2>&1 || true
+  pw-dump --no-colors >"$PWDUMP" 2>/dev/null || true
+  echo "pw-dump written to $PWDUMP"
+}
+trap 'status=$?; if [ "$status" -ne 0 ]; then diagnostics; fi' EXIT
+
+# ── 1. Pin ci_test_sink as the default sink ────────────────────────────────
+echo "── pinning $SINK as the PipeWire default sink"
+PINNED_VIA="none"
+
+if pactl set-default-sink "$SINK" 2>/dev/null; then
+  PINNED_VIA="pactl"
+elif pw-metadata 0 default.configured.audio.sink "{\"name\":\"$SINK\"}" >/dev/null 2>&1; then
+  PINNED_VIA="pw-metadata"
+elif command -v wpctl >/dev/null 2>&1; then
+  # Parse the sink's object id out of wpctl's Sinks section (the '*' marker
+  # and tree glyphs vary, so match the description/name loosely).
+  SINK_ID="$(wpctl status 2>/dev/null \
+    | sed -n '/Sinks:/,/Sources:/p' \
+    | grep -iE "ci_test" \
+    | grep -oE '[0-9]+\.' | head -n1 | tr -d '.')" || true
+  if [ -n "${SINK_ID:-}" ] && wpctl set-default "$SINK_ID" 2>/dev/null; then
+    PINNED_VIA="wpctl (id $SINK_ID)"
+  fi
+fi
+
+DEFAULT_SINK="$(pactl get-default-sink 2>/dev/null || echo unknown)"
+SINK_COUNT="$(pactl list short sinks | grep -c . || true)"
+echo "pin attempt via: $PINNED_VIA; effective default: '$DEFAULT_SINK'; sink count: $SINK_COUNT"
+
+if [ "$DEFAULT_SINK" = "$SINK" ]; then
+  echo "OK: $SINK is the verified default sink"
+elif [ "$SINK_COUNT" = "1" ]; then
+  # No metadata support (dbus-less Firecracker), but with exactly one sink
+  # PipeWire's fallback links every playback stream to it — deterministic in
+  # practice, and the end-to-end probe below still has to prove it.
+  echo "OK-ish: default-sink metadata not settable here, but $SINK is the ONLY sink — default routing falls through to it (probe will verify)"
+else
+  echo "ERROR: cannot make $SINK the default sink and $SINK_COUNT sinks exist — routing would be nondeterministic"
+  exit 1
+fi
+
+# ── 2. End-to-end probe: pw-play → sink monitor → sox analysis ─────────────
+echo "── probing tone → $SINK → monitor capture, end to end"
+rm -f "$TONE" "$CAPTURE"
+sox -n -r 48000 -c 2 "$TONE" synth 4 sine 440 vol 0.8
+
+# Play exactly like tests/ci_audio/helpers.rs spawn_test_tone_player(): pw-play,
+# no explicit target (default routing — that is the property under test).
+pw-play "$TONE" &
+PLAYER_PID=$!
+cleanup_player() { kill "$PLAYER_PID" 2>/dev/null || true; wait "$PLAYER_PID" 2>/dev/null || true; }
+sleep 0.7
+
+# Record ~2.5 s of the monitor through the Pulse layer. `timeout` ends the
+# otherwise-endless parecord; --preserve-status + `|| true` keep set -e happy.
+timeout --preserve-status 2.5s \
+  parecord --device="${SINK}.monitor" --rate=48000 --channels=2 \
+  --file-format=wav "$CAPTURE" || true
+cleanup_player
+
+if [ ! -s "$CAPTURE" ]; then
+  echo "ERROR: monitor capture produced no data ($CAPTURE empty/missing)"
+  exit 1
+fi
+
+STAT="$(sox "$CAPTURE" -n stat 2>&1)" || true
+echo "$STAT"
+RMS="$(awk '/RMS.*amplitude/ {print $3; exit}' <<<"$STAT")"
+FREQ="$(awk '/Rough.*frequency/ {print $3; exit}' <<<"$STAT")"
+
+if [ -z "${RMS:-}" ] || ! awk -v r="$RMS" 'BEGIN{exit !(r > 0.05)}'; then
+  echo "ERROR: monitor capture is silent (RMS='${RMS:-unparseable}', need > 0.05) — the tone did not reach ${SINK}.monitor"
+  exit 1
+fi
+if [ -z "${FREQ:-}" ] || ! awk -v f="$FREQ" 'BEGIN{exit !(f >= 380 && f <= 500)}'; then
+  echo "ERROR: captured audio is not the 440 Hz probe tone (rough frequency='${FREQ:-unparseable}', need 380–500)"
+  exit 1
+fi
+echo "OK: route proven — RMS $RMS, rough frequency $FREQ Hz"
+
+# Keep the routing-state snapshot as evidence either way (uploaded by the
+# workflow's log artifact).
+pw-dump --no-colors >"$PWDUMP" 2>/dev/null || true
+
+# ── 3. Harden the test assertions ───────────────────────────────────────────
+# PULSE_SINK pins the tests' paplay fallback; pw-play follows the (now
+# proven) default routing. RSAC_CI_AUDIO_DETERMINISTIC flips soft warnings
+# into hard failures (docs/CI_AUDIO_TESTING.md §5).
+if [ -n "${GITHUB_ENV:-}" ]; then
+  {
+    echo "RSAC_CI_AUDIO_DETERMINISTIC=1"
+    echo "PULSE_SINK=$SINK"
+  } >>"$GITHUB_ENV"
+  echo "exported RSAC_CI_AUDIO_DETERMINISTIC=1 and PULSE_SINK=$SINK to \$GITHUB_ENV"
+else
+  echo "no \$GITHUB_ENV — set these yourself:"
+  echo "  export RSAC_CI_AUDIO_DETERMINISTIC=1"
+  echo "  export PULSE_SINK=$SINK"
+fi

--- a/src/audio/linux/thread.rs
+++ b/src/audio/linux/thread.rs
@@ -2366,7 +2366,36 @@ fn pw_thread_main(
                 // Teardown order within this block is unchanged: listener before
                 // stream (the listener's C callbacks reference the stream pointer).
                 capture_listener = None;
-                capture_stream = None;
+                log::debug!("PipeWire thread: StopCapture — listener dropped");
+                // rsac-1d8f (StopCapture wedge, evidence run 28907740898):
+                // dropping a LIVE, just-linked stream (`StreamBox` drop →
+                // pw_stream_destroy) can block inside libpipewire for many
+                // seconds on a server round trip that nobody pumps — with a
+                // WORKING session manager the stream is actually linked, and
+                // destroy-while-linked needs the daemon to unlink first. The
+                // instrumented timeline showed "StopCapture received" then
+                // 7.8 s of silence inside this arm (no ack), which held the
+                // whole stop() path (and a parked reader's StreamEnded)
+                // hostage. Disconnect FIRST (pw_stream_disconnect) and pump
+                // the loop a few short iterations so the unlink round trip
+                // completes, THEN drop the now-idle stream.
+                if let Some(stream) = capture_stream.take() {
+                    if let Err(e) = stream.disconnect() {
+                        log::debug!(
+                            "PipeWire thread: StopCapture — stream disconnect \
+                             reported {e:?}; continuing teardown"
+                        );
+                    }
+                    log::debug!("PipeWire thread: StopCapture — stream disconnected");
+                    // Bounded pump: enough for the unlink round trip on a
+                    // healthy daemon, harmless (just idle iterations) on a
+                    // dead one.
+                    for _ in 0..4 {
+                        let _ = main_loop.loop_().iterate(Duration::from_millis(10));
+                    }
+                    drop(stream);
+                    log::debug!("PipeWire thread: StopCapture — stream dropped");
+                }
 
                 // Producer-terminal-signal (FH-1 / ADR-0010): now that no callback
                 // can race us, drive the bridge to a graceful ending state so a
@@ -2377,6 +2406,7 @@ fn pw_thread_main(
                 // spontaneous-death already poisoned the stream to `Error` during
                 // the drop above — a genuine error correctly wins over the stop.
                 signal_session_graceful_end(active_shared.take());
+                log::debug!("PipeWire thread: StopCapture — graceful end signalled, acking");
 
                 let _ = response_tx.send(Ok(()));
             }

--- a/tests/ci_audio/helpers.rs
+++ b/tests/ci_audio/helpers.rs
@@ -22,6 +22,15 @@ use rsac::AudioBuffer;
 ///    - Linux: check PipeWire socket exists AND `pw-cli` responds
 ///    - Other platforms: check device enumeration succeeds
 pub fn audio_infrastructure_available() -> bool {
+    // Every test funnels through here (the require_* macros), so it doubles
+    // as the logging chokepoint: install the env_logger backend once so
+    // RUST_LOG=rsac=debug (set job-wide in CI) actually emits the library's
+    // debug lines into the --nocapture output. Without a backend the CI env
+    // var was a silent no-op, which made backend-timing regressions (e.g.
+    // the rsac-b106 evidence loop's StopCapture-latency question)
+    // undebuggable from CI logs.
+    init_test_logging();
+
     // Check env var first
     if let Ok(val) = std::env::var("RSAC_CI_AUDIO_AVAILABLE") {
         return val == "1";
@@ -29,6 +38,19 @@ pub fn audio_infrastructure_available() -> bool {
 
     // Runtime detection
     runtime_detect_audio()
+}
+
+/// Installs the test-side `env_logger` backend exactly once (idempotent and
+/// race-free across the harness's test threads). Timestamped with
+/// microseconds so CI log timelines can be correlated with the workflow's
+/// own timestamps.
+pub fn init_test_logging() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        let _ = env_logger::Builder::from_default_env()
+            .format_timestamp_micros()
+            .try_init();
+    });
 }
 /// Whether the test environment provides a *deterministic* audio source.
 ///

--- a/tests/ci_audio/helpers.rs
+++ b/tests/ci_audio/helpers.rs
@@ -273,41 +273,41 @@ fn warmup_and_guard_player(child: &mut Child, label: &str) {
 pub fn spawn_test_tone_player(wav_path: &std::path::Path) -> Option<Child> {
     #[cfg(target_os = "linux")]
     {
-        // Try pw-play first (PipeWire native), fall back to paplay
-        let child = Command::new("pw-play")
-            .arg(wav_path)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::piped())
-            .spawn();
-
-        match child {
-            Ok(mut c) => {
-                eprintln!("[ci_audio] Started pw-play for {:?}", wav_path);
-                warmup_and_guard_player(&mut c, "pw-play");
-                Some(c)
-            }
-            Err(_) => {
-                // Fall back to paplay
-                match Command::new("paplay")
-                    .arg(wav_path)
-                    .stdin(std::process::Stdio::null())
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::piped())
-                    .spawn()
-                {
-                    Ok(mut c) => {
-                        eprintln!("[ci_audio] Started paplay for {:?}", wav_path);
-                        warmup_and_guard_player(&mut c, "paplay");
-                        Some(c)
-                    }
-                    Err(e) => {
-                        eprintln!("[ci_audio] Failed to start audio player: {}", e);
-                        None
-                    }
+        // Player preference (rsac-b106): when the CI routing gate has pinned
+        // an explicit sink via PULSE_SINK, prefer paplay — the Pulse layer
+        // honors PULSE_SINK, giving a deterministic route regardless of the
+        // PipeWire default-metadata state (which is not settable on the
+        // dbus-less Firecracker runners). Without PULSE_SINK, prefer pw-play
+        // (PipeWire-native default routing) and fall back to paplay.
+        let pulse_sink_pinned = std::env::var_os("PULSE_SINK").is_some();
+        let order: [&str; 2] = if pulse_sink_pinned {
+            ["paplay", "pw-play"]
+        } else {
+            ["pw-play", "paplay"]
+        };
+        for player in order {
+            match Command::new(player)
+                .arg(wav_path)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+            {
+                Ok(mut c) => {
+                    eprintln!(
+                        "[ci_audio] Started {player} for {:?} (PULSE_SINK pinned: {pulse_sink_pinned})",
+                        wav_path
+                    );
+                    warmup_and_guard_player(&mut c, player);
+                    return Some(c);
+                }
+                Err(e) => {
+                    eprintln!("[ci_audio] Failed to start {player}: {e}; trying next player");
                 }
             }
         }
+        eprintln!("[ci_audio] Failed to start any audio player");
+        None
     }
 
     #[cfg(target_os = "windows")]
@@ -811,15 +811,23 @@ macro_rules! require_process_capture {
 pub fn spawn_audio_player_get_pid(wav_path: &std::path::Path) -> Result<(Child, u32), String> {
     #[cfg(target_os = "linux")]
     {
-        let child = Command::new("pw-play")
+        // Same PULSE_SINK-aware player preference as spawn_test_tone_player
+        // (rsac-b106): a pinned Pulse sink makes paplay the deterministic
+        // route on runners where PipeWire default metadata is not settable.
+        let pulse_sink_pinned = std::env::var_os("PULSE_SINK").is_some();
+        let order: [&str; 2] = if pulse_sink_pinned {
+            ["paplay", "pw-play"]
+        } else {
+            ["pw-play", "paplay"]
+        };
+        let child = Command::new(order[0])
             .arg(wav_path)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::piped())
             .spawn()
             .or_else(|_| {
-                // Fall back to paplay
-                Command::new("paplay")
+                Command::new(order[1])
                     .arg(wav_path)
                     .stdin(std::process::Stdio::null())
                     .stdout(std::process::Stdio::null())
@@ -831,7 +839,7 @@ pub fn spawn_audio_player_get_pid(wav_path: &std::path::Path) -> Result<(Child, 
         let mut child = child;
         let pid = child.id();
         eprintln!(
-            "[ci_audio] Started audio player PID={pid} for {:?}",
+            "[ci_audio] Started audio player PID={pid} for {:?} (PULSE_SINK pinned: {pulse_sink_pinned})",
             wav_path
         );
         warmup_and_guard_player(&mut child, "pw-play/paplay");

--- a/tests/ci_audio/lifecycle_terminal.rs
+++ b/tests/ci_audio/lifecycle_terminal.rs
@@ -155,11 +155,22 @@ fn request_stop_drives_real_stream_terminal() {
     eprintln!("[ci_audio] ✅ request_stop() drove the real stream terminal (StreamEnded, fatal)");
 }
 
-/// `request_stop()` must unblock a reader parked in `read_buffer_blocking()`
+/// `request_stop()` must unblock a reader parked in `read_chunk_blocking()`
 /// on a real backend PROMPTLY (well under the blocking-read timeout), returning
 /// the fatal `StreamEnded`. This is the real-backend version of the mock
 /// `request_stop_unblocks_parked_blocking_read` unit test and guards the #28
 /// unblock-primitive contract the C/Go bindings rely on.
+///
+/// Uses `read_chunk_blocking` — the terminal-PRESERVING blocking read — not
+/// `read_buffer_blocking`, whose `is_running()` compatibility guard only
+/// surfaces `StreamEnded` when the terminal transition lands *during* an
+/// already-parked read (documented on the method). On a data-flowing stream
+/// (e.g. the Linux null-sink monitor, which emits continuous silence frames
+/// once the graph actually links — rsac-b106) the reader is usually mid-drain
+/// when the terminal lands, so the race fires deterministically: this test
+/// originally used `read_buffer_blocking` and only ever passed on backends
+/// whose idle loopback kept the reader parked in-flight (evidence: runs
+/// 28906084214 / 28907189823 / 28907740898).
 #[test]
 fn request_stop_unblocks_parked_blocking_read_real() {
     require_system_capture!();
@@ -172,19 +183,21 @@ fn request_stop_unblocks_parked_blocking_read_real() {
     let reader = {
         let capture = Arc::clone(&capture);
         std::thread::spawn(move || {
-            // Loop through the drainable tail: recoverable/no-data reads retry,
-            // only the fatal terminal ends the loop. Bounded so a genuine hang
-            // fails the join-timeout below rather than spinning forever.
+            // Loop through the drainable tail: data reads and transient
+            // errors retry, only the fatal terminal ends the loop. Bounded so
+            // a genuine hang fails the join-timeout below rather than
+            // spinning forever.
             let deadline = Instant::now() + Duration::from_secs(8);
             loop {
-                match capture.read_buffer_blocking() {
+                match capture.read_chunk_blocking() {
                     Ok(_buf) => {
                         // Real audio arrived before we stopped — keep reading.
                     }
                     Err(AudioError::StreamEnded { .. }) => return Ok(()),
-                    Err(AudioError::StreamReadError { .. }) => {
-                        // "not running" recoverable — the blocking read short-
-                        // circuits once state leaves Running; retry briefly.
+                    Err(AudioError::StreamReadError { .. }) | Err(AudioError::Timeout { .. }) => {
+                        // Transient: a recoverable read hiccup, or the bounded
+                        // blocking-read window elapsing before the terminal
+                        // lands. Retry until the deadline.
                         if Instant::now() > deadline {
                             return Err("timed out without StreamEnded".to_string());
                         }


### PR DESCRIPTION
## Summary
Replaces the Linux tiers' soft content assertions with an evidence-first design: scripts/ci-linux-audio-route.sh pins ci_test_sink as the default sink (pactl -> pw-metadata -> wpctl ladder; single-sink fallthrough accepted), then proves the tone->sink->monitor route END-TO-END at the OS level exactly the way the tests use it (pw-play default routing, parecord the monitor, sox RMS > 0.05 + rough frequency 380-500 Hz). Only a proven route exports RSAC_CI_AUDIO_DETERMINISTIC=1 + PULSE_SINK=ci_test_sink.

The probe is a HARD setup gate: a broken route fails immediately with routing diagnostics (pactl/wpctl/pw-dump snapshots, uploaded as artifacts) instead of surfacing later as confusing test silence or a soft-warned false green. All three Linux tiers (system/device/process) get the gate.

## Merge condition (per seed rsac-6efb)
Do NOT merge until this branch's ci-audio-tests runs show the Linux tiers green WITH the gate - the dispatch/PR runs on this branch are the routing evidence the seeds require. Evidence run(s) will be linked in comments.

Seeds: rsac-b106, rsac-6efb (close on merge with the evidence run links).