### PR TITLE
devex: mise tasks for the release scripts + host audio suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,9 @@ mise run gate        # or: bash scripts/gate.sh   (pwsh scripts/gate.ps1 on Wind
 #   fmt --check → clippy -D warnings (feat_<host>,compose,cli) → bare-build smoke
 mise run gate:full   # + lib tests, doctests, docsrs cargo doc, module-DAG guard
 mise run test        # just the CI test-job replica for the host OS
+mise run test:audio  # ci_audio integration suite on this machine (all 3 tiers)
+mise run release:bump -- X.Y.Z [--dry-run]  # six-manifest lockstep bump + CHANGELOG rotation
+mise run release:verify-docs                # post-publish docs.rs spot-check
 ```
 
 mise is a convenience, not a requirement — every task is a thin alias over

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -66,6 +66,12 @@ mise run gate:full   # or: bash scripts/gate.sh --full
 #   and the module-DAG guard — the rest of the fast CI legs.
 ```
 
+Other everyday tasks (`mise tasks` is the live list): `mise run test`
+(CI test-job replica), `mise run test:audio` (the `ci_audio` integration
+suite on this machine, dispatching to the host-OS script), and the
+release pair `mise run release:bump -- X.Y.Z [--dry-run]` /
+`mise run release:verify-docs` (§7).
+
 `cargo doc` is part of `gate:full` because `src/lib.rs` declares
 `#![deny(rustdoc::broken_intra_doc_links)]` — a stale link becomes a
 build error.
@@ -228,6 +234,7 @@ heading and re-seeds an empty `[Unreleased]`).
 
 ```bash
 # Substitute the target version for X.Y.Z (e.g. the current release is 0.4.0).
+# `mise run release:bump -- X.Y.Z` is the same command via the task runner.
 bash scripts/bump-version.sh X.Y.Z --dry-run   # preview
 bash scripts/bump-version.sh X.Y.Z             # apply
 git diff                                        # review

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -837,10 +837,10 @@ rewrites all six lockstep manifests plus rotates the CHANGELOG:
 
 ```bash
 # Preview the edits without writing them:
-bash scripts/bump-version.sh 0.3.0 --dry-run
+bash scripts/bump-version.sh 0.3.0 --dry-run    # or: mise run release:bump -- 0.3.0 --dry-run
 
 # Apply them:
-bash scripts/bump-version.sh 0.3.0
+bash scripts/bump-version.sh 0.3.0              # or: mise run release:bump -- 0.3.0
 ```
 
 This rewrites, in one shot:
@@ -1042,6 +1042,7 @@ propagate, run the one-command spot-check:
 ```bash
 bash scripts/verify-docs-rs.sh              # uses version from Cargo.toml
 bash scripts/verify-docs-rs.sh 0.2.0        # pin a specific version
