### PR TITLE
release: v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ Releases with no ABI change omit the subsection (or state "No C ABI changes").
 
 ### Changed
 
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.4.2] - 2026-07-17
+
+### Added
+
+### Changed
+
 - Release version lockstep now includes `mobile/android-native/Cargo.toml`, so
   the Android `librsac.so` shim version stays aligned with the root crate and
   binding manifests.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,7 +1705,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rsac"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "atomic-waker",
  "audioadapter-buffers",
@@ -1752,14 +1752,14 @@ dependencies = [
 
 [[package]]
 name = "rsac-android-native"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "rsac",
 ]
 
 [[package]]
 name = "rsac-ffi"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cbindgen",
  "log",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "rsac-napi"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "napi",
  "napi-build",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "rsac-python"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "pyo3",
  "rsac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 # Explicit MSRV floor. wasapi 0.23 bumps its own MSRV to 1.76; declaring it here
 # makes the minimum supported Rust version visible (under the pinned 1.95

--- a/bindings/rsac-ffi/Cargo.toml
+++ b/bindings/rsac-ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "rsac-ffi"
 # In lockstep with the workspace version (rsac + napi + python) — ci.yml's
 # version-lockstep gate and scripts/bump-version.sh treat all seven manifests as
 # one version.
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 # Mirror the parent crate's MSRV floor (1.87): rsac-ffi builds against rsac and
 # must not require a newer toolchain than the library it wraps.
@@ -49,7 +49,7 @@ compose = ["rsac/compose"]
 # requirement is what a future cargo publish records (crates.io ignores `path`).
 # Keep the version in lockstep with the parent crate's `[package].version` so a
 # future published rsac-ffi resolves the matching rsac release.
-rsac = { path = "../../", version = "0.4.1", default-features = false }
+rsac = { path = "../../", version = "0.4.2", default-features = false }
 log = "0.4"
 
 [build-dependencies]

--- a/bindings/rsac-napi/Cargo.toml
+++ b/bindings/rsac-napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac-napi"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Node.js/TypeScript bindings for rsac (Rust Cross-Platform Audio Capture)"
 license = "MIT OR Apache-2.0"

--- a/bindings/rsac-napi/package.json
+++ b/bindings/rsac-napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsac/audio",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Node.js bindings for rsac (Rust cross-platform audio capture)",
   "main": "index.js",
   "types": "index.d.ts",

--- a/bindings/rsac-python/Cargo.toml
+++ b/bindings/rsac-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac-python"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Python bindings for rsac (Rust Cross-Platform Audio Capture)"
 license = "MIT OR Apache-2.0"

--- a/bindings/rsac-python/pyproject.toml
+++ b/bindings/rsac-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rsac"
-version = "0.4.1"
+version = "0.4.2"
 description = "Python bindings for rsac (cross-platform audio capture library)"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }

--- a/mobile/android-native/Cargo.toml
+++ b/mobile/android-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac-android-native"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 publish = false
 description = "Android cdylib shim: builds librsac.so (via cargo-ndk) for the rsac AAR's jniLibs (rsac-0aa9)"


### PR DESCRIPTION
Version bump 0.4.1 → 0.4.2 across all seven lockstep manifests (+ the rsac-ffi internal dep pin and Cargo.lock) and CHANGELOG rotation of [Unreleased] → [0.4.2] - 2026-07-17.

Release content already landed via PR #54 (squash 3650456): macOS input-only mic -10851 fix (GH #53), compose exact-rate tail flush, bindings terminal-observability migration, CodeRabbit PR #36 minors, build.rs supply-chain hardening, TCC test gates + Windows compose deflake, devex pins. No C ABI changes; no public Rust API changes.

Note: this branch is the Release Prepare workflow's push (the workflow could not open the PR itself — org blocks Actions-created PRs) plus the Cargo.lock version refresh the workflow's bump misses.

⚠️ Squash-merge with the exact subject `release: v0.4.2` — release-tag.yml keys on it to create the tags + GitHub Release.