### PR TITLE
ci: promote Windows device/process audio tiers to deterministic via a shared VB-CABLE endpoint gate (rsac-0f33)

### DIFF
--- a/.github/workflows/ci-audio-tests.yml
+++ b/.github/workflows/ci-audio-tests.yml
@@ -14,11 +14,13 @@ name: Audio Integration Tests
 #                           gate), and then run with
 #                           RSAC_CI_AUDIO_DETERMINISTIC=1 — content assertions
 #                           hard-fail on silence (rsac-b106 / rsac-6efb).
-#   ✅ Windows (WASAPI)  — FIRST-CLASS for system capture on GitHub-hosted
-#                           windows-latest + LABSN/VB-CABLE. Device/process jobs
-#                           are hard-gated for setup/build/start/panic regressions,
-#                           but their content assertions remain soft because the
-#                           per-device/per-process tone route is not yet proven.
+#   ✅ Windows (WASAPI)  — FIRST-CLASS on GitHub-hosted windows-latest +
+#                           LABSN/VB-CABLE. All three tiers run DETERMINISTIC:
+#                           the shared endpoint gate
+#                           (scripts/ci-windows-audio-default.ps1) sets and
+#                           hard-verifies VB-CABLE as the default playback
+#                           endpoint, which every tier's tone route flows
+#                           through (rsac-0f33).
 #   ⏳ macOS (CoreAudio) — advisory on managed CI. Process Tap based system,
 #                           application, and process-tree capture require
 #                           kTCCServiceAudioCapture, which cannot be granted
@@ -652,100 +654,14 @@ jobs:
       - name: Install virtual audio (VB-CABLE via LABSN)
         uses: LABSN/sound-ci-helpers@d08c889a7bba7d9b1b059f8f76dac4672ea3a9cf # v1 (v1 tag == v1.0.4, resolved via git ls-remote)
 
-      - name: Set VB-CABLE as default audio device
+      # rsac-0f33: shared deterministic-endpoint gate (set VB-CABLE as the
+      # default playback endpoint with retries, HARD-verify it, then export
+      # RSAC_CI_AUDIO_AVAILABLE=1 + RSAC_CI_AUDIO_DETERMINISTIC=1). Single-
+      # sourced across all three Windows tiers - see the script header for
+      # why the deterministic flip is sound per tier.
+      - name: Set + verify VB-CABLE default endpoint (hard gate, enables deterministic mode)
         shell: pwsh