+# (or: mise run release:verify-docs [-- X.Y.Z])
 ```
 
 The script is a focused probe — not a smoketest — and hits a handful of

--- a/mise.toml
+++ b/mise.toml
@@ -46,3 +46,18 @@ run_windows = "pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/gate.ps1 --
 [tasks.fmt]
 description = "Format the workspace"
 run = "cargo fmt --all"
+
+[tasks."test:audio"]
+description = "ci_audio integration suite on this machine, all 3 capture tiers (extra args pass through, e.g. `mise run test:audio -- --tier system`)"
+run = """bash -c 'case "$(uname -s)" in Darwin) exec bash scripts/test-audio-macos.sh "$@" ;; *) exec bash scripts/test-audio-linux.sh "$@" ;; esac' --"""
+run_windows = "pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test-audio-windows.ps1"
+
+[tasks."release:bump"]
+description = "Bump the six lockstep manifests + rotate CHANGELOG: mise run release:bump -- X.Y.Z [--dry-run]"
+run = "bash scripts/bump-version.sh"
+run_windows = "pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/run-bash.ps1 scripts/bump-version.sh"
+
+[tasks."release:verify-docs"]
+description = "Post-publish docs.rs rendering spot-check: mise run release:verify-docs [-- X.Y.Z]"
+run = "bash scripts/verify-docs-rs.sh"
+run_windows = "pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/run-bash.ps1 scripts/verify-docs-rs.sh"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,9 +9,10 @@ deleted in the 2026-07-05 rot cleanup (rsac-a3c4) — recover via
 | Script | Purpose | Called by |
 |---|---|---|
 | `gate.sh` | The local gate — replica of ci.yml's `lint` job for the host OS (`--full` adds tests/doc/DAG) | `mise run gate`, lefthook pre-push, humans |
-| `gate.ps1` | PowerShell wrapper for `gate.sh` (finds Git bash, avoids WSL bash) | `mise run gate` on Windows, humans |
+| `gate.ps1` | PowerShell wrapper for `gate.sh` (delegates via `run-bash.ps1`) | `mise run gate` on Windows, lefthook pre-push |
+| `run-bash.ps1` | Generic Windows wrapper: finds Git bash (avoids WSL bash) and runs any repo bash script with args | `gate.ps1`, the Windows legs of `mise run release:bump` / `release:verify-docs` |
 | `hooks/commit-msg.sh` | Rejects `Co-Authored-By:` trailers / tool bylines (AGENTS.md §6) | lefthook commit-msg hook |
-| `test-audio-linux.sh` / `test-audio-macos.sh` / `test-audio-windows.ps1` | Run the `ci_audio` integration suite (all 3 capture tiers) on a physical machine | humans (see `docs/LOCAL_TESTING_GUIDE.md`) |
+| `test-audio-linux.sh` / `test-audio-macos.sh` / `test-audio-windows.ps1` | Run the `ci_audio` integration suite (all 3 capture tiers) on a physical machine | `mise run test:audio` (host-OS dispatch), humans (see `docs/LOCAL_TESTING_GUIDE.md`) |
 | `install-pipewire-deps.sh` | Distro-detecting install of the Linux PipeWire build deps | humans |
 | `setup_env.sh` + `check_deps.sh` | Basic Linux env init + pkg-config dependency check | humans (`setup_env.sh` calls `check_deps.sh`) |
 | `test-pipewire-setup.sh` | Diagnose a Linux PipeWire environment (daemons, tools, nodes) | humans |
@@ -24,8 +25,8 @@ deleted in the 2026-07-05 rot cleanup (rsac-a3c4) — recover via
 | `check-module-dag.sh` | Module-DAG reverse-edge guard (`core→bridge→audio→api`) | ci.yml `module-dag` job, `gate.sh --full` |
 | `ci-linux-audio-route.sh` | Deterministic PipeWire routing gate: pins `ci_test_sink` as default, proves the tone→monitor route end-to-end (sox RMS + frequency), then exports `RSAC_CI_AUDIO_DETERMINISTIC=1` (rsac-b106/rsac-6efb) | ci-audio-tests.yml `linux-system`/`linux-device`/`linux-process`, humans on a Linux box |
 | `ci-windows-audio-default.ps1` | Deterministic VB-CABLE endpoint gate: sets + hard-verifies the default playback endpoint, then exports `RSAC_CI_AUDIO_DETERMINISTIC=1` (rsac-0f33) | ci-audio-tests.yml `windows-system`/`windows-device`/`windows-process` |
-| `bump-version.sh` | Bumps the six version-bearing manifests + rotates CHANGELOG | release-prepare.yml, humans (see CONTRIBUTING §7) |
-| `verify-docs-rs.sh` | Post-publish docs.rs rendering spot-check | humans (see RELEASE_PROCESS.md) |
+| `bump-version.sh` | Bumps the six version-bearing manifests + rotates CHANGELOG | release-prepare.yml, `mise run release:bump -- X.Y.Z`, humans (see CONTRIBUTING §7) |
+| `verify-docs-rs.sh` | Post-publish docs.rs rendering spot-check | `mise run release:verify-docs`, humans (see RELEASE_PROCESS.md) |
 
 ## Docker testing stack
 

--- a/scripts/gate.ps1
+++ b/scripts/gate.ps1
@@ -1,31 +1,12 @@
 # scripts/gate.ps1 — PowerShell entry point for the local gate (rsac-7e19).
 #
 # The gate logic lives once, in scripts/gate.sh (bash), so it cannot drift
-# between platforms. Git for Windows ships bash, so this wrapper just finds
-# it and delegates. Usage mirrors gate.sh:
+# between platforms; the Git-bash discovery likewise lives once, in
+# scripts/run-bash.ps1. Usage mirrors gate.sh:
 #   pwsh scripts/gate.ps1              # lint-job replica
 #   pwsh scripts/gate.ps1 --full       # + tests, doctests, docs, module-DAG
 #   pwsh scripts/gate.ps1 --tests-only # test-job replica only
 $ErrorActionPreference = 'Stop'
 
-# Prefer Git for Windows' bash explicitly. A bare `bash` on PATH often
-# resolves to WSL's System32\bash.exe, which is a different OS (wrong
-# backend feature, no cargo on PATH).
-$candidates = @(
-    (Join-Path $env:ProgramFiles 'Git\bin\bash.exe'),
-    (Join-Path ${env:ProgramFiles(x86)} 'Git\bin\bash.exe'),
-    (Join-Path $env:LOCALAPPDATA 'Programs\Git\bin\bash.exe')
-) | Where-Object { $_ -and (Test-Path $_) }
-
-$bashExe = $candidates | Select-Object -First 1
-if (-not $bashExe) {
-    $cmd = Get-Command bash -ErrorAction SilentlyContinue
-    if ($cmd -and $cmd.Source -notmatch 'System32') { $bashExe = $cmd.Source }
-}
-if (-not $bashExe) {
-    Write-Error "gate: Git bash not found. Install Git for Windows, then re-run."
-    exit 1
-}
-
-& $bashExe (Join-Path $PSScriptRoot 'gate.sh') @args
+& (Join-Path $PSScriptRoot 'run-bash.ps1') (Join-Path $PSScriptRoot 'gate.sh') @args
 exit $LASTEXITCODE

--- a/scripts/run-bash.ps1
+++ b/scripts/run-bash.ps1
@@ -1,0 +1,37 @@
+# scripts/run-bash.ps1 — generic "run a bash script with Git bash" wrapper.
+#
+# The repo's script logic lives once, in bash, so it cannot drift between
+# platforms (the gate.sh principle). Git for Windows ships bash, so on
+# Windows this wrapper finds it and delegates — for ANY script, so each new
+# mise task doesn't need its own copy of the bash-discovery logic.
+#
+# Usage:
+#   pwsh scripts/run-bash.ps1 scripts/bump-version.sh 0.5.0 --dry-run
+#   pwsh scripts/run-bash.ps1 scripts/verify-docs-rs.sh
+param(
+    [Parameter(Mandatory = $true, Position = 0)][string]$Script,
+    [Parameter(ValueFromRemainingArguments = $true)][string[]]$Rest
+)
+$ErrorActionPreference = 'Stop'
+
+# Prefer Git for Windows' bash explicitly. A bare `bash` on PATH often
+# resolves to WSL's System32\bash.exe, which is a different OS (wrong
+# backend feature, no cargo on PATH).
+$candidates = @(
+    (Join-Path $env:ProgramFiles 'Git\bin\bash.exe'),
+    (Join-Path ${env:ProgramFiles(x86)} 'Git\bin\bash.exe'),
+    (Join-Path $env:LOCALAPPDATA 'Programs\Git\bin\bash.exe')
+) | Where-Object { $_ -and (Test-Path $_) }
+
+$bashExe = $candidates | Select-Object -First 1
+if (-not $bashExe) {
+    $cmd = Get-Command bash -ErrorAction SilentlyContinue
+    if ($cmd -and $cmd.Source -notmatch 'System32') { $bashExe = $cmd.Source }
+}
+if (-not $bashExe) {
+    Write-Error "run-bash: Git bash not found. Install Git for Windows, then re-run."
+    exit 1
+}
+
+& $bashExe $Script @Rest
+exit $LASTEXITCODE


### PR DESCRIPTION
Follow-through on the 2026-07-05 DevEx overhaul: `gate`/`test` got mise aliases, but the other operator-facing scripts stayed bare bash invocations — most visibly `bump-version.sh`, which the release runbook cites constantly. Every human entry point in `scripts/` now has a task:

| Task | Delegates to |
|---|---|
| `mise run release:bump -- X.Y.Z [--dry-run]` | `scripts/bump-version.sh` |
| `mise run release:verify-docs [-- X.Y.Z]` | `scripts/verify-docs-rs.sh` |
| `mise run test:audio [-- --tier T]` | `scripts/test-audio-{linux,macos}.sh` / `test-audio-windows.ps1` (host-OS dispatch) |

**`scripts/run-bash.ps1` (new)** — extracts `gate.ps1`'s Git-bash discovery (prefer Git for Windows bash, refuse WSL's `System32\bash.exe`) into a generic *run-any-repo-bash-script* wrapper, so each new Windows task leg doesn't re-copy the logic. `gate.ps1` now delegates to it — the discovery lives once, matching the ''gate logic lives once'' principle.

## Validation (Windows host)

- `mise run release:bump -- 0.9.9 --dry-run` — end-to-end through mise → `run-bash.ps1` → Git bash, arg passthrough proven, all six manifests previewed
- `pwsh scripts/gate.ps1 --bogus-flag` — refactored delegation passes args and propagates the exit code (`gate: unknown flag` + exit 1)
- `mise tasks` parses the new TOML; the pre-push hook exercised the refactored `gate.ps1` path on this push

## Docs

CONTRIBUTING §2 (task list) + §7 (release), RELEASE_PROCESS both usage sites, `scripts/README.md` caller cells (incl. the new wrapper row), AGENTS §6 DevEx block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new routine tasks for audio integration testing, version bumping, and post-publish documentation checks.
  * Added a Windows-friendly bash launcher to simplify running shell scripts on that platform.

* **Documentation**
  * Expanded contributor and release process docs with the new task commands and updated version-bump workflow.
  * Clarified how common scripts are triggered across local and release workflows.

* **Bug Fixes**
  * Improved Windows script execution by standardizing bash delegation and avoiding inconsistent shell resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->