### PR TITLE
wave 10 — runtime-verification: Android playback tier, iOS sim mic route, ADR-0006 bench A/B

### DIFF
--- a/.claude/skills/rsac-jni-token-mint-consume-single-so/SKILL.md
+++ b/.claude/skills/rsac-jni-token-mint-consume-single-so/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: rsac-jni-token-mint-consume-single-so
+description: |
+  Rust-on-Android trap: two .so files that each statically link the same Rust
+  library contain DISJOINT copies of its statics — an opaque handle (JNI
+  GlobalRef wrapped as a jlong token, registry entry, channel, atomic) minted
+  through one .so is not safely consumable through the other. Use when:
+  (1) adding a second cdylib that `pub use`s rsac (or any shared Rust rlib),
+  (2) a JNI token/handle "mysteriously" fails validation or dereferences a
+  dead registry when consumed, (3) deciding lib names for test-only Android
+  cdylibs, (4) reviewing System.loadLibrary call sites across test classes.
+  In rsac specifically: RsacProjection hard-codes System.loadLibrary("rsac"),
+  so any driver consuming an AndroidProjectionToken must live in THE SAME
+  librsac.so that registered nativeRetainProjection.
+author: Claude Code
+version: 1.0.0
+date: 2026-07-20
+---
+
+# JNI tokens must mint and consume inside one .so (single rsac copy)
+
+## Problem
+
+rsac's Android consent flow mints an opaque projection token in Kotlin
+(`RsacProjection` → `nativeRetainProjection`, registered by rsac's
+`JNI_OnLoad`) and consumes it in Rust (`AndroidProjectionToken::from_raw` →
+`with_android_projection`). If the mint path and the consume path resolve
+into *different* .so files that each statically link rsac, the token's
+backing state (deletion latch, any registry the token participates in) lives
+in one copy's statics while the consumer reads the other copy's — silent
+misbehavior, not a linker error.
+
+Extra hazard: **both** .so files re-export rsac's `#[no_mangle] JNI_OnLoad`,
+and `RegisterNatives` is last-loaded-wins per Java class. If both libs load
+in one process, whichever loaded last owns `RsacProjection`'s natives.
+
+## Context / Trigger Conditions
+
+- Adding any new cdylib crate with `rsac = { path = ... }` + `pub use rsac;`
+  (the JNI_OnLoad keep-alive trick from `mobile/android-native`).
+- A test needs to drive an API that consumes a Kotlin-minted native handle.
+- Reviewing: multiple `System.loadLibrary` calls across androidTest classes.
+
+## Solution (the wave-10 playback-tier design, review-verified)
+
+1. **Name the test cdylib's `[lib] name = "rsac"` on purpose** so
+   `System.loadLibrary("rsac")` (hard-coded in the shipped `RsacProjection`)
+   loads the ONE .so that both registers the natives (mint) and exposes the
+   driver export (consume). See `mobile/androidtest-native/Cargo.toml`.
+2. The name **collides** with `mobile/android-native`'s output. Safe because
+   they are never co-compiled: every Android build in CI uses explicit `-p`
+   into distinct `-o` dirs, and no `cargo … --workspace` compile exists in
+   any workflow/script (verified by grep + an empirical `cargo build
+   --workspace`, which anyway only WARNS on the artifact-name collision).
+   The root `rsac` crate is a pure rlib (no crate-type), so it never emits
+   `librsac.*` itself.
+3. **Keep load sets disjoint per test class**: the mic tier loads only
+   `rsac_ffi` + shim; the playback tier loads only `rsac`. Kotlin
+   `object`/companion initializers are LAZY (first access, not JUnit class
+   enumeration), so scanning the APK's test classes does not load the other
+   tier's libs. Sequential (non-orchestrated, non-parallel) execution keeps
+   last-wins RegisterNatives deterministic even when both eventually load.
+
+## Verification
+
+- `cargo metadata` exits 0 with three `rsac`-named targets (root rlib +
+  two cdylibs).
+- Reviewer trace: no transitive class-init in the playback test touches
+  `NativeCaptureDriver`; either test order leaves librsac.so's natives
+  current during mint+consume.
+
+## Notes
+
+- If a future change enables the Android test orchestrator (fresh process
+  per test) that is *safer*; in-process parallel test execution would race
+  last-wins RegisterNatives and must not be enabled without revisiting this.
+- If any CI job ever adds an Android-target `--workspace` build, the two
+  cdylibs' output filenames collide in one invocation — split with `-p`.
+- Generalizes beyond JNI: any two cdylibs linking one Rust lib have disjoint
+  `static`s, `OnceLock`s, and registries. Handles must not cross.

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -56,10 +56,11 @@ jobs:
           cargo bench --bench observability -- --quick --save-baseline default
 
       # bridge-zerocopy A/B — advisory input to ADR-0006's promote-or-remove
-      # gate (docs/designs/0006-bridge-zerocopy-samplering.md §6). Does not
-      # currently exercise SampleRing directly (no bench wires it in yet —
-      # tracked separately); this establishes the artifact pipeline so that
-      # work has somewhere to land its numbers.
+      # gate (docs/designs/0006-bridge-zerocopy-samplering.md §6). benches/bridge.rs's
+      # `bridge_ab/samplering/*` vs. `bridge_ab/audiobuffer/*` groups (feature-gated,
+      # so only compiled/run here) directly A/B SampleRing against the default
+      # AudioBuffer ring on the same push+pop round trip; this step is what
+      # accumulates that promote-criterion data run over run.
       - name: cargo bench (bridge-zerocopy feature, --quick)
         run: |
           cargo bench --bench bridge --features bridge-zerocopy -- --quick --save-baseline zerocopy

--- a/.github/workflows/ci-android-emu.yml
+++ b/.github/workflows/ci-android-emu.yml
@@ -9,10 +9,12 @@ name: Android Emulator Runtime Leg
 # `emulator-verified`. It proves the AAudio input path delivers frames through
 # the rsac public API, runs the previously-dormant cfg(android) unit tests
 # (capabilities, record parsing, conversion helpers), and asserts the honest
-# SystemDefault-without-consent refusal. MediaProjection playback tiers need
-# consent-dialog automation (uiautomator) and stay a follow-up extension of
-# this leg; a physical-device pass stays a runbook. This leg is NOT a required
-# PR gate until its acceptance criteria are observed green on a runner.
+# SystemDefault-without-consent refusal. The MediaProjection SystemDefault
+# playback tier is now exercised too (playback tier below — appops-auto-approved
+# consent, no uiautomator needed); the Application/ApplicationByName/ProcessTree
+# UID-filtered playback tiers stay unverified, and a physical-device pass stays
+# a runbook. This leg is NOT a required PR gate until its acceptance criteria
+# are observed green on a runner.
 #
 # KVM: hardware acceleration is mandatory for a usable x86_64 emulator.
 # Blacksmith (blacksmith-4vcpu-ubuntu-2404) KVM support is UNVERIFIED — the
@@ -48,6 +50,22 @@ name: Android Emulator Runtime Leg
 # loud assumption-skip unless `require_frames` — same discipline as the
 # shell-uid smoke. This tier is ADVISORY until observed green (then, as a
 # follow-up: flip require_frames and/or promote to a required check).
+#
+# Playback tier (rsac-e6d3): the SAME test APK also drives
+# CaptureTarget::SystemDefault (AudioPlaybackCapture / MediaProjection) through
+# rsac's PUBLIC capture API. The host phase builds a THIRD native lib — the
+# test-only mobile/androidtest-native cdylib as librsac.so — which re-exports
+# rsac's JNI_OnLoad (so RsacProjection.nativeRetainProjection is registered)
+# and exports the NativePlaybackDriver Java_* symbols. The test pre-grants the
+# PROJECT_MEDIA appop via the UiAutomation shell so the API 30 consent dialog
+# auto-approves (no uiautomator), mints a real token through the shipped
+# RsacProjection flow, plays a USAGE_MEDIA tone as capturable playback, and
+# asserts frames-delivered + negotiated-format sanity (never content). The mic
+# tier and this playback tier keep DISJOINT native-library sets on purpose
+# (librsac_ffi.so+shim vs librsac.so): both link rsac and export JNI_OnLoad, so
+# the winning RegisterNatives must be the .so that both mints and consumes the
+# token — see NativePlaybackDriver.kt. SystemDefault ONLY: the UID-filtered
+# tiers stay unverified. Same soft-skip-unless-`require_frames` discipline.
 # =============================================================================
 
 on:
@@ -76,6 +94,9 @@ on:
       # built from bindings/rsac-ffi/.
       - 'mobile/android/**'
       - 'bindings/rsac-ffi/**'
+      # rsac-e6d3 playback tier: the test-only driver cdylib (librsac.so) that
+      # drives the public SystemDefault playback API from the instrumented test.
+      - 'mobile/androidtest-native/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/ci-android-emu.yml'
@@ -216,12 +237,23 @@ jobs:
                   p for p in glob.glob(pat)
                   if os.access(p, os.X_OK) and not p.endswith((".d", ".rlib", ".rmeta", ".so"))
               ]
-              if len(cands) != 1:
-                  # Newest-mtime wins when hashes accumulated across runs.
-                  cands.sort(key=os.path.getmtime)
-                  cands = cands[-1:]
               if not cands:
                   sys.exit(f"{path}: no executable via json OR glob {pat!r}")
+              if len(cands) != 1:
+                  # Multiple hashed binaries accumulated across runs (a warm
+                  # target dir). Picking newest-mtime here could silently run a
+                  # STALE cached binary and fake runtime evidence — the whole
+                  # point of this leg is that the evidence is real. Hard-fail
+                  # with the candidate list instead (CodeRabbit PR #65,
+                  # fix-now): the caller must clean target/ (or the json path,
+                  # which is unambiguous, must work) rather than gamble on mtime.
+                  listing = "\n".join(f"  {c}" for c in sorted(cands))
+                  sys.exit(
+                      f"{path}: glob {pat!r} matched {len(cands)} executables; "
+                      f"refusing to guess which is current (a stale pick would "
+                      f"fake runtime evidence). Clean target/ and re-run. "
+                      f"Candidates:\n{listing}"
+                  )
               shutil.copy(cands[0], out)
               print(f"{path}: glob-discovered {cands[0]} -> {out}")
 
@@ -299,6 +331,46 @@ jobs:
             }
           ls -l "$JNILIBS"
 