-        run: |
-          # rsac#24: LABSN installs the VB-CABLE driver via devcon but
-          # does NOT set it as the default playback endpoint — we have
-          # to do that explicitly with AudioDeviceCmdlets
-          # (https://github.com/frgnca/AudioDeviceCmdlets). On
-          # windows-latest VB-CABLE's playback endpoint is named
-          # "Speakers (VB-Audio Virtual Cable)", not "CABLE Input ...",
-          # so the name filter has to accept either form.
-          #
-          # rsac-eb2f: the endpoint can take a few seconds to register with
-          # AudioSrv after the driver installs, so device discovery AND the
-          # Set-AudioDevice call are retried with a bounded backoff instead of
-          # failing the whole (only) hard e2e tier on a provisioning race.
-          Install-Module -Name AudioDeviceCmdlets -Force -Scope CurrentUser 2>$null
-          Import-Module AudioDeviceCmdlets -ErrorAction Stop
-
-          $cable = $null
-          $maxAttempts = 6
-          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-            Write-Host "=== Audio device discovery (attempt $attempt/$maxAttempts) ==="
-            $devices = Get-AudioDevice -List
-            $devices | Format-Table Index, Type, Name, Default -AutoSize
-
-            $cable = $devices | Where-Object {
-              $_.Type -eq "Playback" -and (
-                $_.Name -like "*CABLE Input*" -or
-                $_.Name -like "*VB-Audio*" -or
-                $_.Name -like "*VB-CABLE*"
-              )
-            } | Select-Object -First 1
-
-            if ($cable) {
-              try {
-                Write-Host "Setting VB-CABLE as default playback device: $($cable.Name) (Index=$($cable.Index))"
-                Set-AudioDevice -Index $cable.Index -DefaultOnly
-                break
-              } catch {
-                Write-Host "Set-AudioDevice failed on attempt ${attempt}: $_"
-                $cable = $null
-              }
-            }
-            if ($attempt -lt $maxAttempts) { Start-Sleep -Seconds 5 }
-          }
-
-          if (-not $cable) {
-            Write-Error "No VB-CABLE playback device found after $maxAttempts attempts — LABSN install likely failed"
-            exit 1
-          }
-
-      - name: Verify VB-CABLE is the active default playback
-        # rsac#24: if the default playback isn't VB-CABLE, the test
-        # tone goes to the wrong endpoint and system-capture loopback
-        # sees zero buffers. Fail loudly here instead of wasting 15
-        # minutes on cargo compile + tests that cannot possibly pass.
-        shell: pwsh
-        run: |
-          Import-Module AudioDeviceCmdlets -ErrorAction Stop
-          $playback = Get-AudioDevice -Playback
-          Write-Host "Default playback: $($playback.Name) (Default=$($playback.Default), Type=$($playback.Type))"
-          $isCable = ($playback.Name -like "*VB-Audio*") -or
-                     ($playback.Name -like "*CABLE*") -or
-                     ($playback.Name -like "*VB-CABLE*")
-          if (-not $isCable) {
-            Write-Error "Default playback is NOT VB-CABLE (got: '$($playback.Name)'). System capture loopback cannot succeed."
-            exit 1
-          }
-          Write-Host "OK: VB-CABLE is the default playback endpoint."
-
-      - name: Verify audio devices
-        id: verify_audio
-        shell: pwsh
-        run: |
-          Write-Host "=== Audio Devices ==="
-          $devices = Get-PnpDevice -ErrorAction SilentlyContinue | Where-Object {
-            $_.FriendlyName -like "*VB-Audio*" -or
-            $_.FriendlyName -like "*CABLE*" -or
-            $_.Class -eq "AudioEndpoint" -or
-            $_.Class -eq "MEDIA"
-          }
-          if ($devices) {
-            $devices | Format-List FriendlyName, Status
-            echo "RSAC_CI_AUDIO_AVAILABLE=1" >> $env:GITHUB_ENV
-            # rsac M5: VB-CABLE is installed AND verified as the active default
-            # playback endpoint by the hard gate two steps above. That makes
-            # system-capture loopback deterministic — the test tone provably
-            # routes to the captured endpoint — so enable the hard
-            # non-silence/tone asserts for this system-capture tier.
-            echo "RSAC_CI_AUDIO_DETERMINISTIC=1" >> $env:GITHUB_ENV
-          } else {
-            Write-Host "No audio devices found"
-            echo "RSAC_CI_AUDIO_AVAILABLE=0" >> $env:GITHUB_ENV
-          }
+        run: ./scripts/ci-windows-audio-default.ps1
 
       - name: Compilation check
         # compose is included tier-wide so the ci_audio binary compiles once
@@ -846,14 +762,13 @@ jobs:
   windows-device:
     name: "Windows | Device Capture"
     runs-on: windows-latest
-    # rsac M5: first-class, hard-gated (no continue-on-error). NOTE: we do NOT
-    # set RSAC_CI_AUDIO_DETERMINISTIC here. The deterministic hard-asserts in
-    # tests/ci_audio/device_capture.rs are written against the Linux null-sink
-    # *monitor* (which always carries the 440 Hz tone). On windows-latest the
-    # device-capture path opens VB-CABLE's capture endpoint directly with no
-    # tone guaranteed to be routed to it, so a deterministic non-silence assert
-    # would false-RED. The job still hard-fails on build/start/panic regressions
-    # (a genuine WASAPI device-open regression), which is the M5 goal.
+    # rsac M5 + rsac-0f33: first-class, hard-gated (no continue-on-error),
+    # and DETERMINISTIC: the tests target enumerator.default_device() — the
+    # exact endpoint the shared gate hard-verifies to be VB-CABLE — and spawn
+    # their own tone player to that same (default) endpoint, so the loopback
+    # content route is as deterministic as the system tier's. The old
+    # "opens VB-CABLE's capture endpoint directly with no tone routed to it"
+    # concern described a path the tests do not take.
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -865,29 +780,14 @@ jobs:
       - name: Install virtual audio (VB-CABLE via LABSN)
         uses: LABSN/sound-ci-helpers@d08c889a7bba7d9b1b059f8f76dac4672ea3a9cf # v1 (v1 tag == v1.0.4, resolved via git ls-remote)
 
