### PR TITLE
fix: review-body sweep — Windows tier exit-code masking, toolchain comment, Go example hygiene

### DIFF
--- a/.github/workflows/ci-audio-tests.yml
+++ b/.github/workflows/ci-audio-tests.yml
@@ -349,29 +349,37 @@ jobs:
         env:
           RSAC_TEST_CAPTURE_TIMEOUT_SECS: "15"
         run: |
+          # $LASTEXITCODE after EVERY cargo pipe (PR #56 outside-diff review):
+          # a later successful cargo call overwrites the exit code, so without
+          # per-invocation checks an early tier failure is silently masked.
           cargo test --test ci_audio system_capture `
             --no-default-features --features feat_windows,compose `
             -- --test-threads=1 --nocapture `
             2>&1 | Tee-Object -FilePath ci-audio-system.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cargo test --test ci_audio platform_caps `
             --no-default-features --features feat_windows,compose `
             -- --test-threads=1 --nocapture `
             2>&1 | Tee-Object -FilePath ci-audio-system-caps.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cargo test --test ci_audio stream_lifecycle `
             --no-default-features --features feat_windows,compose `
             -- --test-threads=1 --nocapture `
             2>&1 | Tee-Object -FilePath ci-audio-system-lifecycle.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # `lifecycle_terminal` matches ONLY this module (not `stream_lifecycle`).
           cargo test --test ci_audio lifecycle_terminal `
             --no-default-features --features feat_windows,compose `
             -- --test-threads=1 --nocapture `
             2>&1 | Tee-Object -FilePath ci-audio-system-terminal.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # Composed multi-source capture on the deterministic VB-CABLE default
           # endpoint — first HARD tone-content verification of the compose engine.
           cargo test --test ci_audio "compose::" `
             --no-default-features --features feat_windows,compose `
             -- --test-threads=1 --nocapture `
             2>&1 | Tee-Object -FilePath ci-audio-system-compose.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # Wiring existence check: a renamed/cfg'd-out compose module would make
           # the filter above match zero tests and pass vacuously.
           $list = cargo test --test ci_audio `
@@ -392,14 +400,17 @@ jobs:
         env:
           RSAC_TEST_CAPTURE_TIMEOUT_SECS: "15"
         run: |
+          # $LASTEXITCODE after every cargo pipe (PR #56 outside-diff review).
           cargo test --test ci_audio device_capture `
             --no-default-features --features feat_windows,compose `
             -- --test-threads=1 --nocapture `
             2>&1 | Tee-Object -FilePath ci-audio-device.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cargo test --test ci_audio device_enumeration `
             --no-default-features --features feat_windows,compose `
             -- --test-threads=1 --nocapture `
             2>&1 | Tee-Object -FilePath ci-audio-device-enum.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # CI-4 (Windows arm): enumeration_matrix's "no silent empty list"
           # assertion only executes where RSAC_CI_AUDIO_AVAILABLE=1 — this tier
           # has real WASAPI endpoints (VB-CABLE).
@@ -407,6 +418,7 @@ jobs:
             --no-default-features --features feat_windows,compose `
             -- --nocapture `
             2>&1 | Tee-Object -FilePath ci-audio-device-enum-matrix.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       # Formerly only in the windows-process job; needed before the process tier.
       - name: Generate test WAV file (process tier)
@@ -451,15 +463,18 @@ jobs:
           # job-wide deterministic mode; the process-tree step below stays hard.
           # Build/start/panic regressions here still fail the tier.
           $env:RSAC_CI_AUDIO_DETERMINISTIC = "0"
+          # $LASTEXITCODE after every cargo pipe (PR #56 outside-diff review).
           cargo test --test ci_audio app_capture `
             --no-default-features --features feat_windows,compose `
             -- --test-threads=1 --nocapture `
             2>&1 | Tee-Object -FilePath ci-audio-process.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           $env:RSAC_CI_AUDIO_DETERMINISTIC = "1"
           cargo test --test ci_audio process_tree_capture `
             --no-default-features --features feat_windows,compose `
             -- --test-threads=1 --nocapture `
             2>&1 | Tee-Object -FilePath ci-audio-process-proctree.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # Windows-specific ApplicationByName coverage (WASAPI sysinfo→PID→
           # process loopback). The `application_by_name_windows` filter matches
           # ONLY this module (the macOS `application_by_name` module is cfg'd out).
@@ -467,6 +482,7 @@ jobs:
             --no-default-features --features feat_windows,compose `
             -- --test-threads=1 --nocapture `
             2>&1 | Tee-Object -FilePath ci-audio-process-appbyname.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Record tier outcomes
         id: record

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -140,7 +140,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       # Toolchain needed for the `cargo update` step below. Same SHA pin as
-      # ci.yml (channel 1.95.0 baked into the action's default at this commit).
+      # ci.yml. The SHA pins the ACTION's script version only — the Rust
+      # channel itself is resolved from rust-toolchain.toml at runtime.
       # This workflow otherwise runs no cargo command, so it had no toolchain.
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 