+      # ── Playback-tier driver cdylib (rsac-e6d3) ──────────────────────
+      # librsac.so for the PLAYBACK instrumented test: the test-only
+      # mobile/androidtest-native cdylib re-exports rsac's JNI_OnLoad (so
+      # loading it registers RsacProjection.nativeRetainProjection) AND exports
+      # the NativePlaybackDriver Java_* symbols that drive the public
+      # SystemDefault capture API. Same cargo-ndk pattern as the librsac_ffi.so
+      # step (no --message-format=json; the cdylib's -o path is deterministic).
+      # Distinct -o output dir so it never collides with the ffi build's, then
+      # copied into the SAME androidTest jniLibs (packaged into the test APK
+      # only, never the AAR). This .so is named librsac.so on purpose —
+      # RsacProjection hard-codes System.loadLibrary("rsac") — and is never
+      # co-built with mobile/android-native's identically-named cdylib (each is
+      # a separate `-p` invocation into its own dir), so no cargo output
+      # collision. The mic tier (librsac_ffi.so + shim) and this playback tier
+      # keep disjoint library sets on purpose (see NativePlaybackDriver.kt).
+      - name: Build librsac.so (playback driver) into androidTest jniLibs (x86_64)
+        if: steps.kvm.outputs.available == 'true'
+        run: |
+          export ANDROID_NDK_HOME="${ANDROID_NDK_LATEST_HOME:-$ANDROID_NDK_ROOT}"
+          echo "Using NDK at: $ANDROID_NDK_HOME"
+          cargo ndk -t x86_64 --platform 29 -o playback-jnilibs \
+            build --release -p rsac-androidtest-native \
+            --no-default-features --features feat_android
+          JNILIBS="mobile/android/src/androidTest/jniLibs/x86_64"
+          mkdir -p "$JNILIBS"
+          cp playback-jnilibs/x86_64/librsac.so "$JNILIBS/"
+          # Sanity: the driver .so must export both the driver entry points AND
+          # rsac's JNI_OnLoad (re-exported via `pub use rsac`), else the token
+          # mint would have no registrant in this .so.
+          TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          for sym in JNI_OnLoad \
+            Java_ai_codeseys_rsac_NativePlaybackDriver_drivePlaybackCapture \
+            Java_ai_codeseys_rsac_NativePlaybackDriver_lastNativeError; do
+            "$TOOLCHAIN/llvm-nm" -D "$JNILIBS/librsac.so" | grep -q " $sym\$" || {
+              echo "FAIL: librsac.so (playback driver) does not export $sym"
+              exit 1
+            }
+          done
+          ls -l "$JNILIBS"
+
       # ── Boot the AVD and run the payload ─────────────────────────────
       - name: Run tests on the emulator
         if: steps.kvm.outputs.available == 'true'
@@ -339,13 +411,15 @@ jobs:
               unit-tests.log smoke.log 2>/dev/null || echo "logs missing — see artifacts"
             echo '```'
             echo ""
-            echo "### Instrumented tier (rsac-255b — real app uid + RECORD_AUDIO, shipped C ABI)"
+            echo "### Instrumented tier (real app uid + RECORD_AUDIO)"
+            echo ""
+            echo "_rsac-255b mic tier (shipped C ABI) + rsac-e6d3 playback tier (SystemDefault, public API via MediaProjection)._"
             echo ""
             echo '```'
             grep -iE "BUILD SUCCESSFUL|BUILD FAILED|tests? (passed|failed|completed)|connectedDebugAndroidTest" \
               instrumented.log 2>/dev/null || echo "instrumented.log missing — see artifacts"
             grep -E "drive result|frames delivered|SKIP-WITH-SUMMARY" \
-              instrumented-logcat.log 2>/dev/null || echo "no RsacFramesTest logcat evidence — see artifacts"
+              instrumented-logcat.log 2>/dev/null || echo "no RsacFramesTest/RsacPlaybackTest logcat evidence — see artifacts"
             echo '```'
             echo ""
             echo "_emulator-verified, not device-verified (rsac-e6d3 / rsac-255b)._"

--- a/.github/workflows/ci-android-emu.yml
+++ b/.github/workflows/ci-android-emu.yml
@@ -364,7 +364,7 @@ jobs:
           for sym in JNI_OnLoad \
             Java_ai_codeseys_rsac_NativePlaybackDriver_drivePlaybackCapture \
             Java_ai_codeseys_rsac_NativePlaybackDriver_lastNativeError; do