-      - name: Set VB-CABLE as default audio device
+      # rsac-0f33: shared deterministic-endpoint gate (set VB-CABLE as the
+      # default playback endpoint with retries, HARD-verify it, then export
+      # RSAC_CI_AUDIO_AVAILABLE=1 + RSAC_CI_AUDIO_DETERMINISTIC=1). Single-
+      # sourced across all three Windows tiers - see the script header for
+      # why the deterministic flip is sound per tier.
+      - name: Set + verify VB-CABLE default endpoint (hard gate, enables deterministic mode)
         shell: pwsh
-        run: |
-          Install-Module -Name AudioDeviceCmdlets -Force -Scope CurrentUser 2>$null
-          Import-Module AudioDeviceCmdlets -ErrorAction SilentlyContinue
-          try {
-            $devices = Get-AudioDevice -List
-            $cable = $devices | Where-Object { $_.Name -like "*CABLE Input*" -and $_.Type -eq "Playback" }
-            if (-not $cable) { $cable = $devices | Where-Object { $_.Name -like "*VB-Audio*" -and $_.Type -eq "Playback" } }
-            if ($cable) { Set-AudioDevice -Index $cable[0].Index; Write-Host "Default playback: $($cable[0].Name)" }
-          } catch { Write-Host "Skipping default device setup: $_" }
-
-      - name: Verify audio devices
-        shell: pwsh
-        run: |
-          $devices = Get-PnpDevice -ErrorAction SilentlyContinue | Where-Object {
-            $_.FriendlyName -like "*VB-Audio*" -or $_.FriendlyName -like "*CABLE*"
-          }
-          if ($devices) {
-            echo "RSAC_CI_AUDIO_AVAILABLE=1" >> $env:GITHUB_ENV
-          } else {
-            echo "RSAC_CI_AUDIO_AVAILABLE=0" >> $env:GITHUB_ENV
-          }
+        run: ./scripts/ci-windows-audio-default.ps1
 
       - name: Compilation check
         run: cargo check --no-default-features --features feat_windows
@@ -942,12 +842,12 @@ jobs:
   windows-process:
     name: "Windows | Process Capture"
     runs-on: windows-latest
-    # rsac M5: first-class, hard-gated (no continue-on-error). As with the
-    # device tier, RSAC_CI_AUDIO_DETERMINISTIC is intentionally NOT set: the
-    # per-process loopback tone is generated by a child player whose routing is
-    # not as tightly verified as the system-default endpoint, so a deterministic
-    # non-silence assert risks a false RED. Build/start/panic regressions in the
-    # WASAPI Process Loopback path still hard-fail the job (the M5 goal).
+    # rsac M5 + rsac-0f33: first-class, hard-gated (no continue-on-error),
+    # and DETERMINISTIC: the child player's PlayLooping output routes to the
+    # default playback endpoint, which the shared gate hard-verifies to be
+    # VB-CABLE before any test runs — so WASAPI process loopback of that
+    # child has a proven tone route. (application_by_name_windows keeps its
+    # content asserts soft by its own module-documented design.)
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -965,29 +865,14 @@ jobs:
       - name: Install virtual audio (VB-CABLE via LABSN)
         uses: LABSN/sound-ci-helpers@d08c889a7bba7d9b1b059f8f76dac4672ea3a9cf # v1 (v1 tag == v1.0.4, resolved via git ls-remote)
 