--- a/bindings/rsac-go/example_test.go
+++ b/bindings/rsac-go/example_test.go
@@ -264,30 +264,52 @@ func ExampleListDevices() {
 // appends the groups' channels into one interleaved stream.
 func ExampleComposition() {
 	// A "voice" group folding two app sources to mono, plus a "system" group
-	// keeping the system mix's native channels.
+	// keeping the system mix's native channels. Free() is deferred right after
+	// construction: it is a no-op once AddGroup consumes the handle, and it
+	// releases the handle on every early-error path before that.
 	voice, err := rsac.NewGroup("voice")
 	if err != nil {
 		fmt.Printf("group error: %v\n", err)
 		return
 	}
-	_ = voice.SetLayout(rsac.LayoutMono)
-	_ = voice.AddSource("name:Discord")
-	_ = voice.AddSourceWithGain("name:Zoom", 0.8)
+	defer voice.Free()
+	if err := voice.SetLayout(rsac.LayoutMono); err != nil {
+		fmt.Printf("voice layout: %v\n", err)
+		return
+	}
+	if err := voice.AddSource("name:Discord"); err != nil {
+		fmt.Printf("voice source: %v\n", err)
+		return
+	}
+	if err := voice.AddSourceWithGain("name:Zoom", 0.8); err != nil {
+		fmt.Printf("voice source: %v\n", err)
+		return
+	}
 
 	system, err := rsac.NewGroup("system")
 	if err != nil {
 		fmt.Printf("group error: %v\n", err)
 		return
 	}
-	_ = system.SetLayout(rsac.LayoutStereo)
-	_ = system.AddSource("system")
+	defer system.Free()
+	if err := system.SetLayout(rsac.LayoutStereo); err != nil {
+		fmt.Printf("system layout: %v\n", err)
+		return
+	}
+	if err := system.AddSource("system"); err != nil {
+		fmt.Printf("system source: %v\n", err)
+		return
+	}
 
 	builder, err := rsac.NewCompositionBuilder()
 	if err != nil {
 		fmt.Printf("builder error: %v\n", err)
 		return
 	}
-	_ = builder.SetSampleRate(48000)
+	if err := builder.SetSampleRate(48000); err != nil {
+		fmt.Printf("sample rate: %v\n", err)
+		return
+	}
 	if err := builder.AddGroup(voice); err != nil {
 		fmt.Printf("add voice: %v\n", err)
 		return


### PR DESCRIPTION
## Summary

A comprehensive audit of PRs #54–#59 (all three comment surfaces: inline threads, review bodies, issue comments) found 35 findings addressed and **3 that never got dispositions** — all embedded in review bodies where GitHub renders them as collapsed text rather than resolvable threads.

### PR #56 outside-diff — Major (the real one)
The Windows audio tiers run **multiple cargo invocations per pwsh step**, and only the last one's exit code decided the step outcome — pwsh doesn't stop on a failed native command, so an early-tier test failure (e.g. `system_capture` red, `compose::` green) was silently masked. Every cargo pipe in the system/device/process tiers now checks `$LASTEXITCODE` and exits on failure. This complements #57's macOS pipefail fix — same masking class, PowerShell edition.

### PR #56 nitpick
`release-prepare.yml`'s toolchain comment claimed the Rust channel is "baked into the action's default at this commit"; the SHA pins only the action script — the channel resolves from `rust-toolchain.toml` at runtime. Comment corrected.

### PR #59 nitpick
`ExampleComposition` (Go) now defers `Group.Free()` immediately after construction (no-op once `AddGroup` consumes the handle; releases the handle on early-error paths) and checks every `SetLayout`/`AddSource`/`SetSampleRate` error instead of discarding with `_ =` — examples are documentation; they should model correct hygiene.

## Test plan
- [x] YAML validates; `bash scripts/gate.sh` OK; gofmt/go vet clean
- [ ] Windows audio job on this PR proves the tiers still pass with strict exit-code checking

All three originating review-body findings will get on-thread replies referencing this PR per the repo disposition rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Windows audio integration tests now reliably report failures instead of allowing pipeline or logging behavior to mask errors.
  - Test workflows fail fast when audio capture, device enumeration, or process tests encounter regressions.

- **Examples**
  - Improved error handling and resource cleanup in the Go composition example, with setup failures now surfaced clearly.

- **Documentation**
  - Clarified how the Rust toolchain version is resolved during release preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->