### PR TITLE
docs: refresh stale version-specific claims (rsac-b1c4)

### DIFF
--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -589,7 +589,10 @@ reach a registry.
 ### (b) C ABI changes are MAJOR for `rsac-ffi`
 
 The `rsac-ffi` crate exposes a C ABI: the exported `extern "C"` symbols
-and the generated `rsac.h` header. **Any** of the following is a
+and the C headers under `bindings/rsac-ffi/include/` — `rsac.h` is the
+**curated** header consumers include; `rsac_generated.h` is the raw
+cbindgen output that CI's header-drift check compares it against. **Any**
+of the following is a
 **MAJOR** version change for the FFI surface and MUST be called out in
 the CHANGELOG under a dedicated `### C ABI changes` subsection (see
 [`CHANGELOG.md`](../CHANGELOG.md)):

--- a/docs/features.md
+++ b/docs/features.md
@@ -210,7 +210,7 @@ The following are always compiled and have no opt-out:
 
 ## Version note
 
-This matrix reflects `rsac` at the 0.4.0 line. Future provider-architecture work may add feature flags for cloud-backed capture providers — those will be listed here as they land.
+This matrix reflects `rsac` at the 0.4 line. Future provider-architecture work may add feature flags for cloud-backed capture providers — those will be listed here as they land.
 
 `rsac` and its bindings bump in lockstep on every semver tag, and any
 change to the `rsac-ffi` C ABI is a MAJOR bump for the FFI surface. See


### PR DESCRIPTION
Closes seed `rsac-b1c4` (P1 finding: release/feature docs carried stale point-in-time claims).

## Changes

- **`docs/RELEASE_PROCESS.md` §Versioning & ABI contract (b)** — the C ABI definition called `rsac.h` *"the generated header"*. It is the **curated** consumer header; `rsac_generated.h` is the raw cbindgen output that CI's header-drift check compares the curated header against (symbol-set comparison, `ci.yml` ffi-header job). The old wording blurred exactly the split the drift check relies on.
- **`docs/features.md`** — feature matrix note now says *"the 0.4 line"* instead of the point-in-time *"0.4.0 line"* (evergreen wording; survives the imminent 0.4.1 bump).

## Findings already fixed elsewhere (no change needed)

Audited per the seed's ready-prompt; three of its four findings were resolved by earlier release-stack layers:

| Seed finding | Current state |
|---|---|
| `features.md` claims the 0.2.0 release line | Already says 0.4 line (now evergreen) |
| `rsac-ffi` trails at 0.1.0 while others are 0.2.0 | Doc already states all six manifests agree at 0.4.0 with lockstep note |
| Pre-lockstep `bump-version.sh` warning misleading | Doc already reflects six-manifest lockstep |
| `rsac.h` called generated | **Fixed here** |

Remaining `0.2.0` mentions in `RELEASE_PROCESS.md` are the explicitly labeled worked example (*"The worked example throughout is the 0.2.0 release. Substitute your target version"*) — kept per the seed's own guidance.

Docs-only; the `changes` gate should skip the compile matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the ABI guidance to distinguish the main consumer-facing C header from the generated header used for drift checks.
  * Updated the feature matrix version note to use a shorter release version reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->