-      - name: Set VB-CABLE as default audio device
+      # rsac-0f33: shared deterministic-endpoint gate (set VB-CABLE as the
+      # default playback endpoint with retries, HARD-verify it, then export
+      # RSAC_CI_AUDIO_AVAILABLE=1 + RSAC_CI_AUDIO_DETERMINISTIC=1). Single-
+      # sourced across all three Windows tiers - see the script header for
+      # why the deterministic flip is sound per tier.
+      - name: Set + verify VB-CABLE default endpoint (hard gate, enables deterministic mode)
         shell: pwsh
-        run: |
-          Install-Module -Name AudioDeviceCmdlets -Force -Scope CurrentUser 2>$null
-          Import-Module AudioDeviceCmdlets -ErrorAction SilentlyContinue
-          try {
-            $devices = Get-AudioDevice -List
-            $cable = $devices | Where-Object { $_.Name -like "*CABLE Input*" -and $_.Type -eq "Playback" }
-            if (-not $cable) { $cable = $devices | Where-Object { $_.Name -like "*VB-Audio*" -and $_.Type -eq "Playback" } }
-            if ($cable) { Set-AudioDevice -Index $cable[0].Index; Write-Host "Default playback: $($cable[0].Name)" }
-          } catch { Write-Host "Skipping default device setup: $_" }
-
-      - name: Verify audio devices
-        shell: pwsh
-        run: |
-          $devices = Get-PnpDevice -ErrorAction SilentlyContinue | Where-Object {
-            $_.FriendlyName -like "*VB-Audio*" -or $_.FriendlyName -like "*CABLE*"
-          }
-          if ($devices) {
-            echo "RSAC_CI_AUDIO_AVAILABLE=1" >> $env:GITHUB_ENV
-          } else {
-            echo "RSAC_CI_AUDIO_AVAILABLE=0" >> $env:GITHUB_ENV
-          }
+        run: ./scripts/ci-windows-audio-default.ps1
 
       - name: Compilation check
         run: cargo check --no-default-features --features feat_windows

--- a/.github/workflows/ci-audio-tests.yml
+++ b/.github/workflows/ci-audio-tests.yml
@@ -843,11 +843,13 @@ jobs:
     name: "Windows | Process Capture"
     runs-on: windows-latest
     # rsac M5 + rsac-0f33: first-class, hard-gated (no continue-on-error),
-    # and DETERMINISTIC: the child player's PlayLooping output routes to the
-    # default playback endpoint, which the shared gate hard-verifies to be
-    # VB-CABLE before any test runs — so WASAPI process loopback of that
-    # child has a proven tone route. (application_by_name_windows keeps its
-    # content asserts soft by its own module-documented design.)
+    # and DETERMINISTIC for process-TREE loopback: the child player's
+    # PlayLooping output routes to the default playback endpoint, which the
+    # shared gate hard-verifies to be VB-CABLE before any test runs — and the
+    # evidence runs show tree loopback capturing the tone (RMS≈0.53). The
+    # per-PID Application step carries a documented evidence exception (see
+    # its step comment); application_by_name_windows keeps its
+    # module-documented soft asserts.
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -903,10 +905,20 @@ jobs:
           $writer.Close(); $stream.Close()
           Write-Host "Test WAV: $((Get-Item $wavPath).Length) bytes"
 
+      # Evidence exception (rsac-0f33, run 28902137869 + historical runs):
+      # per-PID Application capture (WASAPI session capture) has NEVER
+      # delivered content on windows-latest — the spawned player's session is
+      # not found for its PID, every buffer is silence-padded — while
+      # ProcessTree loopback of the SAME player captures the tone
+      # (RMS≈0.53). Until that per-PID session-resolution gap is fixed
+      # (tracked as a product seed), this one step opts back out of the
+      # job-wide deterministic mode; the step below (process tree) stays
+      # hard. Build/start/panic regressions in this step still fail the job.
       - name: Run application capture tests
         shell: pwsh
         env:
           RSAC_TEST_CAPTURE_TIMEOUT_SECS: "15"
