### PR TITLE
chore: release 0.4.1 — lockstep bump + CHANGELOG rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ Releases with no ABI change omit the subsection (or state "No C ABI changes").
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.4.1] - 2026-07-08
+
+### Added
+
 - **`macos-tcc-spi` feature — real audio-capture permission preflight
   (ADR-0015).** `check_audio_capture_permission()` on macOS can now return a
   real answer: there is no public API for the `kTCCServiceAudioCapture`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,7 +1705,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rsac"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "atomic-waker",
  "audioadapter-buffers",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "rsac-ffi"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cbindgen",
  "log",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "rsac-napi"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "napi",
  "napi-build",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "rsac-python"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pyo3",
  "rsac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 # Explicit MSRV floor. wasapi 0.23 bumps its own MSRV to 1.76; declaring it here
 # makes the minimum supported Rust version visible (under the pinned 1.95

--- a/bindings/rsac-ffi/Cargo.toml
+++ b/bindings/rsac-ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "rsac-ffi"
 # In lockstep with the workspace version (rsac + napi + python) — ci.yml's
 # version-lockstep gate and scripts/bump-version.sh treat all six manifests as
 # one version.
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 # Mirror the parent crate's MSRV floor (1.87): rsac-ffi builds against rsac and
 # must not require a newer toolchain than the library it wraps.
@@ -50,7 +50,7 @@ compose = ["rsac/compose"]
 # requirement is what `cargo publish` records (crates.io ignores `path`). Keep
 # the version in lockstep with the parent crate's `[package].version` so a
 # published rsac-ffi resolves the matching rsac release. See README.
-rsac = { path = "../../", version = "0.4.0", default-features = false }
+rsac = { path = "../../", version = "0.4.1", default-features = false }
 log = "0.4"
 
 [build-dependencies]

--- a/bindings/rsac-napi/Cargo.toml
+++ b/bindings/rsac-napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac-napi"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Node.js/TypeScript bindings for rsac (Rust Cross-Platform Audio Capture)"
 license = "MIT OR Apache-2.0"

--- a/bindings/rsac-napi/package.json
+++ b/bindings/rsac-napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsac/audio",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Node.js bindings for rsac (Rust cross-platform audio capture)",
   "main": "index.js",
   "types": "index.d.ts",

--- a/bindings/rsac-python/Cargo.toml
+++ b/bindings/rsac-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac-python"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Python bindings for rsac (Rust Cross-Platform Audio Capture)"
 license = "MIT OR Apache-2.0"

--- a/bindings/rsac-python/pyproject.toml
+++ b/bindings/rsac-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rsac"
-version = "0.4.0"
+version = "0.4.1"
 description = "Python bindings for rsac (cross-platform audio capture library)"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }


### PR DESCRIPTION
The version-bump gate for the `release/0.4.1 → master` PR (#47), per its merge checklist and RELEASE_PROCESS §3 (manual flow — no `CARGO_REGISTRY_TOKEN`-era automation secrets configured yet).

Mechanical output of `mise run release:bump -- 0.4.1` (the task added in #49, exercising it for real on its first release):

- Six lockstep manifests `0.4.0 → 0.4.1` (root, rsac-ffi + internal dep pin, rsac-napi Cargo+package.json, rsac-python Cargo+pyproject)
- `Cargo.lock` — the four workspace crate version entries
- `CHANGELOG.md` — `[Unreleased]` rotated to `[0.4.1] - 2026-07-08`, fresh scaffold re-seeded

No hand edits. The `version-lockstep` CI job on this PR is the required green before #47 merges (with squash subject exactly `release: v0.4.1`).