-            "$TOOLCHAIN/llvm-nm" -D "$JNILIBS/librsac.so" | grep -q " $sym\$" || {
+            "$TOOLCHAIN/llvm-nm" -D --defined-only "$JNILIBS/librsac.so" | grep -q " $sym\$" || {
               echo "FAIL: librsac.so (playback driver) does not export $sym"
               exit 1
             }

--- a/.github/workflows/ci-ios-sim.yml
+++ b/.github/workflows/ci-ios-sim.yml
@@ -85,6 +85,7 @@ jobs:
     outputs:
       runtime: ${{ steps.pick.outputs.runtime }}
       device_udid: ${{ steps.pick.outputs.udid }}
+      host_input_route: ${{ steps.vaudio.outputs.route }}
       unit_tests: ${{ steps.record.outputs.unit_tests }}
       frames_smoke: ${{ steps.record.outputs.frames_smoke }}
       frames_app: ${{ steps.record.outputs.frames_app }}
@@ -179,6 +180,93 @@ jobs:
           echo "**Selected:** iOS \`$RT_VER\` on \`$DTYPE\` (udid \`$UDID\`)." >> "$GITHUB_STEP_SUMMARY"
           echo "runtime=$RT_VER" >> "$GITHUB_OUTPUT"
           echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+
+      # ── Virtual audio input route (rsac-f18f) ─────────────────────────────
+      # Headless macOS runners expose NO host default audio INPUT device, so the
+      # simulator's AVAudioEngine input node reports 0 Hz / 0 ch ("no active
+      # audio input route") regardless of TCC state — the bare + app-hosted
+      # frames smokes then only ever soft-fail (skip-with-summary). The iOS
+      # simulator uses the HOST's default input device as its mic, so installing
+      # a virtual audio device (BlackHole) on the host and making it the default
+      # input BEFORE the simulator boots gives the sim a real input route.
+      # BlackHole delivers (silent) buffers with a valid 48kHz/2ch format, and
+      # the smokes assert DELIVERY + format sanity — never content — so silence
+      # is fine.
+      #
+      # Runs before "Boot the simulator" so the device exists and is the
+      # default input by the time the sim establishes its mic route. (CoreAudio
+      # default-device changes generally propagate to running clients too, so
+      # this ordering is the safe choice rather than a proven hard requirement.)
+      #
+      # Every action here is INDIVIDUALLY tolerant + LOUD: brew install may fail
+      # on a locked-down image, and the coreaudiod restart may be denied by the
+      # runner's sudo policy. Any failure emits a ::warning + a step-summary line
+      # and continues (route=0). It NEVER fails the leg — the frames evidence is
+      # a bonus on top of the always-green harness-chain proof.
+      - name: Virtual audio input route (BlackHole → host default input)
+        id: vaudio
+        if: steps.pick.outputs.runtime != 'none'
+        run: |
+          echo "## Virtual audio input route" >> "$GITHUB_STEP_SUMMARY"
+
+          # Emit route=0 + a summary line and continue (never leg-fatal). The
+          # signal travels as a step output → job output → summary job; nothing
+          # in-job consumes it.
+          no_route() {
+            echo "::warning::$1"
+            echo "- no virtual input route — frames evidence unavailable this run ($1)" >> "$GITHUB_STEP_SUMMARY"
+            echo "route=0" >> "$GITHUB_OUTPUT"
+          }
+
+          # ── Install the HAL plugin + the input-device switcher ──────────────
+          if ! brew install blackhole-2ch switchaudio-osx 2>&1; then
+            no_route "brew install blackhole-2ch/switchaudio-osx failed (locked-down image?)"
+            exit 0
+          fi
+          if ! command -v SwitchAudioSource >/dev/null 2>&1; then
+            no_route "SwitchAudioSource not on PATH after install"
+            exit 0
+          fi
+
+          # ── Reload coreaudiod so the freshly-installed HAL plugin loads ─────
+          # kickstart -k is the supported restart; fall back to killall. Both may
+          # be denied by the runner sudo policy — tolerate and keep polling
+          # (the plugin sometimes registers without a restart).
+          echo "Restarting coreaudiod so the BlackHole HAL plugin loads…"
+          sudo launchctl kickstart -k system/com.apple.audio.coreaudiod 2>&1 \
+            || sudo killall coreaudiod 2>&1 \
+            || echo "::notice::could not restart coreaudiod (sudo policy?) — polling anyway."
+
+          # ── Poll (≤30s) for the BlackHole input device to appear ────────────
+          echo "Inputs before:"
+          SwitchAudioSource -a -t input 2>&1 || true
+          found=0
+          for _ in $(seq 1 30); do
+            if SwitchAudioSource -a -t input 2>/dev/null | grep -qi "BlackHole 2ch"; then
+              found=1
+              break
+            fi
+            sleep 1
+          done
+          if [ "$found" -ne 1 ]; then
+            no_route "BlackHole 2ch input never appeared within 30s (coreaudiod reload likely denied)"
+            exit 0
+          fi
+
+          # ── Make it the host DEFAULT INPUT (what the sim samples at boot) ────
+          if ! SwitchAudioSource -t input -s "BlackHole 2ch" 2>&1; then
+            no_route "could not set BlackHole 2ch as the default input"
+            exit 0
+          fi
+
+          CUR="$(SwitchAudioSource -t input -c 2>/dev/null || echo '<unknown>')"
+          echo "Inputs after (current default input: $CUR):"
+          SwitchAudioSource -a -t input 2>&1 || true
+          {
+            echo "- virtual input route ACTIVE — default input is \`$CUR\`"
+            echo "- frames evidence available this run (route present)"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "route=1" >> "$GITHUB_OUTPUT"
 
       - name: Boot the simulator
         if: steps.pick.outputs.runtime != 'none'
@@ -436,12 +524,25 @@ jobs:
       - name: Report (simulator-verified only)
         env:
           RT: ${{ needs.ios-sim.outputs.runtime }}
+          ROUTE: ${{ needs.ios-sim.outputs.host_input_route }}
           UNIT: ${{ needs.ios-sim.outputs.unit_tests }}
           SMOKE: ${{ needs.ios-sim.outputs.frames_smoke }}
           APP: ${{ needs.ios-sim.outputs.frames_app }}
           JOB: ${{ needs.ios-sim.result }}
         run: |
           set -u
+          # Honest one-shot diagnosis of the frames smokes: a soft-fail means
+          # something different depending on whether a host input route existed.
+          # With no route (ROUTE!=1) zero frames is EXPECTED (headless runner has
+          # no default input). With a route present (ROUTE=1) a soft-fail is a
+          # real signal worth chasing (grant/route wiring), not just "silent CI".
+          if [ "${ROUTE:-0}" = "1" ]; then
+            ROUTE_TXT="present (BlackHole virtual input)"
+            FRAMES_NOTE="a soft-fail here means route present but ZERO frames — investigate (TCC/route wiring), not just a silent runner"
+          else
+            ROUTE_TXT="absent (no host default input on this runner)"
+            FRAMES_NOTE="frames smokes soft-fail EXPECTED — no virtual input route was established this run"
+          fi
           {
             echo "# iOS Simulator Runtime Leg — Summary (simulator-verified)"
             echo ""
@@ -449,10 +550,13 @@ jobs:
             echo "|---|---|---|"
             echo "| ios-sim job | ${JOB:-n/a} | — |"
             echo "| iOS runtime selected | ${RT:-n/a} | probe |"
+            echo "| Host input route (virtual audio) | ${ROUTE_TXT} | probe |"
             echo "| Dormant cfg(ios) unit tests | ${UNIT:-n/a} | simulator-verified |"
             echo "| Frames-delivered smoke (bare binary, public API) | ${SMOKE:-n/a} | simulator-verified |"
             echo "| Frames-delivered smoke (app-hosted, TCC-granted, C API) | ${APP:-n/a} | simulator-verified |"
             echo ""
+            echo "> Frames evidence: ${FRAMES_NOTE}."
+            echo ">"
             echo "> The simulator is NOT a device. Physical-device capture, the"
             echo "> interleaved-delivery fast path, and start-failure rollback"
             echo "> remain a runbook (needs-real-device)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,6 +541,14 @@ jobs:
       - name: Cross-check rsac-ffi for Android (feat_android)
         run: cargo check -p rsac-ffi --target aarch64-linux-android --no-default-features --features feat_android
 
+      # rsac-e6d3: the test-only playback driver cdylib is otherwise compiled
+      # ONLY inside ci-android-emu.yml's KVM-gated step — without this check a
+      # Rust error in its cfg(feat_android) driver module would be invisible
+      # whenever KVM is absent (the emu leg skips). check-not-build is enough:
+      # linking is proven by the emu leg's cargo-ndk build + llvm-nm assert.
+      - name: Cross-check rsac-androidtest-native for Android (feat_android)
+        run: cargo check -p rsac-androidtest-native --target aarch64-linux-android --no-default-features --features feat_android
+
       # rsac-f21c / ADR-0014 §7: the plugin's #[cfg(mobile)] mobile.rs
       # (register_android_plugin, run_mobile_plugin, AndroidProjectionToken
       # threading) is cross-checked here. On the android target the plugin's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3341,6 +3341,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsac-androidtest-native"
+version = "0.4.2"
+dependencies = [
+ "jni-sys 0.3.1",
+ "rsac",
+]
+
+[[package]]
 name = "rsac-ffi"
 version = "0.4.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -416,6 +416,14 @@ members = [
     # Lives under /mobile, which is excluded from the crates.io package —
     # workspace membership is orthogonal to packaging.
     "mobile/android-native",
+    # TEST-ONLY Android cdylib that drives rsac's public PLAYBACK API from the
+    # instrumented androidTest playback tier (rsac-e6d3). publish = false;
+    # built only by ci-android-emu.yml into the git-ignored androidTest
+    # jniLibs. Shares the `rsac` lib name with android-native on purpose (the
+    # shipped System.loadLibrary("rsac") must load ONE librsac.so so token
+    # mint + consume share rsac's statics) — never co-compiled with it, so no
+    # output collision. See the crate's Cargo.toml + src/lib.rs.
+    "mobile/androidtest-native",
     # Tauri v2 plugin (ADR-0014). Lives under /integrations, excluded from the
     # crates.io package (see [package].exclude) — membership is orthogonal to
     # packaging; the desktop target builds + clippies in the workspace CI.

--- a/benches/bridge.rs
+++ b/benches/bridge.rs
@@ -30,6 +30,18 @@
 //!   loop against the new bulk `slice::align_to::<f32>()` reinterpret. Pure
 //!   conversion, no WASAPI/COM — so it builds and runs on any host. See the
 //!   `wasapi_byte_decode` group below for the measured before/after.
+//! - **bridge_ab** (feature `bridge-zerocopy` only) — the default `AudioBuffer`
+//!   ring (`create_bridge`) vs. the opt-in zero-copy `SampleRing` plane
+//!   (`create_sample_ring`) on the identical producer-push + consumer-drain
+//!   round trip, across mono/stereo × small/typical/large chunk sizes. A
+//!   `bridge_ab_push/*` sibling times ONLY the producer push (`iter_custom`,
+//!   drain untimed) — the isolated producer-side cost ADR-0006 §6
+//!   promote-criterion #1 names, which the round trip structurally masks
+//!   (SampleRing pays a consumer-side reconstruction copy the default ring's
+//!   moved `Vec` never does). This is the A/B data ADR-0006's
+//!   promote-or-remove decision needs (see
+//!   `docs/designs/0006-bridge-zerocopy-samplering.md` §6). A no-op when the
+//!   feature is off, since `SampleRing*` does not exist without it.
 //!
 //! All hot values flow through [`std::hint::black_box`] (re-exported by criterion)
 //! so the optimizer cannot elide the work being measured.
@@ -249,11 +261,310 @@ fn bench_wasapi_byte_decode(c: &mut Criterion) {
     group.finish();
 }
 
+// ── bridge_ab: SampleRing vs. AudioBuffer (ADR-0006 promote-or-remove data) ─
+//
+// `--features bridge-zerocopy` only. A/Bs the default `AudioBuffer` ring
+// (`create_bridge`) against the opt-in zero-copy `SampleRing` plane
+// (`create_sample_ring`, `docs/designs/0006-bridge-zerocopy-samplering.md`)
+// on the IDENTICAL producer-push + consumer-drain round trip, at the same
+// chunk sizes, same sample counts, same warm-up discipline as the rest of
+// this file — so the numbers are apples-to-apples and feed ADR-0006 §6
+// promote-criterion #1. Group/benchmark names are stable and greppable
+// (`bridge_ab/samplering/...` vs. `bridge_ab/audiobuffer/...`) so `bench.yml`
+// and any future extraction script can select them by substring.
+#[cfg(feature = "bridge-zerocopy")]
+mod bridge_ab {
+    use std::hint::black_box;
+    use std::time::{Duration, Instant};
+
+    use criterion::{BenchmarkId, Criterion, Throughput};
+
+    use rsac::bridge::ring_buffer::{
+        calculate_capacity, create_bridge, create_sample_ring, BridgeConsumer, BridgeProducer,
+        SampleRingConsumer, SampleRingProducer,
+    };
+    use rsac::core::config::AudioFormat;
+
+    /// One (channels, frames) case per row of the A/B matrix. Frame counts mirror
+    /// the sizes already used elsewhere in this file: a small ~10 ms WASAPI-style
+    /// packet (480 frames, see `WASAPI_PACKET_FRAMES` above), the typical 1024-frame
+    /// period the rest of `bridge.rs` benches against (`FRAMES`/`SAMPLES` above),
+    /// and a large 4096-frame period (matches `SCRATCH_MIN_FRAMES` /
+    /// `TAP_BUFFER_FRAMES` sizing used by the Android/iOS backends).
+    struct Case {
+        label: &'static str,
+        channels: u16,
+        frames: usize,
+    }
+
+    const CASES: &[Case] = &[
+        Case {
+            label: "mono_small",
+            channels: 1,
+            frames: super::WASAPI_PACKET_FRAMES, // 480
+        },
+        Case {
+            label: "stereo_small",
+            channels: 2,
+            frames: super::WASAPI_PACKET_FRAMES, // 480
+        },
+        Case {
+            label: "mono_typical",
+            channels: 1,
+            frames: super::FRAMES, // 1024
+        },
+        Case {
+            label: "stereo_typical",
+            channels: 2,
+            frames: super::FRAMES, // 1024
+        },
+        Case {
+            label: "mono_large",
+            channels: 1,
+            frames: 4096,
+        },
+        Case {
+            label: "stereo_large",
+            channels: 2,
+            frames: 4096,
+        },
+    ];
+
+    /// Build a deterministic interleaved slice of `samples` `f32`s — the same
+    /// generator shape as [`super::make_slice`], parameterized on size so every
+    /// case (and both sides of the A/B) pushes an identical payload.
+    fn make_case_slice(samples: usize) -> Vec<f32> {
+        (0..samples).map(|i| (i as f32) * 1e-4).collect()
+    }
+
+    /// Warm the default `AudioBuffer` ring's free-list, mirroring [`super::warm_up`].
+    fn warm_up_audiobuffer(
+        producer: &mut BridgeProducer,
+        consumer: &mut BridgeConsumer,
+        slice: &[f32],
+        channels: u16,
+        sample_rate: u32,
+    ) {
+        for _ in 0..64 {
+            producer.push_samples_or_drop(slice, channels, sample_rate);
+            let _ = consumer.pop();
+        }
+    }
+
+    /// Warm the `SampleRing`'s sample + metadata rings the same way — pushing
+    /// and draining a few cycles before timing starts — so both sides of the A/B
+    /// are measured in steady state, not during ring warm-up.
+    fn warm_up_sample_ring(
+        producer: &mut SampleRingProducer,
+        consumer: &mut SampleRingConsumer,
+        slice: &[f32],
+        channels: u16,
+        sample_rate: u32,
+    ) {
+        for _ in 0..64 {
+            producer.push_samples_or_drop(slice, channels, sample_rate);
+            let _ = consumer.pop();
+        }
+    }
+
+    /// The default `AudioBuffer` ring side of the A/B: identical push+pop round
+    /// trip to [`super::bench_push_pop_roundtrip`], parameterized over the case
+    /// matrix so it can be compared directly against the `SampleRing` side below.
+    fn bench_audiobuffer_side(c: &mut Criterion) {
+        let sample_rate = super::SAMPLE_RATE;
+        let capacity = calculate_capacity(Some(64), 4);
+
+        let mut group = c.benchmark_group("bridge_ab/audiobuffer");
+        for case in CASES {
+            let samples = case.frames * case.channels as usize;
+            let slice = make_case_slice(samples);
+            group.throughput(Throughput::Elements(samples as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(case.label), case, |b, case| {
+                let (mut producer, mut consumer) = create_bridge(capacity, AudioFormat::default());
+                warm_up_audiobuffer(
+                    &mut producer,
+                    &mut consumer,
+                    &slice,
+                    case.channels,
+                    sample_rate,
+                );
+
+                b.iter(|| {
+                    let pushed = producer.push_samples_or_drop(
+                        black_box(&slice),
+                        case.channels,
+                        sample_rate,
+                    );
+                    black_box(pushed);
+                    let popped = consumer.pop();
+                    black_box(popped);
+                });
+            });
+        }
+        group.finish();
+    }
+
+    /// The zero-copy `SampleRing` side of the A/B: identical push+pop round trip
+    /// and case matrix, but through `create_sample_ring` instead of
+    /// `create_bridge` — the producer writes straight into the ring's
+    /// uninitialized slots (no `Vec`/`AudioBuffer` on this call) via
+    /// `write_chunk_uninit` + `CopyToUninit` (see `SampleRingProducer` docs in
+    /// `src/bridge/ring_buffer.rs`), and the consumer reconstructs an
+    /// `AudioBuffer` equivalent to what the default ring would deliver.
+    fn bench_samplering_side(c: &mut Criterion) {
+        let sample_rate = super::SAMPLE_RATE;
+        let capacity_chunks = calculate_capacity(Some(64), 4);
+
+        let mut group = c.benchmark_group("bridge_ab/samplering");
+        for case in CASES {
+            let samples = case.frames * case.channels as usize;
+            let slice = make_case_slice(samples);
+            // Ring sized PER CASE (`capacity_chunks * this case's samples`), not
+            // by the matrix maximum: a shared largest-case ring (~2 MB) would
+            // make the linear producer/consumer cursor sweep touch cold cache
+            // lines on the small/mono cases — a footprint asymmetry the
+            // AudioBuffer side (tiny recycled Vec working set) never pays, and
+            // therefore bias, not signal.
+            let sample_capacity = capacity_chunks * samples;
+            group.throughput(Throughput::Elements(samples as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(case.label), case, |b, case| {
+                let (mut producer, mut consumer) =
+                    create_sample_ring(sample_capacity, capacity_chunks, AudioFormat::default());
+                warm_up_sample_ring(
+                    &mut producer,
+                    &mut consumer,
+                    &slice,
+                    case.channels,
+                    sample_rate,
+                );
+
+                b.iter(|| {
+                    let pushed = producer.push_samples_or_drop(
+                        black_box(&slice),
+                        case.channels,
+                        sample_rate,
+                    );
+                    black_box(pushed);
+                    let popped = consumer.pop();
+                    black_box(popped);
+                });
+            });
+        }
+        group.finish();
+    }
+
+    /// Producer-side-only push cost — the metric ADR-0006 §6 promote-criterion
+    /// #1 actually names ("producer-side win: lower p99 push cost and/or fewer
+    /// copies"). The round-trip groups above cannot isolate it: on the pop
+    /// side, `SampleRing` pays a second payload memcpy (ring → reconstructed
+    /// `AudioBuffer`) while the default ring MOVES its recycled `Vec` out with
+    /// no copy — so a producer-side win is structurally masked in a round
+    /// trip. Here `iter_custom` times ONLY `push_samples_or_drop`; the drain
+    /// that keeps the ring unsaturated (steady-state recycle path, never the
+    /// drop path) happens outside the timed region. The `Instant` read
+    /// overhead is identical on both sides, so the comparison stays fair.
+    fn bench_push_only_sides(c: &mut Criterion) {
+        let sample_rate = super::SAMPLE_RATE;
+        let capacity_chunks = calculate_capacity(Some(64), 4);
+
+        let mut group = c.benchmark_group("bridge_ab_push/audiobuffer");
+        for case in CASES {
+            let samples = case.frames * case.channels as usize;
+            let slice = make_case_slice(samples);
+            group.throughput(Throughput::Elements(samples as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(case.label), case, |b, case| {
+                let (mut producer, mut consumer) =
+                    create_bridge(capacity_chunks, AudioFormat::default());
+                warm_up_audiobuffer(
+                    &mut producer,
+                    &mut consumer,
+                    &slice,
+                    case.channels,
+                    sample_rate,
+                );
+                b.iter_custom(|iters| {
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        let start = Instant::now();
+                        let pushed = producer.push_samples_or_drop(
+                            black_box(&slice),
+                            case.channels,
+                            sample_rate,
+                        );
+                        total += start.elapsed();
+                        black_box(pushed);
+                        let _ = consumer.pop();
+                    }
+                    total
+                });
+            });
+        }
+        group.finish();
+
+        let mut group = c.benchmark_group("bridge_ab_push/samplering");
+        for case in CASES {
+            let samples = case.frames * case.channels as usize;
+            let slice = make_case_slice(samples);
+            // Per-case ring sizing — same cache-fairness rationale as the
+            // round-trip group above.
+            let sample_capacity = capacity_chunks * samples;
+            group.throughput(Throughput::Elements(samples as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(case.label), case, |b, case| {
+                let (mut producer, mut consumer) =
+                    create_sample_ring(sample_capacity, capacity_chunks, AudioFormat::default());
+                warm_up_sample_ring(
+                    &mut producer,
+                    &mut consumer,
+                    &slice,
+                    case.channels,
+                    sample_rate,
+                );
+                b.iter_custom(|iters| {
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        let start = Instant::now();
+                        let pushed = producer.push_samples_or_drop(
+                            black_box(&slice),
+                            case.channels,
+                            sample_rate,
+                        );
+                        total += start.elapsed();
+                        black_box(pushed);
+                        let _ = consumer.pop();
+                    }
+                    total
+                });
+            });
+        }
+        group.finish();
+    }
+
+    pub(super) fn bench_bridge_ab(c: &mut Criterion) {
+        bench_audiobuffer_side(c);
+        bench_samplering_side(c);
+        bench_push_only_sides(c);
+    }
+}
+
+#[cfg(feature = "bridge-zerocopy")]
+fn bench_bridge_ab(c: &mut Criterion) {
+    bridge_ab::bench_bridge_ab(c);
+}
+
+#[cfg(not(feature = "bridge-zerocopy"))]
+fn bench_bridge_ab(_c: &mut Criterion) {
+    // No-op without the feature: `SampleRing*` does not exist, so there is
+    // nothing to A/B. Kept as a real (empty) criterion target rather than
+    // conditionally omitted from `criterion_group!` so the group list below
+    // stays a single unconditional statement regardless of feature state.
+}
+
 criterion_group!(
     benches,
     bench_push_throughput,
     bench_push_pop_roundtrip,
     bench_capacity_sweep,
-    bench_wasapi_byte_decode
+    bench_wasapi_byte_decode,
+    bench_bridge_ab
 );
 criterion_main!(benches);

--- a/docs/designs/0006-bridge-zerocopy-samplering.md
+++ b/docs/designs/0006-bridge-zerocopy-samplering.md
@@ -113,16 +113,15 @@ feature as an internal A/B alternative, with the following invariants recorded:
    the floor matters ("0.3.4: write_chunk_uninit + CopyToUninit for bridge-zerocopy").
    Do not relax this floor while `bridge-zerocopy` exists.
 
-5. **No backend and no benchmark uses it today (honest status).** The only call sites of
-   `create_sample_ring` / `SampleRing*` in the tree are the
-   `#[cfg(all(test, feature = "bridge-zerocopy"))] mod sample_ring_tests` unit tests
-   (data round-trip, timestamp preservation, FIFO+wrap, atomic-drop-when-full,
-   `available_chunks`). No `src/audio/*` backend constructs a `SampleRing`, and — despite
-   the `Cargo.toml` comment saying it is "A/B'd in benches/bridge.rs" — `benches/bridge.rs`
-   exercises only the default `create_bridge` + `push_samples_or_drop` path. **It is
-   implemented and unit-tested, not benched and not wired.** (The "benched" framing in the
-   critique and the Cargo.toml comment overstates the current state; the benchmark wiring
-   is part of the promote criteria below.)
+5. **No backend uses it today; the A/B bench now does (honest status).** The only call
+   sites of `create_sample_ring` / `SampleRing*` in the tree are
+   `#[cfg(all(test, feature = "bridge-zerocopy"))] mod sample_ring_tests` (data
+   round-trip, timestamp preservation, FIFO+wrap, atomic-drop-when-full,
+   `available_chunks`) and, as of the `bridge_ab` groups in `benches/bridge.rs`
+   (feature-gated on `bridge-zerocopy`), the promote-criterion #1 benchmark itself. No
+   `src/audio/*` backend constructs a `SampleRing` — that remains unwired (promote
+   criterion #2, §6). The `Cargo.toml` "A/B'd in benches/bridge.rs" comment is now
+   accurate for the benchmark half of the claim; the wiring half is still open.
 
 ## 5. Consequences
 
@@ -148,17 +147,24 @@ an unwired, unbenchmarked feature.
 weekly schedule + `workflow_dispatch` (previously `cargo bench` had zero CI callers —
 this ADR's promote-criteria data could never accumulate). The workflow archives
 `target/criterion/**` baselines for both the default feature set and `--features
-bridge-zerocopy`, but neither `benches/bridge.rs` nor `benches/observability.rs` yet
-constructs a `SampleRing` — promote-criterion #1 below (an actual A/B of `SampleRing`
-vs. the default ring) is still unimplemented. Tracked as a follow-on seed (filed
-alongside rsac-1da3) rather than folded into this ADR's decision, which still requires
-that data.
+bridge-zerocopy`.
+
+**Status update (rsac-6508):** `benches/bridge.rs` now carries the `bridge_ab`
+groups (`bridge_ab/samplering/*` vs. `bridge_ab/audiobuffer/*`, behind
+`--features bridge-zerocopy`) that A/B `SampleRing` against the default
+`AudioBuffer` ring on the identical producer-push + consumer-drain round trip,
+at mono/stereo × small/typical/large chunk sizes. `bench.yml`'s weekly
+`bridge-zerocopy` leg now exercises it every run, so promote-criterion #1's
+data starts accumulating from this point forward. The *decision* itself is
+still open — it needs repeatable data across multiple runs/targets, not a
+single sample — and criteria #2 (backend wiring) and #3 (`rt_alloc` probe on
+the `SampleRing` producer) remain unimplemented.
 
 **Promote** (wire into a backend) when *all* hold:
-1. A benchmark in `benches/bridge.rs` (behind `--features bridge-zerocopy`) A/Bs
-   `SampleRing` against the default `AudioBuffer` ring on the same 1024-frame stereo
-   period, and shows a measurable, repeatable producer-side win (lower p99 push cost
-   and/or fewer copies) on at least one supported target. This also makes the existing
+1. The `bridge_ab` benchmark in `benches/bridge.rs` (behind `--features
+   bridge-zerocopy`) shows a measurable, repeatable producer-side win (lower
+   p99 push cost and/or fewer copies) on at least one supported target, across
+   multiple accumulated `bench.yml` runs. This also makes the existing
    `Cargo.toml` "A/B'd in benches/bridge.rs" comment true.
 2. At least one interleaved-`f32` backend (PipeWire or CoreAudio, which already hand the
    producer a contiguous `&[f32]` — see the Linux `align_to::<f32>()` reinterpret) is

--- a/docs/designs/0006-bridge-zerocopy-samplering.md
+++ b/docs/designs/0006-bridge-zerocopy-samplering.md
@@ -6,7 +6,8 @@
 `create_sample_ring`, `ChunkMeta`), `Cargo.toml` feature `bridge-zerocopy`
 **Verdict:** Ship a parallel sample-domain SPSC ring behind the **default-off**
 `bridge-zerocopy` feature as an internal A/B alternative to the default `AudioBuffer`
-ring. It is implemented and unit-tested but **wired into no backend and no benchmark
+ring. It is implemented, unit-tested, and A/B-benched (`benches/bridge.rs`
+`bridge_ab*` groups, accumulating via `bench.yml`) but **wired into no backend
 today**; record the promote-or-remove criteria so it does not rot as undocumented
 near-dead surface.
 

--- a/mobile/android/build.gradle.kts
+++ b/mobile/android/build.gradle.kts
@@ -95,4 +95,11 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation("androidx.test:rules:1.6.1") // GrantPermissionRule
+    // rsac-e6d3 playback tier: ActivityScenario (launches RsacTestActivity to
+    // host the MediaProjection consent flow). The consent dialog is auto-
+    // approved via `appops set … PROJECT_MEDIA allow` through the
+    // instrumentation UiAutomation shell, so no uiautomator dependency is
+    // needed; add androidx.test.uiautomator:uiautomator:2.3.0 only if a future
+    // image ignores the appop and a dialog click becomes the fallback.
+    androidTestImplementation("androidx.test:core:1.6.1") // ActivityScenario
 }

--- a/mobile/android/src/androidTest/AndroidManifest.xml
+++ b/mobile/android/src/androidTest/AndroidManifest.xml
@@ -1,15 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  rsac-255b — androidTest manifest for the self-instrumenting test APK.
+  rsac-e6d3 — androidTest manifest for the self-instrumenting test APK.
 
-  RECORD_AUDIO already merges in from the library's main manifest, but it is
-  redeclared here explicitly so the TEST APK's permission never depends on
-  manifest-merge scoping (GrantPermissionRule can only grant a permission the
-  installed package actually declares). Mic path only: no MediaProjection,
-  no foreground-service permissions needed here.
+  MIC tier (rsac-255b): RECORD_AUDIO is redeclared here explicitly so the TEST
+  APK's permission never depends on manifest-merge scoping (GrantPermissionRule
+  can only grant a permission the installed package actually declares).
+
+  PLAYBACK tier (rsac-e6d3): the MediaProjection consent flow additionally
+  needs the foreground-service permissions and the mediaProjection-typed
+  RsacCaptureService, plus a foreground test Activity to launch the consent
+  dialog from. RsacCaptureService and the FGS permissions merge in from the
+  library's main manifest, but — same defensive posture as RECORD_AUDIO above —
+  the FGS uses-permissions are redeclared here so the test APK never depends on
+  merge scoping, and the test-only Activity is declared here (it exists only in
+  androidTest, so it can only be declared here).
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+
+    <!--
+      allowAudioPlaybackCapture=true: the test process plays a MEDIA tone and
+      captures it via SystemDefault. AudioPlaybackCapture only picks up
+      playback the PLAYING app permits; the default is true for apps targeting
+      API 29+, but we set it explicitly so capturability never hinges on the
+      test APK's resolved targetSdk (minSdk is 29). USAGE_MEDIA is capturable
+      by third parties (unlike USAGE_VOICE_COMMUNICATION).
+    -->
+    <application android:allowAudioPlaybackCapture="true">
+        <!--
+          Foreground host Activity for the consent flow. exported=false; it is
+          launched only in-process by ActivityScenario. No launcher intent
+          filter — the test drives it directly.
+        -->
+        <activity
+            android:name="ai.codeseys.rsac.RsacTestActivity"
+            android:exported="false" />
+    </application>
 
 </manifest>

--- a/mobile/android/src/androidTest/kotlin/ai/codeseys/rsac/NativePlaybackDriver.kt
+++ b/mobile/android/src/androidTest/kotlin/ai/codeseys/rsac/NativePlaybackDriver.kt
@@ -1,0 +1,69 @@
+// rsac-e6d3 (playback tier) — TEST-ONLY binding to the playback driver
+// exported from librsac.so (mobile/androidtest-native). Lives in
+// src/androidTest/ so neither the class nor the .so ever enters the production
+// rsac.aar.
+package ai.codeseys.rsac
+
+/**
+ * Drives `CaptureTarget::SystemDefault` playback capture
+ * (`AudioPlaybackCapture` / MediaProjection) through rsac's **public** capture
+ * API, consuming a real projection token minted by [RsacProjection].
+ *
+ * ### Why this loads ONLY `librsac.so` (and the mic tier only its own libs)
+ *
+ * `librsac.so` (this driver + rsac's re-exported `JNI_OnLoad`) and
+ * `librsac_ffi.so` (the mic tier's shipped C ABI) each statically link rsac —
+ * so each carries its **own** copy of rsac's process statics (the JNI class
+ * cache, the ingest-session registry) and each exports rsac's `JNI_OnLoad`,
+ * which `RegisterNatives`-binds the shared AAR natives
+ * (`nativeRetainProjection`, `nativePush`, …). If both `.so`s load in one
+ * process, the **last** `JNI_OnLoad` to run wins that registration.
+ *
+ * The projection token is minted (`RsacProjection.nativeRetainProjection`) and
+ * consumed (the driver's `build()` → capture) inside rsac's statics — a token
+ * minted against one copy is not safely consumable against the other. So the
+ * two tiers keep disjoint library sets:
+ *  - this playback tier loads ONLY `rsac` (here); [RsacProjection] also loads
+ *    only `rsac`. `librsac.so` is loaded by the playback path alone, so its
+ *    `JNI_OnLoad` is the winning registrant at mint time — mint and consume
+ *    share one rsac copy.
+ *  - the mic tier ([NativeCaptureDriver]) loads ONLY `rsac_ffi` +
+ *    `rsac_androidtest_shim`, never `rsac`.
+ *
+ * Do not add a `System.loadLibrary("rsac_ffi")` here (or a `"rsac"` load in
+ * the mic tier): that would reintroduce the cross-copy registration race.
+ */
+object NativePlaybackDriver {
+    init {
+        // The ONE library for the playback tier. Idempotent with
+        // RsacProjection.isNativeAvailable()'s own load of the same lib; both
+        // resolve the projection natives + this driver's Java_* exports out of
+        // the same librsac.so.
+        System.loadLibrary("rsac")
+    }
+
+    /**
+     * Drives `SystemDefault` playback capture end-to-end through rsac's public
+     * API (mirrors `tests/android_emu_smoke.rs`):
+     * `AndroidProjectionToken::from_raw(tokenRaw) →
+     * with_target(SystemDefault) → with_android_projection → sample_rate →
+     * channels → build → start → format → bounded read loop → request_stop`.
+     *
+     * @param tokenRaw the opaque projection token from
+     *   [RsacProjection.Callback.onToken]
+     * @return `[errorCode, buffers, frames, negRate, negChannels,
+     *   negSampleFormat]` — errorCode 0 == no hard error; on a build/start/
+     *   format failure the negotiated fields stay 0/0/-1 and
+     *   [lastNativeError] carries the `AudioError` text. Frames are counted,
+     *   content is never inspected.
+     */
+    external fun drivePlaybackCapture(
+        tokenRaw: Long,
+        sampleRate: Int,
+        channels: Int,
+        timeoutMs: Int,
+    ): LongArray
+
+    /** The `AudioError` text captured at the last failing stage ("" if none). */
+    external fun lastNativeError(): String
+}

--- a/mobile/android/src/androidTest/kotlin/ai/codeseys/rsac/RsacPlaybackInstrumentedTest.kt
+++ b/mobile/android/src/androidTest/kotlin/ai/codeseys/rsac/RsacPlaybackInstrumentedTest.kt
@@ -1,0 +1,348 @@
+// rsac-e6d3 (playback tier) — instrumented frames-delivered evidence for the
+// Android PLAYBACK path (AudioPlaybackCapture / MediaProjection), the twin of
+// the MIC tier (RsacFramesInstrumentedTest).
+//
+// WHY THIS EXISTS: SystemDefault playback capture needs a user-consented
+// MediaProjection, a mediaProjection-typed foreground service confirmed-
+// foreground before acquisition (see the rsac-android-mediaprojection-fgs-
+// ordering skill), and RECORD_AUDIO — none of which the shell-uid smoke or the
+// mic tier exercise. This self-instrumenting test APK installs as a REAL
+// package with a REAL uid, pre-grants the projection consent via appops so the
+// API 30 system dialog auto-approves, drives the SHIPPED RsacProjection consent
+// flow to mint a real token, and hands that token to rsac's PUBLIC capture API
+// (CaptureTarget::SystemDefault) through the test-only librsac.so driver.
+//
+// SCOPE — SystemDefault playback tier ONLY. The Application / ApplicationByName
+// / ProcessTree UID-filtered tiers are NOT exercised here and stay unverified.
+// Assertions cover frames-delivered + negotiated-format sanity, NEVER audio
+// content: a continuous MEDIA tone is played so there is capturable playback,
+// but a pass proves the projection→FGS→AudioPlaybackCapture→CaptureBridge→JNI
+// →bridge→public-read WIRING reaches rsac under an app uid, not that it carries
+// that tone.
+//
+// HONESTY: a pass is emulator-verified, never device-verified. Consent that
+// never fires (appops did not auto-approve on this image), a refused build/
+// start, or zero frames degrades to a LOUD assumption-skip unless the
+// `rsac_require_frames` instrumentation arg is "1" (wired from the workflow's
+// require_frames dispatch input) — mirroring the mic tier and the shell-uid
+// smoke.
+//
+// LIBRARY-LOADING DISCIPLINE (load-bearing — see NativePlaybackDriver): this
+// tier loads ONLY librsac.so (here + via RsacProjection). The mic tier loads
+// ONLY librsac_ffi.so + the shim. Both .so's statically link rsac and export
+// rsac's JNI_OnLoad, and the LAST JNI_OnLoad to run wins the RegisterNatives
+// for the shared AAR natives (nativeRetainProjection / nativePush). Test
+// methods run sequentially and only the mic test touches NativeCaptureDriver
+// (which loads librsac_ffi.so), so during THIS test librsac.so is the most-
+// recent registrant — the token mint (nativeRetainProjection) and the ingest
+// (nativePush → the session registry populated by build()) both resolve into
+// librsac.so's ONE rsac copy. Do not load librsac_ffi.so from this test.
+package ai.codeseys.rsac
+
+import android.Manifest
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import android.os.ParcelFileDescriptor
+import android.util.Log
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.PI
+import kotlin.math.sin
+
+@RunWith(AndroidJUnit4::class)
+class RsacPlaybackInstrumentedTest {
+    // Playback capture requires RECORD_AUDIO too (API 29+ contract), granted
+    // to this package's real uid exactly as the mic tier does.
+    @get:Rule
+    val recordAudio: GrantPermissionRule =
+        GrantPermissionRule.grant(Manifest.permission.RECORD_AUDIO)
+
+    private fun requireFramesHard(): Boolean =
+        InstrumentationRegistry.getArguments().getString("rsac_require_frames") == "1"
+
+    @Test
+    fun playbackFramesDeliveredViaPublicApi() {
+        val requireFrames = requireFramesHard()
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        // Self-instrumenting library test: the package that requests the
+        // projection (and whose PROJECT_MEDIA appop gates the dialog) is this
+        // APK's own package.
+        val targetPackage = instrumentation.targetContext.packageName
+
+        // Pre-grant the projection consent so the API 30 system dialog auto-
+        // approves without any UI interaction. FALLBACK (not wired here to
+        // avoid the uiautomator dependency): if a future image ignores this
+        // appop, a UiAutomator click on the dialog's "Start now" button would
+        // approve it — add androidx.test.uiautomator only if that becomes
+        // necessary. Until then, a non-firing dialog is an honest soft-skip.
+        preGrantProjectMedia(targetPackage)
+
+        // Continuous MEDIA tone from THIS process → capturable playback for the
+        // SystemDefault (all-usages, no-UID-filter) capture to pick up. The
+        // androidTest manifest sets allowAudioPlaybackCapture=true so this
+        // process's USAGE_MEDIA playback is capturable regardless of the test
+        // APK's resolved targetSdk.
+        // token/denied are written in the callback (main thread) and read here
+        // after consent.await(); CountDownLatch.countDown happens-before a
+        // successful await return, so the writes are visible without @Volatile
+        // (which Kotlin does not allow on locals anyway).
+        val tone = ContinuousTone()
+        var token = 0L
+        var denied: String? = null
+        val consent = CountDownLatch(1)
+
+        val scenario = ActivityScenario.launch(RsacTestActivity::class.java)
+        try {
+            tone.start()
+
+            // RsacProjection.request must run on the main thread with a started
+            // Activity; the callback also fires on the main thread. Latch bridges
+            // it back to this instrumentation thread.
+            scenario.onActivity { activity ->
+                RsacProjection.request(
+                    activity,
+                    object : RsacProjection.Callback {
+                        override fun onToken(t: Long) {
+                            token = t
+                            consent.countDown()
+                        }
+
+                        override fun onDenied(reason: String) {
+                            denied = reason
+                            consent.countDown()
+                        }
+                    },
+                )
+            }
+
+            val fired = consent.await(CONSENT_TIMEOUT_SEC, TimeUnit.SECONDS)
+            if (!fired) {
+                softSkip(
+                    requireFrames,
+                    "consent callback never fired within ${CONSENT_TIMEOUT_SEC}s " +
+                        "(appops PROJECT_MEDIA did not auto-approve the dialog on " +
+                        "this image). emulator-verified evidence NOT produced.",
+                )
+                return
+            }
+            denied?.let {
+                softSkip(
+                    requireFrames,
+                    "MediaProjection consent denied: $it. emulator-verified " +
+                        "evidence NOT produced.",
+                )
+                return
+            }
+            if (token == 0L) {
+                softSkip(
+                    requireFrames,
+                    "consent granted but the projection token was 0 (the " +
+                        "GlobalRef could not be retained). emulator-verified " +
+                        "evidence NOT produced.",
+                )
+                return
+            }
+
+            // Drive SystemDefault playback capture end-to-end through rsac's
+            // public API. The FGS started by RsacProjection.request is still
+            // foreground (we stop it in `finally`, after the capture is torn
+            // down inside the driver via request_stop + Drop).
+            // [errorCode, buffers, frames, negRate, negChannels, negSampleFormat]
+            val r = NativePlaybackDriver.drivePlaybackCapture(
+                tokenRaw = token,
+                sampleRate = 48_000,
+                channels = 2,
+                timeoutMs = 15_000,
+            )
+            val errorCode = r[0]
+            val buffers = r[1]
+            val frames = r[2]
+            val negRate = r[3]
+            val negChannels = r[4]
+            val negSampleFormat = r[5]
+
+            Log.i(
+                TAG,
+                "drive result: errorCode=$errorCode buffers=$buffers frames=$frames " +
+                    "negotiated rate=$negRate channels=$negChannels " +
+                    "sampleFormat=$negSampleFormat",
+            )
+
+            if (errorCode != 0L) {
+                val detail = NativePlaybackDriver.lastNativeError()
+                softSkip(
+                    requireFrames,
+                    "rsac refused the SystemDefault playback route with a real " +
+                        "projection token (errorCode=$errorCode: $detail). " +
+                        "emulator-verified evidence NOT produced.",
+                )
+                return
+            }
+            if (buffers < 1L || frames <= 0L) {
+                softSkip(
+                    requireFrames,
+                    "playback capture started but delivered buffers=$buffers " +
+                        "frames=$frames within the deadline (no capturable " +
+                        "playback reached the record?). emulator-verified " +
+                        "evidence NOT produced.",
+                )
+                return
+            }
+
+            // Frames delivered — negotiated format must be real (the Kotlin
+            // CaptureBridge builds AudioRecord with the requested shape in
+            // PCM_FLOAT and does not renegotiate, so this equals the request,
+            // but assert VALIDITY, not identity).
+            assertTrue("negotiated sample rate $negRate outside 8000..=96000", negRate in 8_000..96_000)
+            assertTrue("negotiated channels $negChannels not in {1, 2}", negChannels == 1L || negChannels == 2L)
+            assertTrue(
+                "negotiated sample_format $negSampleFormat not a valid rsac_sample_format_t",
+                negSampleFormat in 0L..3L,
+            )
+
+            Log.i(
+                TAG,
+                "playback frames delivered via public API (emulator-verified): " +
+                    "buffers=$buffers frames=$frames rate=$negRate " +
+                    "channels=$negChannels",
+            )
+        } finally {
+            tone.stop()
+            // Stop the mediaProjection FGS the consent flow started (the capture
+            // itself was torn down inside the driver). Idempotent; harmless if
+            // consent never started it.
+            RsacCaptureService.stop(instrumentation.targetContext)
+            scenario.close()
+        }
+    }
+
+    /**
+     * `appops set <pkg> PROJECT_MEDIA allow` via the instrumentation's
+     * UiAutomation shell — makes [android.media.projection.MediaProjectionManager]
+     * auto-approve the consent dialog. The returned [ParcelFileDescriptor] MUST
+     * be drained/closed or the shell command's pipe leaks.
+     */
+    private fun preGrantProjectMedia(pkg: String) {
+        val pfd = InstrumentationRegistry.getInstrumentation()
+            .uiAutomation
+            .executeShellCommand("appops set $pkg PROJECT_MEDIA allow")
+        // Drain then close (also closes the fd) so the command completes and no
+        // descriptor leaks.
+        ParcelFileDescriptor.AutoCloseInputStream(pfd).use { it.readBytes() }
+        Log.i(TAG, "pre-granted PROJECT_MEDIA appop for $pkg")
+    }
+
+    private fun softSkip(requireFrames: Boolean, message: String) {
+        val msg = "SKIP-WITH-SUMMARY: $message"
+        Log.w(TAG, msg)
+        if (requireFrames) {
+            throw AssertionError(msg)
+        }
+        assumeTrue(msg, false) // loud skip, not a red X
+    }
+
+    /**
+     * A dedicated thread streaming a continuous sine tone through an
+     * [AudioTrack] with `USAGE_MEDIA` — capturable playback for the capture to
+     * pick up. Not audible on a `-no-window` emulator; it exists purely to make
+     * the playback-capture record non-silent. Idempotent start/stop.
+     */
+    private class ContinuousTone {
+        private val running = AtomicBoolean(false)
+        @Volatile private var thread: Thread? = null
+
+        fun start() {
+            if (!running.compareAndSet(false, true)) return
+            thread = Thread({ loop() }, "rsac-test-tone").apply {
+                isDaemon = true
+                start()
+            }
+        }
+
+        fun stop() {
+            running.set(false)
+            thread?.join(2_000)
+            thread = null
+        }
+
+        private fun loop() {
+            val minBytes = AudioTrack.getMinBufferSize(
+                SAMPLE_RATE,
+                AudioFormat.CHANNEL_OUT_STEREO,
+                AudioFormat.ENCODING_PCM_FLOAT,
+            )
+            val bufferBytes = maxOf(minBytes, FRAMES_PER_WRITE * CHANNELS * BYTES_PER_FLOAT)
+            val track = AudioTrack.Builder()
+                .setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_MEDIA)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                        .build(),
+                )
+                .setAudioFormat(
+                    AudioFormat.Builder()
+                        .setEncoding(AudioFormat.ENCODING_PCM_FLOAT)
+                        .setSampleRate(SAMPLE_RATE)
+                        .setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
+                        .build(),
+                )
+                .setBufferSizeInBytes(bufferBytes)
+                .setTransferMode(AudioTrack.MODE_STREAM)
+                .build()
+
+            val buf = FloatArray(FRAMES_PER_WRITE * CHANNELS)
+            var phase = 0.0
+            val step = 2.0 * PI * TONE_HZ / SAMPLE_RATE
+            try {
+                track.play()
+                while (running.get()) {
+                    var i = 0
+                    while (i < buf.size) {
+                        val s = (sin(phase) * 0.25).toFloat()
+                        buf[i] = s
+                        buf[i + 1] = s
+                        i += 2
+                        phase += step
+                        if (phase > 2.0 * PI) phase -= 2.0 * PI
+                    }
+                    track.write(buf, 0, buf.size, AudioTrack.WRITE_BLOCKING)
+                }
+            } catch (t: Throwable) {
+                Log.w(TAG, "tone thread stopped: ${t.message}")
+            } finally {
+                try {
+                    track.stop()
+                } catch (_: IllegalStateException) {
+                }
+                track.release()
+            }
+        }
+
+        private companion object {
+            const val SAMPLE_RATE = 48_000
+            const val CHANNELS = 2
+            const val BYTES_PER_FLOAT = 4
+            const val FRAMES_PER_WRITE = 480
+            const val TONE_HZ = 440.0
+        }
+    }
+
+    private companion object {
+        const val TAG = "RsacPlaybackTest"
+
+        /** Generous: appops auto-approve is near-instant, but boot/service
+         * scheduling on a loaded emulator can add seconds. */
+        const val CONSENT_TIMEOUT_SEC = 30L
+    }
+}

--- a/mobile/android/src/androidTest/kotlin/ai/codeseys/rsac/RsacTestActivity.kt
+++ b/mobile/android/src/androidTest/kotlin/ai/codeseys/rsac/RsacTestActivity.kt
@@ -1,0 +1,16 @@
+// rsac-e6d3 (playback tier) — TEST-ONLY host Activity for the MediaProjection
+// consent flow. Lives in src/androidTest/ so it never enters the production
+// rsac.aar.
+package ai.codeseys.rsac
+
+import androidx.activity.ComponentActivity
+
+/**
+ * A bare [ComponentActivity] whose only job is to be a started, foreground
+ * Activity from which [RsacProjection.request] can launch the system consent
+ * dialog and start the `mediaProjection` foreground service
+ * (`startActivityForResult` + FGS-while-in-foreground both need a foreground
+ * Activity). Declared in the androidTest manifest and driven via
+ * `ActivityScenario` by [RsacPlaybackInstrumentedTest].
+ */
+class RsacTestActivity : ComponentActivity()

--- a/mobile/androidtest-native/Cargo.toml
+++ b/mobile/androidtest-native/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "rsac-androidtest-native"
+version = "0.4.2"
+edition = "2021"
+# TEST-ONLY, never published and never shipped in any artifact. Excluded from
+# the crates.io tarball (lives under /mobile) and from the version-lockstep
+# gate's hardcoded manifest set (ci.yml) — but kept in workspace-version step
+# for tidiness.
+publish = false
+description = "TEST-ONLY Android cdylib driving rsac's public playback-capture API from an instrumented androidTest (rsac-e6d3). Produces librsac.so; never ships."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/Codeseys-Labs/rust-crossplat-audio-capture"
+
+# The lib name is `rsac` on purpose: RsacProjection.isNativeAvailable() (the
+# shipped consent flow) hard-codes System.loadLibrary("rsac"), so the .so that
+# both mints the projection token (nativeRetainProjection, registered by rsac's
+# JNI_OnLoad) and consumes it (this crate's driver export → rsac's public
+# playback API) MUST be one and the same librsac.so — otherwise two .so files
+# each statically link rsac and a token minted in one is not consumable in the
+# other (disjoint statics). This collides in *lib name* (not package name) with
+# mobile/android-native, which also emits `rsac`/librsac.so; that is safe
+# because the two are never compiled in a single cargo invocation (always built
+# with an explicit `-p`, into distinct `-o` output dirs) — see
+# ci-android-emu.yml. cargo only errors on an output-filename collision when
+# both artifacts are emitted by the same build, which never happens here.
+[lib]
+name = "rsac"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+# Passthrough to rsac's Android backend (mirrors rsac-ffi's feat_android
+# forwarding). Enabling it LINKS the Android JNI + AAudio backend into this
+# cdylib and gates the driver module in src/lib.rs. The required check is
+# `cargo check --target x86_64-linux-android --no-default-features
+#  --features feat_android -p rsac-androidtest-native`.
+feat_android = ["rsac/feat_android"]
+
+[dependencies]
+# The whole rsac library, re-exported (`pub use rsac`) so its #[no_mangle]
+# JNI_OnLoad and Android backend link into this cdylib — the same keep-alive
+# trick as mobile/android-native. default-features off; the backend is pulled
+# in only via this crate's `feat_android` passthrough above.
+rsac = { path = "../..", default-features = false }
+# Declarations-only JNI transcription (the same crate rsac itself uses for the
+# JNI boundary — pinned to the already-resolved 0.3 to avoid adding a second
+# jni-sys to the lockfile). Only used to hand back the jlong[] result and the
+# last-error jstring.
+jni-sys = "0.3"

--- a/mobile/androidtest-native/src/lib.rs
+++ b/mobile/androidtest-native/src/lib.rs
@@ -1,0 +1,276 @@
+//! TEST-ONLY Android cdylib for the instrumented **playback**-capture tier
+//! (rsac-e6d3). Produces `librsac.so`; it is never published and never ships
+//! in any consumer artifact (it lives under `/mobile`, excluded from the
+//! crates.io tarball, and is only built by `ci-android-emu.yml` into the
+//! git-ignored `mobile/android/src/androidTest/jniLibs/x86_64/`).
+//!
+//! # Why this crate exists, and why its lib name is `rsac`
+//!
+//! The shipped consent flow (`RsacProjection`, `mobile/android`) hard-codes
+//! `System.loadLibrary("rsac")` and mints the `MediaProjection` token through
+//! `nativeRetainProjection` — a symbol registered by **rsac's** `JNI_OnLoad`.
+//! The playback test must then hand that token straight back into rsac's
+//! public capture API (`with_android_projection`). For the mint and the
+//! consume to touch the **same** `MediaProjection` `GlobalRef` and the same
+//! session/registry statics, both must live in **one** loaded `librsac.so`:
+//! two separate `.so`s each statically linking rsac would have disjoint
+//! statics, and a token minted in one is not safely consumable in the other.
+//!
+//! So this cdylib:
+//!   1. `pub use rsac;` — links the whole rsac rlib in, re-exporting its
+//!      `#[no_mangle] JNI_OnLoad` (the exact keep-alive trick
+//!      `mobile/android-native` uses). Loading this `.so` therefore runs
+//!      rsac's `RegisterNatives` (CaptureBridge / RsacProjection / RsacDevices)
+//!      just like the production `librsac.so`.
+//!   2. Adds the name-mangled `Java_ai_codeseys_rsac_NativePlaybackDriver_*`
+//!      exports below, resolved by the JVM's standard lazy JNI lookup when the
+//!      Kotlin `NativePlaybackDriver` first calls them — no second
+//!      `JNI_OnLoad`, no `RegisterNatives` of our own, nothing that could
+//!      clash with rsac's registration.
+//!
+//! The **mic** instrumented tier (`RsacFramesInstrumentedTest`) is untouched
+//! and separate: it drives the shipped C ABI through its own
+//! `librsac_ffi.so` + C shim and loads those, never this `.so`. Keep the two
+//! test tiers loading disjoint library sets (see the Kotlin side).
+//!
+//! # Honesty
+//!
+//! A pass here is **emulator-verified** for the `SystemDefault` playback tier
+//! only. It proves the MediaProjection → FGS → `AudioPlaybackCapture` →
+//! `CaptureBridge` → JNI ingest → bridge → public read path delivers frames
+//! under a real app uid. It says NOTHING about the
+//! `Application`/`ApplicationByName`/`ProcessTree` UID-filtered tiers, and it
+//! is never device-verified. Content is never inspected — only frame counts
+//! and the negotiated format.
+
+// Re-export rsac so its #[no_mangle] JNI_OnLoad (and the whole Android backend
+// it registers) is linked into this cdylib. Present on every target — on a
+// non-Android host it is just the rsac rlib re-export and compiles to nothing
+// platform-specific (mirrors mobile/android-native/src/lib.rs).
+pub use rsac;
+
+// The driver export exists only where rsac's Android playback API does. On any
+// other target the crate collapses to the `pub use rsac` above, so a
+// `cargo build --workspace` on macOS/Linux/Windows still compiles cleanly.
+#[cfg(all(target_os = "android", feature = "feat_android"))]
+mod driver {
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::sync::{Mutex, OnceLock};
+    use std::time::{Duration, Instant};
+
+    use jni_sys::{jint, jlong, jlongArray, jobject, jstring, JNIEnv};
+
+    use rsac::{AndroidProjectionToken, AudioCaptureBuilder, CaptureTarget, SampleFormat};
+
+    /// Last human-readable failure, captured at the failing stage and read
+    /// back by the Kotlin side via `lastNativeError()` on the same
+    /// (single-threaded instrumentation) thread. `""` when the last drive had
+    /// no failure.
+    fn last_error() -> &'static Mutex<String> {
+        static LAST_ERROR: OnceLock<Mutex<String>> = OnceLock::new();
+        LAST_ERROR.get_or_init(|| Mutex::new(String::new()))
+    }
+
+    fn set_last_error(msg: String) {
+        if let Ok(mut slot) = last_error().lock() {
+            *slot = msg;
+        }
+    }
+
+    /// rsac `SampleFormat` → the `rsac_sample_format_t` integer encoding the
+    /// mic tier's assertion uses (I16=0, I24=1, I32=2, F32=3), so the Kotlin
+    /// `negSampleFormat in 0..3` sanity check is shared across both tiers.
+    fn sample_format_code(fmt: SampleFormat) -> i64 {
+        match fmt {
+            SampleFormat::I16 => 0,
+            SampleFormat::I24 => 1,
+            SampleFormat::I32 => 2,
+            SampleFormat::F32 => 3,
+        }
+    }
+
+    /// errorCode slots (out[0]); 0 == RSAC_OK-equivalent (no hard error).
+    const CODE_OK: i64 = 0;
+    const CODE_BUILD_FAILED: i64 = 1;
+    const CODE_START_FAILED: i64 = 2;
+    const CODE_FORMAT_NONE: i64 = 3;
+    const CODE_READ_ERROR: i64 = 4;
+
+    /// Drives `CaptureTarget::SystemDefault` playback capture through rsac's
+    /// PUBLIC API end-to-end, mirroring `tests/android_emu_smoke.rs`:
+    ///
+    /// `from_raw(token) → with_target(SystemDefault) → with_android_projection
+    /// → sample_rate → channels → build() → start() → format() → bounded
+    /// read_buffer() poll (count frames, never content) → request_stop()`.
+    ///
+    /// Returns `[errorCode, buffers, frames, negRate, negChannels,
+    /// negSampleFormat]`. On a build/start/format failure the negotiated
+    /// fields stay 0/0/-1 and `last_error()` carries the `AudioError` text.
+    fn drive(token_raw: i64, sample_rate: i32, channels: i32, timeout_ms: i32) -> [i64; 6] {
+        let mut out: [i64; 6] = [CODE_OK, 0, 0, 0, 0, -1];
+        set_last_error(String::new());
+
+        // SAFETY: `token_raw` is the opaque jlong minted by
+        // RsacProjection.nativeRetainProjection (rsac's JNI_OnLoad registered
+        // it in THIS librsac.so) and is wrapped exactly once here — the token
+        // is handed to a single build()/capture that owns its release on drop.
+        // A 0 handle is caught by create_playback_capture with an actionable
+        // error rather than dereferenced (see from_raw's contract).
+        let token = unsafe { AndroidProjectionToken::from_raw(token_raw) };
+
+        let mut capture = match AudioCaptureBuilder::new()
+            .with_target(CaptureTarget::SystemDefault)
+            .with_android_projection(token)
+            .sample_rate(sample_rate.max(0) as u32)
+            .channels(channels.max(0) as u16)
+            .build()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                set_last_error(format!("build(): {e}"));
+                out[0] = CODE_BUILD_FAILED;
+                return out;
+            }
+        };
+
+        if let Err(e) = capture.start() {
+            set_last_error(format!("start(): {e}"));
+            out[0] = CODE_START_FAILED;
+            return out;
+        }
+
+        // Negotiated format: for Android playback the CaptureBridge builds its
+        // AudioRecord with the requested rate/channels in PCM_FLOAT (no
+        // renegotiation), so this is the delivered format published before the
+        // first push. None after a successful start is a real defect.
+        match capture.format() {
+            Some(fmt) => {
+                out[3] = i64::from(fmt.sample_rate);
+                out[4] = i64::from(fmt.channels);
+                out[5] = sample_format_code(fmt.sample_format);
+            }
+            None => {
+                set_last_error("format() returned None after start()".to_string());
+                capture.request_stop();
+                out[0] = CODE_FORMAT_NONE;
+                return out;
+            }
+        }
+
+        // Bounded non-blocking poll (Ok(None) => no data yet) so a silent /
+        // blocked route cannot park past the deadline. Emulator playback is
+        // synthetic: count frames, never inspect content. Same
+        // buffers>=3 && frames>0 stop condition as the mic tier + the smoke.
+        let deadline = Instant::now() + Duration::from_millis(timeout_ms.max(0) as u64);
+        let mut buffers: i64 = 0;
+        let mut frames: i64 = 0;
+        while Instant::now() < deadline && !(buffers >= 3 && frames > 0) {
+            match capture.read_buffer() {
+                Ok(Some(buf)) => {
+                    let n = buf.num_frames();
+                    if n > 0 {
+                        buffers += 1;
+                        frames += n as i64;
+                    }
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+                Err(e) => {
+                    set_last_error(format!("read_buffer(): {e}"));
+                    out[0] = CODE_READ_ERROR;
+                    break;
+                }
+            }
+        }
+        out[1] = buffers;
+        out[2] = frames;
+
+        // Stop, then let Drop free the projection GlobalRef + bridge (the
+        // teardown choke point). request_stop is the graceful producer
+        // terminal; dropping `capture` releases the token per its one-session
+        // contract.
+        capture.request_stop();
+        out
+    }
+
+    /// `NativePlaybackDriver.drivePlaybackCapture` — JNI signature `(JIII)[J`.
+    ///
+    /// Resolved by the JVM's standard lazy `Java_*` lookup after
+    /// `System.loadLibrary("rsac")`; no `RegisterNatives` (that is rsac's
+    /// `JNI_OnLoad`'s job for the shipped natives).
+    ///
+    /// Never lets a panic cross the JNI frame (UB): the whole body is
+    /// `catch_unwind`-contained. Returns a fresh `long[6]`, or `null` only if
+    /// the JVM array allocation itself fails (OOME already pending).
+    #[no_mangle]
+    pub extern "system" fn Java_ai_codeseys_rsac_NativePlaybackDriver_drivePlaybackCapture(
+        env: *mut JNIEnv,
+        _thiz: jobject,
+        token_raw: jlong,
+        sample_rate: jint,
+        channels: jint,
+        timeout_ms: jint,
+    ) -> jlongArray {
+        let out = catch_unwind(AssertUnwindSafe(|| {
+            drive(token_raw, sample_rate, channels, timeout_ms)
+        }))
+        .unwrap_or_else(|_| {
+            set_last_error("driver panicked (contained at the JNI boundary)".to_string());
+            [-1, 0, 0, 0, 0, -1]
+        });
+
+        // SAFETY: `env` is a valid JNIEnv for this instrumentation thread. The
+        // vtable is fully populated on ART; a missing entry means the process
+        // is unrecoverably broken (contained by the catch_unwind above only on
+        // the Rust-entered `drive`, so guard the raw calls explicitly).
+        unsafe {
+            let new_long_array = (**env)
+                .NewLongArray
+                .expect("JNI vtable missing NewLongArray");
+            let arr = new_long_array(env, 6);
+            if arr.is_null() {
+                return arr; // OutOfMemoryError already pending on the JVM side.
+            }
+            let set_region = (**env)
+                .SetLongArrayRegion
+                .expect("JNI vtable missing SetLongArrayRegion");
+            set_region(env, arr, 0, 6, out.as_ptr());
+            arr
+        }
+    }
+
+    /// `NativePlaybackDriver.lastNativeError` — JNI signature
+    /// `()Ljava/lang/String;`. The `AudioError` text captured at the last
+    /// failing stage, or `""`.
+    #[no_mangle]
+    pub extern "system" fn Java_ai_codeseys_rsac_NativePlaybackDriver_lastNativeError(
+        env: *mut JNIEnv,
+        _thiz: jobject,
+    ) -> jstring {
+        let msg = last_error().lock().map(|s| s.clone()).unwrap_or_default();
+        // NewStringUTF needs a NUL-terminated string; drop any interior NULs
+        // (an AudioError message never contains one, but be defensive).
+        let c = std::ffi::CString::new(msg.replace('\0', "")).unwrap_or_default();
+        // SAFETY: `env` valid for this thread; `c` is a live NUL-terminated
+        // buffer for the duration of the call.
+        unsafe {
+            let new_string_utf = (**env)
+                .NewStringUTF
+                .expect("JNI vtable missing NewStringUTF");
+            new_string_utf(env, c.as_ptr())
+        }
+    }
+
+    // ── Compile-time signature guards ────────────────────────────────────
+    // Pin the exported fn pointers to their JNI-expected shapes so a
+    // parameter drift is a compile error, mirroring jni.rs's _NATIVE_* asserts.
+    const _DRIVE: extern "system" fn(*mut JNIEnv, jobject, jlong, jint, jint, jint) -> jlongArray =
+        Java_ai_codeseys_rsac_NativePlaybackDriver_drivePlaybackCapture;
+    const _LAST_ERROR: extern "system" fn(*mut JNIEnv, jobject) -> jstring =
+        Java_ai_codeseys_rsac_NativePlaybackDriver_lastNativeError;
+
+    #[allow(dead_code)]
+    fn _assert_guards_referenced() {
+        let _ = _DRIVE;
+        let _ = _LAST_ERROR;
+    }
+}

--- a/scripts/ci-android-emu-payload.sh
+++ b/scripts/ci-android-emu-payload.sh
@@ -59,9 +59,10 @@ GRADLE_STATUS=0
 gradle -p mobile/android connectedDebugAndroidTest --no-daemon --stacktrace \
   "-Pandroid.testInstrumentationRunnerArguments.rsac_require_frames=${REQUIRE_FRAMES:-0}" \
   2>&1 | tee instrumented.log || GRADLE_STATUS=$?
-# -d: dump-and-exit (never stream/hang). The RsacFramesTest tag carries the
-# frames/negotiated-format evidence and any SKIP-WITH-SUMMARY line.
-adb logcat -d -s RsacFramesTest TestRunner 2>&1 | tee instrumented-logcat.log || true
+# -d: dump-and-exit (never stream/hang). RsacFramesTest (mic tier) and
+# RsacPlaybackTest (playback tier, rsac-e6d3) carry the frames/negotiated-format
+# evidence and any SKIP-WITH-SUMMARY line; TestRunner carries the JUnit result.
+adb logcat -d -s RsacFramesTest RsacPlaybackTest TestRunner 2>&1 | tee instrumented-logcat.log || true
 if [ "$GRADLE_STATUS" -ne 0 ]; then
   echo "::error::connectedDebugAndroidTest failed (exit $GRADLE_STATUS) — see instrumented.log + instrumented-logcat.log"
   exit "$GRADLE_STATUS"


### PR DESCRIPTION
Three lanes, each implemented and adversarially cross-model-reviewed in isolated worktrees.

## 1. Android playback-tier evidence harness (rsac-e6d3 remainder)
The mic path went emulator-verified in PR #66; this adds the **playback** (SystemDefault via MediaProjection) instrumented tier:
- **`mobile/androidtest-native/`** — test-only cdylib (`publish = false`) re-exporting rsac so token **mint** (`nativeRetainProjection`, registered by rsac's `JNI_OnLoad`) and **consume** (`with_android_projection` through the public API) share one `librsac.so`'s statics. Deliberately shares the `rsac` lib name with `mobile/android-native` (the shipped `System.loadLibrary("rsac")` contract); never co-compiled with it — reviewer verified no `--workspace` compile exists anywhere in CI/scripts.
- **`RsacPlaybackInstrumentedTest`** — pre-grants `PROJECT_MEDIA` via UiAutomation appops (API 30 consent dialog auto-approve), drives the shipped `RsacProjection` consent flow from a real foreground Activity (consent → FGS → `startForeground` → `getMediaProjection` ordering intact per the FGS-ordering skill), plays a `USAGE_MEDIA` tone as the capturable source (matches `CaptureBridge`'s `addMatchingUsage`), asserts **frames delivered + negotiated-format sanity, never content**. Soft-skips loud unless `rsac_require_frames=1`.
- A pass is **emulator-verified, SystemDefault playback tier ONLY** — the UID-filtered tiers (Application/ByName/ProcessTree) stay unverified; no matrix cells flip in this PR.
- ci.yml cross-checks the new crate on every push (otherwise it compiles only inside the KVM-gated leg).
- **CodeRabbit Major from PR #65 (fix-now)**: the emu leg's json→glob artifact fallback now hard-fails on an ambiguous match instead of picking newest-mtime — stale cached binaries must not fake runtime evidence.

## 2. iOS simulator host-mic route (rsac-f18f)
PR #66 proved the whole TCC harness chain but headless runners expose no host default audio **input**, so the sim's input node reports 0 Hz/0 ch. The sim uses the host default input as its mic → new tolerant step in `ci-ios-sim.yml` (before sim boot): install BlackHole 2ch + switchaudio-osx, reload coreaudiod, poll ≤30 s, set default input. **Every arm is individually tolerant + loud and never leg-fatal** (brew/sudo may be denied on the runner). Route presence flows step output → job output → summary, so a soft-fail is one-shot diagnosable: *route present but zero frames — investigate* vs *no route — expected*. `require_frames` stays soft. **This PR's CI run is the live experiment** — watch the ios-sim summary.

## 3. SampleRing-vs-AudioBuffer bench A/B (rsac-6508, first half)
`bridge_ab/*` round-trip matrix (mono/stereo × 480/1024/4096 frames) **plus** `bridge_ab_push/*` producer-only groups (`iter_custom`, drain untimed): review caught that the round trip alone structurally masks the producer-side metric ADR-0006 §6 promote-criterion #1 names (SampleRing pays a consumer-side reconstruction copy the default ring's moved `Vec` never does). SampleRing sized per case so cache footprint is comparable. `bench.yml` already runs `--features bridge-zerocopy` unfiltered, so data accumulates automatically. The promote-or-remove **decision** stays open pending accumulated runs.

## Review evidence
Each lane got an independent opus adversarial review (approve ×3; all non-blocking findings either fixed in-lane or noted in code comments). Key verifications: no `--workspace` compile co-emits the two `librsac.so`s; Kotlin `object` init is lazy so the playback test never loads `librsac_ffi.so`; every new CI command survives `bash -eo pipefail` with a tolerant arm.

Seeds: works rsac-e6d3 (playback half), rsac-f18f (route), rsac-6508 (bench half). Closure only on merged evidence per repo discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end Android playback capture validation through the public audio capture API.
  * Added coverage for the SystemDefault playback tier alongside microphone capture testing.

* **Bug Fixes**
  * Improved Android test artifact selection by failing safely when results are ambiguous.
  * Enhanced iOS simulator diagnostics for missing virtual audio input routes.

* **Documentation**
  * Expanded guidance and benchmark coverage for evaluating zero-copy audio transport performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->