+          RSAC_CI_AUDIO_DETERMINISTIC: "0"
         run: |
           cargo test --test ci_audio app_capture `
             --no-default-features --features feat_windows `

--- a/.github/workflows/ci-audio-tests.yml
+++ b/.github/workflows/ci-audio-tests.yml
@@ -39,6 +39,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'scripts/ci-linux-audio-route.sh'
+      - 'scripts/ci-windows-audio-default.ps1'
       - '.github/workflows/ci-audio-tests.yml'
   pull_request:
     branches: [main, master, 'release/**']
@@ -49,6 +50,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'scripts/ci-linux-audio-route.sh'
+      - 'scripts/ci-windows-audio-default.ps1'
       - '.github/workflows/ci-audio-tests.yml'
   workflow_dispatch:
 

--- a/docs/CI_AUDIO_TESTING.md
+++ b/docs/CI_AUDIO_TESTING.md
@@ -135,9 +135,12 @@ centralised in `helpers.rs` so the tests themselves stay portable.
 - `windows-latest` runner.
 - [`LABSN/sound-ci-helpers@v1`](https://github.com/LABSN/sound-ci-helpers)
   installs the VB-CABLE virtual-cable driver.
-- `AudioDeviceCmdlets` + `Set-AudioDevice -DefaultOnly` sets VB-CABLE
-  as the default playback endpoint; a gating step verifies this and
-  exits 1 otherwise.
+- **Endpoint gate** (`scripts/ci-windows-audio-default.ps1`, rsac-0f33,
+  shared by all three tiers): sets VB-CABLE as the default playback
+  endpoint via `AudioDeviceCmdlets` (bounded retries), **hard-verifies**
+  the active default, then exports `RSAC_CI_AUDIO_DETERMINISTIC=1` — every
+  tier's tone route flows through that verified endpoint (system loopback,
+  `default_device()` capture, process loopback of the test player).
 - Test tones use a **PCM16 sibling WAV** + `SoundPlayer.PlayLooping()`:
   `System.Media.SoundPlayer` silently drops `WAVE_FORMAT_IEEE_FLOAT`
   frames on the runner's default endpoint (rsac#24), so we convert to
@@ -165,11 +168,13 @@ centralised in `helpers.rs` so the tests themselves stay portable.
   `true`. Unset on non-audio jobs.
 - `RSAC_CI_AUDIO_DETERMINISTIC=1` — flips the capture tests' soft
   non-silence warnings into **hard assertions**. Set in CI where audio
-  routing is deterministic: the Windows system tier, and the Linux tiers
-  after the routing gate (`scripts/ci-linux-audio-route.sh`) proves the
-  virtual-sink route end-to-end (seeds rsac-6efb / rsac-b106). On a local
-  machine with real, working audio this is exactly what you want: export
-  it to make a silent capture fail loudly instead of warn.
+  routing is deterministic: all three Windows tiers (via the verified
+  VB-CABLE endpoint gate, `scripts/ci-windows-audio-default.ps1` —
+  rsac-0f33), and all three Linux tiers after the routing gate
+  (`scripts/ci-linux-audio-route.sh`) proves the virtual-sink route
+  end-to-end (seeds rsac-6efb / rsac-b106). On a local machine with
+  real, working audio this is exactly what you want: export it to make
+  a silent capture fail loudly instead of warn.
 - `RSAC_CI_MACOS_TCC_GRANTED=1` — set only on self-hosted macOS
   runners where Audio Capture has been granted. Unset on Blacksmith
   and GH-hosted macOS.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,6 +23,7 @@ deleted in the 2026-07-05 rot cleanup (rsac-a3c4) — recover via
 |---|---|---|
 | `check-module-dag.sh` | Module-DAG reverse-edge guard (`core→bridge→audio→api`) | ci.yml `module-dag` job, `gate.sh --full` |
 | `ci-linux-audio-route.sh` | Deterministic PipeWire routing gate: pins `ci_test_sink` as default, proves the tone→monitor route end-to-end (sox RMS + frequency), then exports `RSAC_CI_AUDIO_DETERMINISTIC=1` (rsac-b106/rsac-6efb) | ci-audio-tests.yml `linux-system`/`linux-device`/`linux-process`, humans on a Linux box |
+| `ci-windows-audio-default.ps1` | Deterministic VB-CABLE endpoint gate: sets + hard-verifies the default playback endpoint, then exports `RSAC_CI_AUDIO_DETERMINISTIC=1` (rsac-0f33) | ci-audio-tests.yml `windows-system`/`windows-device`/`windows-process` |
 | `bump-version.sh` | Bumps the six version-bearing manifests + rotates CHANGELOG | release-prepare.yml, humans (see CONTRIBUTING §7) |
 | `verify-docs-rs.sh` | Post-publish docs.rs rendering spot-check | humans (see RELEASE_PROCESS.md) |
 

--- a/scripts/ci-windows-audio-default.ps1
+++ b/scripts/ci-windows-audio-default.ps1
@@ -1,0 +1,105 @@
+# =============================================================================
+# Deterministic VB-CABLE default-endpoint gate for the Windows audio CI jobs
+# (seed rsac-0f33).
+#
+# Called by: .github/workflows/ci-audio-tests.yml (windows-system,
+#            windows-device, windows-process), after LABSN/sound-ci-helpers
+#            has installed the VB-CABLE driver.
+#
+# What it does, in order:
+#
+#   1. Sets VB-CABLE as the DEFAULT PLAYBACK endpoint via AudioDeviceCmdlets,
+#      with bounded retries (rsac-eb2f: the endpoint can take seconds to
+#      register with AudioSrv after driver install; rsac#24: LABSN installs
+#      the driver but does not set the default).
+#   2. HARD-VERIFIES the active default playback is VB-CABLE. If it is not,
+#      the test tone would route to the wrong endpoint and every loopback
+#      capture would see silence — fail loudly here instead of wasting the
+#      cargo build + 15 minutes of tests that cannot pass.
+#   3. Exports RSAC_CI_AUDIO_AVAILABLE=1 and RSAC_CI_AUDIO_DETERMINISTIC=1.
+#
+# Why the deterministic flip is sound for ALL THREE Windows tiers (not just
+# system capture): every ci_audio content assertion consumes tone played by a
+# test-spawned player to the DEFAULT playback endpoint, which this script has
+# just hard-verified to be VB-CABLE:
+#   - system tier:  SystemDefault loopback of that same endpoint;
+#   - device tier:  the tests target enumerator.default_device() — the very
+#                   endpoint verified here — and spawn their own tone player;
+#   - process tier: WASAPI process loopback of the spawned player process,
+#                   whose PlayLooping output routes to the verified endpoint.
+# (The application_by_name_windows module keeps its content asserts soft by
+# its own module-documented design regardless of this env.)
+# =============================================================================
+$ErrorActionPreference = "Stop"
+
+Install-Module -Name AudioDeviceCmdlets -Force -Scope CurrentUser 2>$null
+Import-Module AudioDeviceCmdlets -ErrorAction Stop
+
+# ── 1. Set VB-CABLE as the default playback endpoint (bounded retries) ──────
+$cable = $null
+$maxAttempts = 6
+for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+    Write-Host "=== Audio device discovery (attempt $attempt/$maxAttempts) ==="
+    $devices = Get-AudioDevice -List
+    $devices | Format-Table Index, Type, Name, Default -AutoSize
+
+    # On windows-latest VB-CABLE's playback endpoint is named
+    # "Speakers (VB-Audio Virtual Cable)", not "CABLE Input ...", so the
+    # filter accepts either form (rsac#24).
+    $cable = $devices | Where-Object {
+        $_.Type -eq "Playback" -and (
+            $_.Name -like "*CABLE Input*" -or
+            $_.Name -like "*VB-Audio*" -or
+            $_.Name -like "*VB-CABLE*"
+        )
+    } | Select-Object -First 1
+
+    if ($cable) {
+        try {
+            Write-Host "Setting VB-CABLE as default playback device: $($cable.Name) (Index=$($cable.Index))"
+            Set-AudioDevice -Index $cable.Index -DefaultOnly
+            break
+        } catch {
+            Write-Host "Set-AudioDevice failed on attempt ${attempt}: $_"
+            $cable = $null
+        }
+    }
+    if ($attempt -lt $maxAttempts) { Start-Sleep -Seconds 5 }
+}
+
+if (-not $cable) {
+    Write-Error "No VB-CABLE playback device found after $maxAttempts attempts - LABSN install likely failed"
+    exit 1
+}
+
+# ── 2. Hard-verify the active default playback ─────────────────────────────
+$playback = Get-AudioDevice -Playback
+Write-Host "Default playback: $($playback.Name) (Default=$($playback.Default), Type=$($playback.Type))"
+$isCable = ($playback.Name -like "*VB-Audio*") -or
+           ($playback.Name -like "*CABLE*") -or
+           ($playback.Name -like "*VB-CABLE*")
+if (-not $isCable) {
+    Write-Error "Default playback is NOT VB-CABLE (got: '$($playback.Name)'). Loopback capture cannot succeed."
+    exit 1
+}
+Write-Host "OK: VB-CABLE is the verified default playback endpoint."
+
+# Endpoint inventory for the logs (diagnostic only — the hard gate above is
+# the authority).
+Get-PnpDevice -ErrorAction SilentlyContinue | Where-Object {
+    $_.FriendlyName -like "*VB-Audio*" -or
+    $_.FriendlyName -like "*CABLE*" -or
+    $_.Class -eq "AudioEndpoint" -or
+    $_.Class -eq "MEDIA"
+} | Format-List FriendlyName, Status
+
+# ── 3. Enable the audio tests' hard content assertions ─────────────────────
+if ($env:GITHUB_ENV) {
+    "RSAC_CI_AUDIO_AVAILABLE=1" >> $env:GITHUB_ENV
+    "RSAC_CI_AUDIO_DETERMINISTIC=1" >> $env:GITHUB_ENV
+    Write-Host "exported RSAC_CI_AUDIO_AVAILABLE=1 and RSAC_CI_AUDIO_DETERMINISTIC=1 to `$GITHUB_ENV"
+} else {
+    Write-Host "no `$GITHUB_ENV - set these yourself:"
+    Write-Host "  `$env:RSAC_CI_AUDIO_AVAILABLE = '1'"
+    Write-Host "  `$env:RSAC_CI_AUDIO_DETERMINISTIC = '1'"
+}


### PR DESCRIPTION
## Summary
Single-sources the Windows audio-CI endpoint setup into scripts/ci-windows-audio-default.ps1 (a faithful extraction of the proven windows-system retry+verify logic) and promotes the device + process tiers to RSAC_CI_AUDIO_DETERMINISTIC=1.

Key insight: the device/process tiers were the only ones whose 'set VB-CABLE as default' step was best-effort (try/catch, no verification) - exactly the condition that made their tone routes unprovable. With the hard-verified default endpoint, every tier's content route flows through it: system loopback captures the endpoint; device_capture targets enumerator.default_device() (the same endpoint) and spawns its own player; process loopback captures the spawned player whose PlayLooping routes there. The old device-tier NOTE described a path the tests do not take. application_by_name_windows keeps its module-documented soft asserts.

## Merge condition (per seed rsac-0f33)
Do NOT merge until this branch's ci-audio-tests runs show the promoted tiers green - the seed asks for 2+ consecutive green process-loopback runs. Evidence runs will be linked in comments.

Seed: rsac-0f33 (closes on merge with the evidence run links).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Windows audio test setup for CI with a shared, deterministic audio routing step.
  * Added stronger verification that the expected audio device is selected before tests continue.

* **Bug Fixes**
  * Reduced flaky Windows audio test behavior by adding bounded retries and hard-fail checks when the default audio device is incorrect.

* **Documentation**
  * Updated CI and scripting docs to describe the new Windows audio setup and its deterministic behavior across all Windows test tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->