### PR TITLE
wave 11 — Android UID-tier playback + device-enumeration emulator evidence

### DIFF
--- a/.github/workflows/ci-android-emu.yml
+++ b/.github/workflows/ci-android-emu.yml
@@ -9,12 +9,17 @@ name: Android Emulator Runtime Leg
 # `emulator-verified`. It proves the AAudio input path delivers frames through
 # the rsac public API, runs the previously-dormant cfg(android) unit tests
 # (capabilities, record parsing, conversion helpers), and asserts the honest
-# SystemDefault-without-consent refusal. The MediaProjection SystemDefault
-# playback tier is now exercised too (playback tier below — appops-auto-approved
-# consent, no uiautomator needed); the Application/ApplicationByName/ProcessTree
-# UID-filtered playback tiers stay unverified, and a physical-device pass stays
-# a runbook. This leg is NOT a required PR gate until its acceptance criteria
-# are observed green on a runner.
+# SystemDefault-without-consent refusal. The MediaProjection playback tiers are
+# now exercised too (playback tier below — appops-auto-approved consent, no
+# uiautomator needed): SystemDefault AND the Application/ApplicationByName/
+# ProcessTree UID-filtered tiers. The UID-filtered tiers are SELF-CAPTURE (the
+# test targets its own uid / package / pid), so they verify the UID-filter
+# PLUMBING (target → resolve_match_uid → addMatchingUid → frames from a
+# matching-uid app) — NOT that capturing a DIFFERENT app's audio works or is
+# correctly scoped; cross-app UID filtering stays unverified. Device
+# enumeration (rsac-ad8a) is exercised too (RsacDevicesTest, no consent). A
+# physical-device pass stays a runbook. This leg is NOT a required PR gate
+# until its acceptance criteria are observed green on a runner.
 #
 # KVM: hardware acceleration is mandatory for a usable x86_64 emulator.
 # Blacksmith (blacksmith-4vcpu-ubuntu-2404) KVM support is UNVERIFIED — the
@@ -51,21 +56,36 @@ name: Android Emulator Runtime Leg
 # shell-uid smoke. This tier is ADVISORY until observed green (then, as a
 # follow-up: flip require_frames and/or promote to a required check).
 #
-# Playback tier (rsac-e6d3): the SAME test APK also drives
-# CaptureTarget::SystemDefault (AudioPlaybackCapture / MediaProjection) through
-# rsac's PUBLIC capture API. The host phase builds a THIRD native lib — the
-# test-only mobile/androidtest-native cdylib as librsac.so — which re-exports
-# rsac's JNI_OnLoad (so RsacProjection.nativeRetainProjection is registered)
-# and exports the NativePlaybackDriver Java_* symbols. The test pre-grants the
+# Playback tier (rsac-e6d3): the SAME test APK also drives the
+# AudioPlaybackCapture / MediaProjection tiers through rsac's PUBLIC capture
+# API. The host phase builds a THIRD native lib — the test-only
+# mobile/androidtest-native cdylib as librsac.so — which re-exports rsac's
+# JNI_OnLoad (so RsacProjection.nativeRetainProjection is registered) and
+# exports the NativePlaybackDriver Java_* symbols. The test pre-grants the
 # PROJECT_MEDIA appop via the UiAutomation shell so the API 30 consent dialog
 # auto-approves (no uiautomator), mints a real token through the shipped
 # RsacProjection flow, plays a USAGE_MEDIA tone as capturable playback, and
-# asserts frames-delivered + negotiated-format sanity (never content). The mic
-# tier and this playback tier keep DISJOINT native-library sets on purpose
+# asserts frames-delivered + negotiated-format sanity (never content). Four
+# @Tests run: systemDefaultTier (no UID filter) plus applicationTier (numeric
+# uid), applicationByNameTier (package name), and processTreeTier (pid) — the
+# ADR-0013 UID-filtered variants. Those three are SELF-CAPTURE: the test
+# targets its OWN uid / package / pid, so a pass verifies the UID-filter
+# PLUMBING (target → resolve_match_uid → CaptureBridge.addMatchingUid → frames
+# from a matching-uid app), NOT that capturing a DIFFERENT app's audio works or
+# is correctly scoped — cross-app UID filtering stays UNVERIFIED. The mic tier
+# and this playback tier keep DISJOINT native-library sets on purpose
 # (librsac_ffi.so+shim vs librsac.so): both link rsac and export JNI_OnLoad, so
 # the winning RegisterNatives must be the .so that both mints and consumes the
-# token — see NativePlaybackDriver.kt. SystemDefault ONLY: the UID-filtered
-# tiers stay unverified. Same soft-skip-unless-`require_frames` discipline.
+# token — see NativePlaybackDriver.kt. Same soft-skip-unless-`require_frames`
+# discipline.
+#
+# Device-enumeration evidence (rsac-ad8a): the SAME driver .so also exports
+# driveEnumerateDevices, and RsacDevicesTest.devicesEnumerated drives rsac's
+# PUBLIC device-enumeration facade (no projection token — rsac gets its Context
+# via ActivityThread.currentApplication() inside its own JNI layer) and asserts
+# a non-empty, unique-id device list including the playback-capture endpoint.
+# A real built-in-mic input entry is asserted only when the AAR RsacDevices
+# path resolved (else an honest soft-skip on the default-route fallback list).
 # =============================================================================
 
 on:
@@ -357,12 +377,15 @@ jobs:
           JNILIBS="mobile/android/src/androidTest/jniLibs/x86_64"
           mkdir -p "$JNILIBS"
           cp playback-jnilibs/x86_64/librsac.so "$JNILIBS/"
-          # Sanity: the driver .so must export both the driver entry points AND
-          # rsac's JNI_OnLoad (re-exported via `pub use rsac`), else the token
-          # mint would have no registrant in this .so.
+          # Sanity: the driver .so must export ALL the driver entry points
+          # (SystemDefault + UID-filtered targeted drive + device enumeration +
+          # last-error) AND rsac's JNI_OnLoad (re-exported via `pub use rsac`),
+          # else the token mint would have no registrant in this .so.
           TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
           for sym in JNI_OnLoad \
             Java_ai_codeseys_rsac_NativePlaybackDriver_drivePlaybackCapture \
+            Java_ai_codeseys_rsac_NativePlaybackDriver_driveTargetedPlaybackCapture \
+            Java_ai_codeseys_rsac_NativePlaybackDriver_driveEnumerateDevices \
             Java_ai_codeseys_rsac_NativePlaybackDriver_lastNativeError; do
             "$TOOLCHAIN/llvm-nm" -D --defined-only "$JNILIBS/librsac.so" | grep -q " $sym\$" || {
               echo "FAIL: librsac.so (playback driver) does not export $sym"

--- a/mobile/android/src/androidTest/kotlin/ai/codeseys/rsac/NativePlaybackDriver.kt
+++ b/mobile/android/src/androidTest/kotlin/ai/codeseys/rsac/NativePlaybackDriver.kt
@@ -64,6 +64,52 @@ object NativePlaybackDriver {
         timeoutMs: Int,
     ): LongArray
 
+    /**
+     * Drives ONE UID-filtered playback tier end-to-end through rsac's public
+     * API — the twin of [drivePlaybackCapture] with the [CaptureTarget]
+     * selected by [kind] + [arg]:
+     *
+     * | [kind] | target | [arg] |
+     * |---|---|---|
+     * | 0 | `SystemDefault` | ignored |
+     * | 1 | `Application(uid)` | the **numeric** app UID string (ADR-0013) |
+     * | 2 | `ApplicationByName(package)` | the package name |
+     * | 3 | `ProcessTree(pid)` | the decimal PID string |
+     *
+     * HONESTY: this is a SELF-CAPTURE drive (the test targets its own uid /
+     * package / pid), so a pass verifies the UID-filter plumbing (target →
+     * resolve → `addMatchingUid` → frames from a matching-uid app), NOT
+     * cross-app capture — see [RsacPlaybackInstrumentedTest]'s header.
+     *
+     * @return `[errorCode, buffers, frames, negRate, negChannels,
+     *   negSampleFormat]` — same slot contract as [drivePlaybackCapture];
+     *   [lastNativeError] carries the `AudioError` text on a hard error.
+     */
+    external fun driveTargetedPlaybackCapture(
+        tokenRaw: Long,
+        kind: Int,
+        arg: String,
+        sampleRate: Int,
+        channels: Int,
+        timeoutMs: Int,
+    ): LongArray
+
+    /**
+     * Drives rsac's PUBLIC device-enumeration facade
+     * (`get_device_enumerator()?.enumerate_devices()`) and returns a parseable
+     * summary (rsac-ad8a):
+     *
+     * ```text
+     * count=<N>;<id>|<name>|<Input|Output>;…
+     * ```
+     *
+     * or `ERROR: <text>` on failure. Needs no projection token: rsac obtains
+     * its `Context` inside its own JNI layer via
+     * `ActivityThread.currentApplication()`, which succeeds once this object's
+     * `System.loadLibrary("rsac")` has run `JNI_OnLoad` in the test process.
+     */
+    external fun driveEnumerateDevices(): String
+
     /** The `AudioError` text captured at the last failing stage ("" if none). */
     external fun lastNativeError(): String
 }

--- a/mobile/android/src/androidTest/kotlin/ai/codeseys/rsac/RsacPlaybackInstrumentedTest.kt
+++ b/mobile/android/src/androidTest/kotlin/ai/codeseys/rsac/RsacPlaybackInstrumentedTest.kt
@@ -12,20 +12,36 @@
 // flow to mint a real token, and hands that token to rsac's PUBLIC capture API
 // (CaptureTarget::SystemDefault) through the test-only librsac.so driver.
 //
-// SCOPE — SystemDefault playback tier ONLY. The Application / ApplicationByName
-// / ProcessTree UID-filtered tiers are NOT exercised here and stay unverified.
-// Assertions cover frames-delivered + negotiated-format sanity, NEVER audio
-// content: a continuous MEDIA tone is played so there is capturable playback,
-// but a pass proves the projection→FGS→AudioPlaybackCapture→CaptureBridge→JNI
-// →bridge→public-read WIRING reaches rsac under an app uid, not that it carries
-// that tone.
+// SCOPE — the SystemDefault playback tier PLUS the Application /
+// ApplicationByName / ProcessTree UID-filtered tiers, each driven through
+// rsac's public API. Assertions cover frames-delivered + negotiated-format
+// sanity, NEVER audio content: a continuous MEDIA tone is played so there is
+// capturable playback, but a pass proves the projection→FGS→
+// AudioPlaybackCapture→CaptureBridge→JNI→bridge→public-read WIRING reaches
+// rsac under an app uid, not that it carries that tone.
 //
-// HONESTY: a pass is emulator-verified, never device-verified. Consent that
+// HONESTY — UID-FILTERED TIERS ARE SELF-CAPTURE (load-bearing): the
+// Application/ApplicationByName/ProcessTree tiers target THIS test process's
+// own uid / package / pid. A pass verifies the UID-filter PLUMBING —
+// target → resolve_match_uid → CaptureBridge.addMatchingUid(matchUid) →
+// frames delivered from an app whose uid MATCHES the filter (src/audio/
+// android/playback.rs::resolve_match_uid). It does NOT verify that capturing a
+// DIFFERENT app's audio works or is correctly scoped; cross-app UID filtering
+// stays UNVERIFIED here (and on the emulator generally). The three UID tiers
+// all resolve to this process's single uid (tree ≡ app ≡ uid on Android), so
+// they exercise three RESOLUTION paths onto the same downstream capture.
+//
+// HONESTY — a pass is emulator-verified, never device-verified. Consent that
 // never fires (appops did not auto-approve on this image), a refused build/
 // start, or zero frames degrades to a LOUD assumption-skip unless the
 // `rsac_require_frames` instrumentation arg is "1" (wired from the workflow's
 // require_frames dispatch input) — mirroring the mic tier and the shell-uid
 // smoke.
+//
+// DEVICE ENUMERATION (rsac-ad8a): devicesEnumerated drives rsac's public
+// device-enumeration facade (no projection needed) and asserts a non-empty,
+// unique-id device list — see that test's own header for the capability-gate
+// note.
 //
 // LIBRARY-LOADING DISCIPLINE (load-bearing — see NativePlaybackDriver): this
 // tier loads ONLY librsac.so (here + via RsacProjection). The mic tier loads
@@ -44,6 +60,7 @@ import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.media.AudioTrack
 import android.os.ParcelFileDescriptor
+import android.os.Process
 import android.util.Log
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -71,8 +88,164 @@ class RsacPlaybackInstrumentedTest {
     private fun requireFramesHard(): Boolean =
         InstrumentationRegistry.getArguments().getString("rsac_require_frames") == "1"
 
+    // ── Per-tier tests ───────────────────────────────────────────────────
+    //
+    // Each tier: preGrantProjectMedia → mint a FRESH token via the consent
+    // flow → tone playing → drive the tier's target → assert frames + format
+    // sanity → soft-skip-loud unless rsac_require_frames=="1". The shared
+    // plumbing lives in [runPlaybackTier]; the four @Tests differ ONLY in the
+    // target they pass. A fresh token is minted per test because each rsac
+    // capture consumes a projection token's single-owner deletion latch
+    // (one token = one capture session — src/audio/android/playback.rs).
+
+    /** SystemDefault (no UID filter) — the baseline all-capturable-playback tier. */
     @Test
-    fun playbackFramesDeliveredViaPublicApi() {
+    fun systemDefaultTier() {
+        runPlaybackTier("systemDefault", DriveTier.SystemDefault)
+    }
+
+    /**
+     * Application(uid) — the numeric-UID tier (ADR-0013:
+     * CaptureTarget::Application carries the app UID). Self-capture: we pass
+     * THIS process's own uid, so the addMatchingUid filter matches the tone's
+     * producer.
+     */
+    @Test
+    fun applicationTier() {
+        runPlaybackTier(
+            "application",
+            DriveTier.Targeted(kind = 1, arg = Process.myUid().toString()),
+        )
+    }
+
+    /**
+     * ApplicationByName(package) — the package-name tier (rsac resolves the
+     * package → uid via the AAR PackageResolver). Self-capture: our own
+     * package resolves to our own uid.
+     */
+    @Test
+    fun applicationByNameTier() {
+        val pkg = InstrumentationRegistry.getInstrumentation().targetContext.packageName
+        runPlaybackTier("applicationByName", DriveTier.Targeted(kind = 2, arg = pkg))
+    }
+
+    /**
+     * ProcessTree(pid) — the PID tier (rsac maps pid → uid via /proc/<pid>/
+     * status). Self-capture: our own pid maps to our own uid (tree ≡ app).
+     */
+    @Test
+    fun processTreeTier() {
+        runPlaybackTier(
+            "processTree",
+            DriveTier.Targeted(kind = 3, arg = Process.myPid().toString()),
+        )
+    }
+
+    /**
+     * rsac-ad8a — device enumeration through rsac's PUBLIC facade. No
+     * projection token is needed: rsac obtains its Context inside its own JNI
+     * layer (ActivityThread.currentApplication()), which works once
+     * librsac.so's JNI_OnLoad has run in this test process.
+     *
+     * HARD assertions (hold on EVERY loaded-library build, AAR path or not —
+     * `enumerate_devices` always frames its list as [default input sentinel,
+     * …real input devices…, playback-capture endpoint], src/audio/android/
+     * mod.rs): count>=1; non-empty UNIQUE ids; the always-present built-in-mic
+     * -ish default input sentinel (`id="default"`, kind Input — the mission's
+     * "built-in-mic-ish entry present"); and the playback-capture endpoint.
+     *
+     * SOFT signal (rsac-ad8a proper): a REAL numeric-id input device beyond
+     * the sentinel appears ONLY when the AAR `RsacDevices.inputDevices` path
+     * resolved at load — the exact condition that flips
+     * `android_device_enumeration_available` true (src/core/capabilities.rs,
+     * set from src/audio/android/jni.rs JNI_OnLoad). This driver does not read
+     * that gate directly, but a real device in the list implies it. On the
+     * honest JNI-/AAR-absent fallback the list is exactly [default,
+     * playback-capture] with no real device, so its absence is a soft-skip
+     * (loud unless require_frames), never a failure.
+     */
+    @Test
+    fun devicesEnumerated() {
+        val summary = NativePlaybackDriver.driveEnumerateDevices()
+        Log.i(DEVICES_TAG, "enumerate result: $summary")
+
+        if (summary.startsWith("ERROR:")) {
+            // Enumeration itself failed (no JavaVM / unexpected). This is a
+            // real defect on a loaded library, so fail loud regardless of
+            // require_frames — enumeration needs no projection and no consent.
+            throw AssertionError("device enumeration failed: $summary")
+        }
+
+        val parsed = parseDeviceSummary(summary)
+        assertTrue("enumeration returned no count= header: $summary", parsed != null)
+        val devices = parsed!!
+
+        assertTrue("device count must be >= 1 (got ${devices.size}): $summary", devices.isNotEmpty())
+
+        // Non-empty ids, and ids are unique.
+        assertTrue("every device id must be non-empty: $summary", devices.all { it.id.isNotEmpty() })
+        val ids = devices.map { it.id }
+        assertTrue("device ids must be unique: $ids", ids.size == ids.toSet().size)
+
+        // The built-in-mic-ish default input sentinel is ALWAYS present
+        // (devices[0] — the "let the OS route the default input" handle,
+        // id="default", kind Input). This is the mission's required
+        // built-in-mic-ish entry; it holds even on the AAR-absent fallback.
+        assertTrue(
+            "expected the default input sentinel (built-in-mic-ish) in the list: $summary",
+            devices.any { it.id == "default" && it.kind == "Input" },
+        )
+
+        // The playback-capture endpoint is always the last entry (rsac's
+        // Android default device); assert it so we know the enumeration
+        // produced the canonical framing, not just any non-empty list.
+        assertTrue(
+            "expected the playback-capture endpoint in the list: $summary",
+            devices.any { it.id == "playback-capture" },
+        )
+
+        // rsac-ad8a proper: a REAL numeric-id input device (not the "default"
+        // sentinel, not the "playback-capture" endpoint) appears only when the
+        // AAR RsacDevices.inputDevices path resolved — the condition that flips
+        // android_device_enumeration_available true. Its absence means only the
+        // fallback list exists, so soft-skip rather than fail.
+        val hasRealInputDevice = devices.any { d ->
+            d.kind == "Input" && d.id != "default" && d.id.toIntOrNull()?.let { it > 0 } == true
+        }
+        if (!hasRealInputDevice) {
+            softSkip(
+                requireFramesHard(),
+                "enumeration succeeded (${devices.size} devices) with the default " +
+                    "sentinel + playback endpoint, but NO real numeric-id input " +
+                    "device — the AAR RsacDevices path did not resolve on this " +
+                    "image (android_device_enumeration_available is false), so " +
+                    "only the default-route fallback list exists. emulator-verified " +
+                    "AAR real-input enumeration (rsac-ad8a) NOT produced.",
+            )
+            return
+        }
+
+        Log.i(
+            DEVICES_TAG,
+            "device enumeration verified (emulator-verified, AAR real-input path): " +
+                "${devices.size} devices, ids=$ids",
+        )
+    }
+
+    // ── Shared tier plumbing ───────────────────────────────────────────────
+
+    /** Which capture target a tier drives (the only thing that varies). */
+    private sealed interface DriveTier {
+        object SystemDefault : DriveTier
+        data class Targeted(val kind: Int, val arg: String) : DriveTier
+    }
+
+    /**
+     * The full mint→tone→drive→assert flow for one tier, logged under [tier].
+     * Every tier shares this so the SystemDefault test is not duplicated
+     * three times — only the [DriveTier] differs.
+     */
+    private fun runPlaybackTier(tier: String, driveTier: DriveTier) {
         val requireFrames = requireFramesHard()
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         // Self-instrumenting library test: the package that requests the
@@ -89,134 +262,41 @@ class RsacPlaybackInstrumentedTest {
         preGrantProjectMedia(targetPackage)
 
         // Continuous MEDIA tone from THIS process → capturable playback for the
-        // SystemDefault (all-usages, no-UID-filter) capture to pick up. The
-        // androidTest manifest sets allowAudioPlaybackCapture=true so this
-        // process's USAGE_MEDIA playback is capturable regardless of the test
-        // APK's resolved targetSdk.
-        // token/denied are written in the callback (main thread) and read here
-        // after consent.await(); CountDownLatch.countDown happens-before a
-        // successful await return, so the writes are visible without @Volatile
-        // (which Kotlin does not allow on locals anyway).
+        // capture to pick up. The androidTest manifest sets
+        // allowAudioPlaybackCapture=true so this process's USAGE_MEDIA playback
+        // is capturable regardless of the test APK's resolved targetSdk. For
+        // the UID-filtered tiers this process IS the matching uid, so the tone
+        // is exactly what the addMatchingUid filter should admit.
         val tone = ContinuousTone()
-        var token = 0L
-        var denied: String? = null
-        val consent = CountDownLatch(1)
-
         val scenario = ActivityScenario.launch(RsacTestActivity::class.java)
         try {
             tone.start()
 
-            // RsacProjection.request must run on the main thread with a started
-            // Activity; the callback also fires on the main thread. Latch bridges
-            // it back to this instrumentation thread.
-            scenario.onActivity { activity ->
-                RsacProjection.request(
-                    activity,
-                    object : RsacProjection.Callback {
-                        override fun onToken(t: Long) {
-                            token = t
-                            consent.countDown()
-                        }
+            // Mint a FRESH projection token via the shipped consent flow.
+            val token = mintProjectionToken(scenario, requireFrames, tier) ?: return
 
-                        override fun onDenied(reason: String) {
-                            denied = reason
-                            consent.countDown()
-                        }
-                    },
-                )
-            }
-
-            val fired = consent.await(CONSENT_TIMEOUT_SEC, TimeUnit.SECONDS)
-            if (!fired) {
-                softSkip(
-                    requireFrames,
-                    "consent callback never fired within ${CONSENT_TIMEOUT_SEC}s " +
-                        "(appops PROJECT_MEDIA did not auto-approve the dialog on " +
-                        "this image). emulator-verified evidence NOT produced.",
-                )
-                return
-            }
-            denied?.let {
-                softSkip(
-                    requireFrames,
-                    "MediaProjection consent denied: $it. emulator-verified " +
-                        "evidence NOT produced.",
-                )
-                return
-            }
-            if (token == 0L) {
-                softSkip(
-                    requireFrames,
-                    "consent granted but the projection token was 0 (the " +
-                        "GlobalRef could not be retained). emulator-verified " +
-                        "evidence NOT produced.",
-                )
-                return
-            }
-
-            // Drive SystemDefault playback capture end-to-end through rsac's
-            // public API. The FGS started by RsacProjection.request is still
-            // foreground (we stop it in `finally`, after the capture is torn
-            // down inside the driver via request_stop + Drop).
+            // Drive this tier end-to-end through rsac's public API. The FGS
+            // started by RsacProjection.request is still foreground (we stop it
+            // in `finally`, after the capture is torn down inside the driver
+            // via request_stop + Drop).
             // [errorCode, buffers, frames, negRate, negChannels, negSampleFormat]
-            val r = NativePlaybackDriver.drivePlaybackCapture(
-                tokenRaw = token,
-                sampleRate = 48_000,
-                channels = 2,
-                timeoutMs = 15_000,
-            )
-            val errorCode = r[0]
-            val buffers = r[1]
-            val frames = r[2]
-            val negRate = r[3]
-            val negChannels = r[4]
-            val negSampleFormat = r[5]
-
-            Log.i(
-                TAG,
-                "drive result: errorCode=$errorCode buffers=$buffers frames=$frames " +
-                    "negotiated rate=$negRate channels=$negChannels " +
-                    "sampleFormat=$negSampleFormat",
-            )
-
-            if (errorCode != 0L) {
-                val detail = NativePlaybackDriver.lastNativeError()
-                softSkip(
-                    requireFrames,
-                    "rsac refused the SystemDefault playback route with a real " +
-                        "projection token (errorCode=$errorCode: $detail). " +
-                        "emulator-verified evidence NOT produced.",
+            val r = when (driveTier) {
+                is DriveTier.SystemDefault -> NativePlaybackDriver.drivePlaybackCapture(
+                    tokenRaw = token,
+                    sampleRate = 48_000,
+                    channels = 2,
+                    timeoutMs = 15_000,
                 )
-                return
-            }
-            if (buffers < 1L || frames <= 0L) {
-                softSkip(
-                    requireFrames,
-                    "playback capture started but delivered buffers=$buffers " +
-                        "frames=$frames within the deadline (no capturable " +
-                        "playback reached the record?). emulator-verified " +
-                        "evidence NOT produced.",
+                is DriveTier.Targeted -> NativePlaybackDriver.driveTargetedPlaybackCapture(
+                    tokenRaw = token,
+                    kind = driveTier.kind,
+                    arg = driveTier.arg,
+                    sampleRate = 48_000,
+                    channels = 2,
+                    timeoutMs = 15_000,
                 )
-                return
             }
-
-            // Frames delivered — negotiated format must be real (the Kotlin
-            // CaptureBridge builds AudioRecord with the requested shape in
-            // PCM_FLOAT and does not renegotiate, so this equals the request,
-            // but assert VALIDITY, not identity).
-            assertTrue("negotiated sample rate $negRate outside 8000..=96000", negRate in 8_000..96_000)
-            assertTrue("negotiated channels $negChannels not in {1, 2}", negChannels == 1L || negChannels == 2L)
-            assertTrue(
-                "negotiated sample_format $negSampleFormat not a valid rsac_sample_format_t",
-                negSampleFormat in 0L..3L,
-            )
-
-            Log.i(
-                TAG,
-                "playback frames delivered via public API (emulator-verified): " +
-                    "buffers=$buffers frames=$frames rate=$negRate " +
-                    "channels=$negChannels",
-            )
+            assertDriveResult(tier, requireFrames, r)
         } finally {
             tone.stop()
             // Stop the mediaProjection FGS the consent flow started (the capture
@@ -225,6 +305,160 @@ class RsacPlaybackInstrumentedTest {
             RsacCaptureService.stop(instrumentation.targetContext)
             scenario.close()
         }
+    }
+
+    /**
+     * Runs the shipped RsacProjection consent flow on the scenario's Activity
+     * and returns a fresh, non-zero projection token — or `null` after a
+     * soft-skip when consent never fired / was denied / retained a 0 handle.
+     */
+    private fun mintProjectionToken(
+        scenario: ActivityScenario<RsacTestActivity>,
+        requireFrames: Boolean,
+        tier: String,
+    ): Long? {
+        // token/denied are written in the callback (main thread) and read here
+        // after consent.await(); CountDownLatch.countDown happens-before a
+        // successful await return, so the writes are visible without @Volatile
+        // (which Kotlin does not allow on locals anyway).
+        var token = 0L
+        var denied: String? = null
+        val consent = CountDownLatch(1)
+
+        // RsacProjection.request must run on the main thread with a started
+        // Activity; the callback also fires on the main thread. Latch bridges
+        // it back to this instrumentation thread.
+        scenario.onActivity { activity ->
+            RsacProjection.request(
+                activity,
+                object : RsacProjection.Callback {
+                    override fun onToken(t: Long) {
+                        token = t
+                        consent.countDown()
+                    }
+
+                    override fun onDenied(reason: String) {
+                        denied = reason
+                        consent.countDown()
+                    }
+                },
+            )
+        }
+
+        val fired = consent.await(CONSENT_TIMEOUT_SEC, TimeUnit.SECONDS)
+        if (!fired) {
+            softSkip(
+                requireFrames,
+                "[$tier] consent callback never fired within ${CONSENT_TIMEOUT_SEC}s " +
+                    "(appops PROJECT_MEDIA did not auto-approve the dialog on " +
+                    "this image). emulator-verified evidence NOT produced.",
+            )
+            return null
+        }
+        denied?.let {
+            softSkip(
+                requireFrames,
+                "[$tier] MediaProjection consent denied: $it. emulator-verified " +
+                    "evidence NOT produced.",
+            )
+            return null
+        }
+        if (token == 0L) {
+            softSkip(
+                requireFrames,
+                "[$tier] consent granted but the projection token was 0 (the " +
+                    "GlobalRef could not be retained). emulator-verified " +
+                    "evidence NOT produced.",
+            )
+            return null
+        }
+        return token
+    }
+
+    /**
+     * Asserts a drive `[errorCode, buffers, frames, negRate, negChannels,
+     * negSampleFormat]` result: a hard error or zero frames soft-skips (loud
+     * unless require_frames); frames delivered assert negotiated-format
+     * VALIDITY (not identity — the CaptureBridge builds AudioRecord with the
+     * requested shape in PCM_FLOAT and does not renegotiate).
+     */
+    private fun assertDriveResult(tier: String, requireFrames: Boolean, r: LongArray) {
+        val errorCode = r[0]
+        val buffers = r[1]
+        val frames = r[2]
+        val negRate = r[3]
+        val negChannels = r[4]
+        val negSampleFormat = r[5]
+
+        Log.i(
+            TAG,
+            "[$tier] drive result: errorCode=$errorCode buffers=$buffers frames=$frames " +
+                "negotiated rate=$negRate channels=$negChannels " +
+                "sampleFormat=$negSampleFormat",
+        )
+
+        if (errorCode != 0L) {
+            val detail = NativePlaybackDriver.lastNativeError()
+            softSkip(
+                requireFrames,
+                "[$tier] rsac refused the playback route with a real " +
+                    "projection token (errorCode=$errorCode: $detail). " +
+                    "emulator-verified evidence NOT produced.",
+            )
+            return
+        }
+        if (buffers < 1L || frames <= 0L) {
+            softSkip(
+                requireFrames,
+                "[$tier] playback capture started but delivered buffers=$buffers " +
+                    "frames=$frames within the deadline (no capturable " +
+                    "playback reached the record?). emulator-verified " +
+                    "evidence NOT produced.",
+            )
+            return
+        }
+
+        assertTrue(
+            "[$tier] negotiated sample rate $negRate outside 8000..=96000",
+            negRate in 8_000..96_000,
+        )
+        assertTrue(
+            "[$tier] negotiated channels $negChannels not in {1, 2}",
+            negChannels == 1L || negChannels == 2L,
+        )
+        assertTrue(
+            "[$tier] negotiated sample_format $negSampleFormat not a valid rsac_sample_format_t",
+            negSampleFormat in 0L..3L,
+        )
+
+        Log.i(
+            TAG,
+            "[$tier] playback frames delivered via public API (emulator-verified): " +
+                "buffers=$buffers frames=$frames rate=$negRate channels=$negChannels",
+        )
+    }
+
+    /** One parsed device record from the driveEnumerateDevices summary. */
+    private data class DeviceRecord(val id: String, val name: String, val kind: String)
+
+    /**
+     * Parses `count=<N>;<id>|<name>|<kind>;…` into records, or `null` when the
+     * `count=` header is missing/malformed. A record with fewer than 3
+     * `|`-fields is skipped (defensive — the Rust side sanitizes delimiters
+     * out of names, so this is belt-and-suspenders).
+     */
+    private fun parseDeviceSummary(summary: String): List<DeviceRecord>? {
+        val parts = summary.split(';')
+        val header = parts.firstOrNull() ?: return null
+        if (!header.startsWith("count=")) return null
+        // The header's N is advisory; we parse the actual records that follow.
+        return parts.drop(1)
+            .filter { it.isNotEmpty() }
+            .mapNotNull { record ->
+                val fields = record.split('|')
+                if (fields.size < 3) return@mapNotNull null
+                DeviceRecord(id = fields[0], name = fields[1], kind = fields[2])
+            }
     }
 
     /**
@@ -340,6 +574,10 @@ class RsacPlaybackInstrumentedTest {
 
     private companion object {
         const val TAG = "RsacPlaybackTest"
+
+        /** Device-enumeration evidence logs under its own tag (rsac-ad8a) so
+         * the CI payload can dump it separately from the playback tiers. */
+        const val DEVICES_TAG = "RsacDevicesTest"
 
         /** Generous: appops auto-approve is near-instant, but boot/service
          * scheduling on a loaded emulator can add seconds. */

--- a/mobile/androidtest-native/src/lib.rs
+++ b/mobile/androidtest-native/src/lib.rs
@@ -35,13 +35,21 @@
 //!
 //! # Honesty
 //!
-//! A pass here is **emulator-verified** for the `SystemDefault` playback tier
-//! only. It proves the MediaProjection → FGS → `AudioPlaybackCapture` →
-//! `CaptureBridge` → JNI ingest → bridge → public read path delivers frames
-//! under a real app uid. It says NOTHING about the
-//! `Application`/`ApplicationByName`/`ProcessTree` UID-filtered tiers, and it
-//! is never device-verified. Content is never inspected — only frame counts
-//! and the negotiated format.
+//! A pass here is **emulator-verified**, never device-verified. Content is
+//! never inspected — only frame counts and the negotiated format.
+//!
+//! - The `SystemDefault` tier proves the MediaProjection → FGS →
+//!   `AudioPlaybackCapture` → `CaptureBridge` → JNI ingest → bridge → public
+//!   read path delivers frames under a real app uid.
+//! - The `Application` / `ApplicationByName` / `ProcessTree` tiers
+//!   (`driveTargetedPlaybackCapture`) are **self-capture**: the test targets
+//!   its own uid / package / pid. They verify the UID-filter PLUMBING
+//!   (target → `resolve_match_uid` → `addMatchingUid` → frames from a
+//!   matching-uid app) — NOT that capturing a *different* app's audio works or
+//!   is correctly scoped. Cross-app UID filtering stays UNVERIFIED here.
+//! - `driveEnumerateDevices` proves rsac's public device-enumeration facade
+//!   returns a non-empty list through the AAR (rsac-ad8a); it inspects no
+//!   audio.
 
 // Re-export rsac so its #[no_mangle] JNI_OnLoad (and the whole Android backend
 // it registers) is linked into this cdylib. Present on every target — on a
@@ -60,7 +68,10 @@ mod driver {
 
     use jni_sys::{jint, jlong, jlongArray, jobject, jstring, JNIEnv};
 
-    use rsac::{AndroidProjectionToken, AudioCaptureBuilder, CaptureTarget, SampleFormat};
+    use rsac::{
+        get_device_enumerator, AndroidProjectionToken, ApplicationId, AudioCaptureBuilder,
+        CaptureTarget, DeviceKind, ProcessId, SampleFormat,
+    };
 
     /// Last human-readable failure, captured at the failing stage and read
     /// back by the Kotlin side via `lastNativeError()` on the same
@@ -96,17 +107,35 @@ mod driver {
     const CODE_FORMAT_NONE: i64 = 3;
     const CODE_READ_ERROR: i64 = 4;
 
-    /// Drives `CaptureTarget::SystemDefault` playback capture through rsac's
-    /// PUBLIC API end-to-end, mirroring `tests/android_emu_smoke.rs`:
+    /// Drives one playback-capture `target` through rsac's PUBLIC API
+    /// end-to-end, mirroring `tests/android_emu_smoke.rs`:
     ///
-    /// `from_raw(token) → with_target(SystemDefault) → with_android_projection
-    /// → sample_rate → channels → build() → start() → format() → bounded
+    /// `from_raw(token) → with_target(target) → with_android_projection →
+    /// sample_rate → channels → build() → start() → format() → bounded
     /// read_buffer() poll (count frames, never content) → request_stop()`.
+    ///
+    /// The `target` is the ONLY thing that varies across the tiers
+    /// (`SystemDefault` vs the `Application`/`ApplicationByName`/`ProcessTree`
+    /// UID-filtered variants); the token lifecycle, format-sanity, poll, and
+    /// teardown are identical, so both driver exports funnel through here.
     ///
     /// Returns `[errorCode, buffers, frames, negRate, negChannels,
     /// negSampleFormat]`. On a build/start/format failure the negotiated
     /// fields stay 0/0/-1 and `last_error()` carries the `AudioError` text.
-    fn drive(token_raw: i64, sample_rate: i32, channels: i32, timeout_ms: i32) -> [i64; 6] {
+    ///
+    /// Token economics: exactly ONE `from_raw` per call, and the token is
+    /// moved into `build()`, which consumes its single-owner deletion latch
+    /// exactly once (rsac-3407). Every early-return arm below has already
+    /// handed the token to `build()` (which owns release-on-drop on success,
+    /// or reclaims/re-arms it on its own failure path), so no arm here leaks
+    /// or double-consumes.
+    fn drive(
+        token_raw: i64,
+        target: CaptureTarget,
+        sample_rate: i32,
+        channels: i32,
+        timeout_ms: i32,
+    ) -> [i64; 6] {
         let mut out: [i64; 6] = [CODE_OK, 0, 0, 0, 0, -1];
         set_last_error(String::new());
 
@@ -119,7 +148,7 @@ mod driver {
         let token = unsafe { AndroidProjectionToken::from_raw(token_raw) };
 
         let mut capture = match AudioCaptureBuilder::new()
-            .with_target(CaptureTarget::SystemDefault)
+            .with_target(target)
             .with_android_projection(token)
             .sample_rate(sample_rate.max(0) as u32)
             .channels(channels.max(0) as u16)
@@ -211,7 +240,13 @@ mod driver {
         timeout_ms: jint,
     ) -> jlongArray {
         let out = catch_unwind(AssertUnwindSafe(|| {
-            drive(token_raw, sample_rate, channels, timeout_ms)
+            drive(
+                token_raw,
+                CaptureTarget::SystemDefault,
+                sample_rate,
+                channels,
+                timeout_ms,
+            )
         }))
         .unwrap_or_else(|_| {
             set_last_error("driver panicked (contained at the JNI boundary)".to_string());
@@ -222,6 +257,58 @@ mod driver {
         // vtable is fully populated on ART; a missing entry means the process
         // is unrecoverably broken (contained by the catch_unwind above only on
         // the Rust-entered `drive`, so guard the raw calls explicitly).
+        unsafe { new_long_array_6(env, &out) }
+    }
+
+    /// The `kind` discriminant of `driveTargetedPlaybackCapture` → the rsac
+    /// [`CaptureTarget`] variant, resolving `arg` per the mission contract:
+    ///
+    /// | kind | target | `arg` |
+    /// |---|---|---|
+    /// | 0 | `SystemDefault` | ignored |
+    /// | 1 | `Application(uid)` | NUMERIC app UID string (ADR-0013) |
+    /// | 2 | `ApplicationByName(package)` | package name |
+    /// | 3 | `ProcessTree(pid)` | decimal PID string |
+    ///
+    /// A pid that does not parse as `u32` (kind 3) is reported via
+    /// `last_error()` and `None` — the caller turns that into a build-failed
+    /// code without ever wrapping the token. `Application`/`ApplicationByName`
+    /// carry `arg` verbatim (rsac's `resolve_match_uid` validates the UID
+    /// string / resolves the package), so an empty/garbage value surfaces as a
+    /// real `AudioError` from `build()` rather than being pre-judged here.
+    fn target_for(kind: i32, arg: String) -> Option<CaptureTarget> {
+        match kind {
+            0 => Some(CaptureTarget::SystemDefault),
+            1 => Some(CaptureTarget::Application(ApplicationId(arg))),
+            2 => Some(CaptureTarget::ApplicationByName(arg)),
+            3 => match arg.trim().parse::<u32>() {
+                Ok(pid) => Some(CaptureTarget::ProcessTree(ProcessId(pid))),
+                Err(e) => {
+                    set_last_error(format!("ProcessTree arg {:?} is not a u32 pid: {e}", arg));
+                    None
+                }
+            },
+            other => {
+                set_last_error(format!(
+                    "unknown targeted-drive kind {other} (expected 0=SystemDefault, \
+                     1=Application, 2=ApplicationByName, 3=ProcessTree)"
+                ));
+                None
+            }
+        }
+    }
+
+    /// Allocates a fresh Java `long[6]` and fills it from `out`, returning the
+    /// array (or `null` only when the JVM allocation itself fails, OOME
+    /// already pending). Shared by both driver exports so the JNI array
+    /// handoff lives in one place.
+    ///
+    /// # Safety
+    ///
+    /// `env` must be a valid `JNIEnv` for the current thread.
+    unsafe fn new_long_array_6(env: *mut JNIEnv, out: &[i64; 6]) -> jlongArray {
+        // SAFETY: the vtable is fully populated on ART; a missing entry means
+        // the process is unrecoverably broken.
         unsafe {
             let new_long_array = (**env)
                 .NewLongArray
@@ -235,6 +322,92 @@ mod driver {
                 .expect("JNI vtable missing SetLongArrayRegion");
             set_region(env, arr, 0, 6, out.as_ptr());
             arr
+        }
+    }
+
+    /// `NativePlaybackDriver.driveTargetedPlaybackCapture` — JNI signature
+    /// `(JILjava/lang/String;III)[J`.
+    ///
+    /// The UID-filtered-tier twin of [`drivePlaybackCapture`](
+    /// Java_ai_codeseys_rsac_NativePlaybackDriver_drivePlaybackCapture): same
+    /// `long[6]` slot contract, same token economics (one `from_raw`, one
+    /// consume via `build()`), but the [`CaptureTarget`] is selected by `kind`
+    /// + `arg` (see [`target_for`]).
+    ///
+    /// # HONESTY (load-bearing)
+    ///
+    /// This is a **self-capture** drive: the test APK targets its OWN uid /
+    /// package / pid. A pass therefore verifies the UID-filter PLUMBING —
+    /// target → `resolve_match_uid` → `addMatchingUid(matchUid)` → frames
+    /// delivered from an app whose uid MATCHES the filter. It does NOT verify
+    /// that capturing a DIFFERENT app's audio works or is correctly scoped;
+    /// cross-app UID filtering stays unverified (see the Kotlin test header).
+    ///
+    /// Resolved by the JVM's standard lazy `Java_*` lookup after
+    /// `System.loadLibrary("rsac")`; no `RegisterNatives` (that is rsac's
+    /// `JNI_OnLoad`'s job for the shipped natives). Never lets a panic cross
+    /// the JNI frame. Returns a fresh `long[6]`, or `null` only if the JVM
+    /// array allocation itself fails.
+    #[no_mangle]
+    pub extern "system" fn Java_ai_codeseys_rsac_NativePlaybackDriver_driveTargetedPlaybackCapture(
+        env: *mut JNIEnv,
+        _thiz: jobject,
+        token_raw: jlong,
+        kind: jint,
+        arg: jstring,
+        sample_rate: jint,
+        channels: jint,
+        timeout_ms: jint,
+    ) -> jlongArray {
+        // SAFETY: `env` is valid for this instrumentation thread; `arg` is a
+        // live java.lang.String local ref (or null, which decodes to "").
+        let arg_str = unsafe { jstring_to_string(env, arg) };
+
+        let out = catch_unwind(AssertUnwindSafe(|| match target_for(kind, arg_str) {
+            Some(target) => drive(token_raw, target, sample_rate, channels, timeout_ms),
+            // Bad kind / unparseable pid: last_error() already set by
+            // target_for. The token was NEVER wrapped, so nothing to release.
+            None => [CODE_BUILD_FAILED, 0, 0, 0, 0, -1],
+        }))
+        .unwrap_or_else(|_| {
+            set_last_error("driver panicked (contained at the JNI boundary)".to_string());
+            [-1, 0, 0, 0, 0, -1]
+        });
+
+        // SAFETY: `env` valid for this thread (as above).
+        unsafe { new_long_array_6(env, &out) }
+    }
+
+    /// Decodes a `java.lang.String` local ref into an owned `String`, or `""`
+    /// on a null ref or a failed JVM copy. Uses `GetStringUTFChars` (the
+    /// driver's `arg`s are ASCII: a numeric uid/pid or a package name), and
+    /// mirrors rsac's own defensive `env`-vtable handling.
+    ///
+    /// # Safety
+    ///
+    /// `env` must be a valid `JNIEnv` for the current thread and `jstr` either
+    /// null or a live `java.lang.String` local ref.
+    unsafe fn jstring_to_string(env: *mut JNIEnv, jstr: jstring) -> String {
+        if jstr.is_null() {
+            return String::new();
+        }
+        // SAFETY: vtable populated on ART; `jstr` is a live String ref.
+        unsafe {
+            let get_utf = (**env)
+                .GetStringUTFChars
+                .expect("JNI vtable missing GetStringUTFChars");
+            let chars = get_utf(env, jstr, std::ptr::null_mut());
+            if chars.is_null() {
+                return String::new();
+            }
+            let text = std::ffi::CStr::from_ptr(chars)
+                .to_string_lossy()
+                .into_owned();
+            let release = (**env)
+                .ReleaseStringUTFChars
+                .expect("JNI vtable missing ReleaseStringUTFChars");
+            release(env, jstr, chars);
+            text
         }
     }
 
@@ -260,17 +433,122 @@ mod driver {
         }
     }
 
+    /// `NativePlaybackDriver.driveEnumerateDevices` — JNI signature
+    /// `()Ljava/lang/String;`.
+    ///
+    /// Drives rsac's PUBLIC device-enumeration facade
+    /// (`get_device_enumerator()?.enumerate_devices()`) — the exact path a
+    /// consumer app uses — and returns a parseable summary the Kotlin side
+    /// asserts on (rsac-ad8a):
+    ///
+    /// ```text
+    /// count=<N>;<id>|<name>|<Input|Output>;<id>|<name>|<Input|Output>;…
+    /// ```
+    ///
+    /// or `ERROR: <text>` on failure. The delimiters (`;` between records,
+    /// `|` within a record) are stripped from any name so the grammar can't be
+    /// broken by a device label.
+    ///
+    /// # How the Context reaches Rust (load-bearing)
+    ///
+    /// `AndroidDeviceEnumerator::enumerate_devices` obtains its `Context`
+    /// entirely inside rsac's JNI layer via
+    /// `ActivityThread.currentApplication()` (see
+    /// `src/audio/android/jni.rs::enumerate_input_device_records`) — NO
+    /// context-publication step is required from the caller. That call
+    /// succeeds once `librsac.so`'s `JNI_OnLoad` has run (which
+    /// `System.loadLibrary("rsac")` in `NativePlaybackDriver`'s initializer
+    /// already did) AND an `Application` object exists — which it always does
+    /// inside an instrumented test process. So this export needs no token, no
+    /// projection, and no extra wiring beyond the library already being loaded.
+    ///
+    /// If the AAR `RsacDevices` class did not resolve at load, enumeration
+    /// silently falls back to `[default-route sentinel, playback-capture]`
+    /// (2 devices) — still a valid, honest result, just without the real
+    /// input-device middle section.
+    #[no_mangle]
+    pub extern "system" fn Java_ai_codeseys_rsac_NativePlaybackDriver_driveEnumerateDevices(
+        env: *mut JNIEnv,
+        _thiz: jobject,
+    ) -> jstring {
+        let summary =
+            catch_unwind(AssertUnwindSafe(enumerate_devices_summary)).unwrap_or_else(|_| {
+                "ERROR: enumeration panicked (contained at the JNI boundary)".to_string()
+            });
+
+        let c = std::ffi::CString::new(summary.replace('\0', "")).unwrap_or_default();
+        // SAFETY: `env` valid for this thread; `c` is a live NUL-terminated
+        // buffer for the duration of the call.
+        unsafe {
+            let new_string_utf = (**env)
+                .NewStringUTF
+                .expect("JNI vtable missing NewStringUTF");
+            new_string_utf(env, c.as_ptr())
+        }
+    }
+
+    /// Renders rsac's enumerated devices into the flat summary string the
+    /// Kotlin `devicesEnumerated` test parses. Never panics (the caller also
+    /// `catch_unwind`s); enumeration errors become `ERROR: <text>`.
+    fn enumerate_devices_summary() -> String {
+        let enumerator = match get_device_enumerator() {
+            Ok(e) => e,
+            Err(e) => return format!("ERROR: get_device_enumerator: {e}"),
+        };
+        let devices = match enumerator.enumerate_devices() {
+            Ok(d) => d,
+            Err(e) => return format!("ERROR: enumerate_devices: {e}"),
+        };
+
+        let mut summary = format!("count={}", devices.len());
+        for device in &devices {
+            let kind = match device.kind() {
+                Ok(DeviceKind::Input) => "Input",
+                Ok(DeviceKind::Output) => "Output",
+                Err(_) => "Unknown",
+            };
+            summary.push(';');
+            summary.push_str(&sanitize_field(&device.id().0));
+            summary.push('|');
+            summary.push_str(&sanitize_field(&device.name()));
+            summary.push('|');
+            summary.push_str(kind);
+        }
+        summary
+    }
+
+    /// Strips the summary's structural delimiters (`;` `|`) from a field so a
+    /// device id/name can never break the Kotlin parser's grammar. Names are
+    /// otherwise arbitrary product strings.
+    fn sanitize_field(s: &str) -> String {
+        s.replace([';', '|'], " ")
+    }
+
     // ── Compile-time signature guards ────────────────────────────────────
     // Pin the exported fn pointers to their JNI-expected shapes so a
     // parameter drift is a compile error, mirroring jni.rs's _NATIVE_* asserts.
     const _DRIVE: extern "system" fn(*mut JNIEnv, jobject, jlong, jint, jint, jint) -> jlongArray =
         Java_ai_codeseys_rsac_NativePlaybackDriver_drivePlaybackCapture;
+    const _DRIVE_TARGETED: extern "system" fn(
+        *mut JNIEnv,
+        jobject,
+        jlong,
+        jint,
+        jstring,
+        jint,
+        jint,
+        jint,
+    ) -> jlongArray = Java_ai_codeseys_rsac_NativePlaybackDriver_driveTargetedPlaybackCapture;
+    const _DRIVE_ENUMERATE: extern "system" fn(*mut JNIEnv, jobject) -> jstring =
+        Java_ai_codeseys_rsac_NativePlaybackDriver_driveEnumerateDevices;
     const _LAST_ERROR: extern "system" fn(*mut JNIEnv, jobject) -> jstring =
         Java_ai_codeseys_rsac_NativePlaybackDriver_lastNativeError;
 
     #[allow(dead_code)]
     fn _assert_guards_referenced() {
         let _ = _DRIVE;
+        let _ = _DRIVE_TARGETED;
+        let _ = _DRIVE_ENUMERATE;
         let _ = _LAST_ERROR;
     }
 }

--- a/scripts/ci-android-emu-payload.sh
+++ b/scripts/ci-android-emu-payload.sh
@@ -60,9 +60,12 @@ gradle -p mobile/android connectedDebugAndroidTest --no-daemon --stacktrace \
   "-Pandroid.testInstrumentationRunnerArguments.rsac_require_frames=${REQUIRE_FRAMES:-0}" \
   2>&1 | tee instrumented.log || GRADLE_STATUS=$?
 # -d: dump-and-exit (never stream/hang). RsacFramesTest (mic tier) and
-# RsacPlaybackTest (playback tier, rsac-e6d3) carry the frames/negotiated-format
-# evidence and any SKIP-WITH-SUMMARY line; TestRunner carries the JUnit result.
-adb logcat -d -s RsacFramesTest RsacPlaybackTest TestRunner 2>&1 | tee instrumented-logcat.log || true
+# RsacPlaybackTest (playback tiers: SystemDefault + Application/
+# ApplicationByName/ProcessTree UID-filtered, rsac-e6d3) carry the
+# frames/negotiated-format evidence; RsacDevicesTest carries the device-
+# enumeration evidence (rsac-ad8a); each also carries any SKIP-WITH-SUMMARY
+# line; TestRunner carries the JUnit result.
+adb logcat -d -s RsacFramesTest RsacPlaybackTest RsacDevicesTest TestRunner 2>&1 | tee instrumented-logcat.log || true
 if [ "$GRADLE_STATUS" -ne 0 ]; then
   echo "::error::connectedDebugAndroidTest failed (exit $GRADLE_STATUS) — see instrumented.log + instrumented-logcat.log"
   exit "$GRADLE_STATUS"


### PR DESCRIPTION
Single lane, cross-model adversarially reviewed (opus, approve with zero blockers). Test evidence only — no library changes; wave 10 proved the library plumbing, this proves the remaining Android tiers.

## UID-filtered playback tiers (rsac-e6d3 remainder)
New driver export `driveTargetedPlaybackCapture(tokenRaw, kind, arg, rate, ch, timeoutMs)` (kind 0–3 → SystemDefault / Application / ApplicationByName / ProcessTree) + one instrumented `@Test` per tier, each minting a **fresh** consent token through the shipped `RsacProjection` flow (appops-pre-granted) and self-capturing the test's own MEDIA tone:
- `Application` — own uid (`Process.myUid()`, numeric string per `resolve_match_uid`'s contract)
- `ApplicationByName` — own package (self-lookup is exempt from API 30 package-visibility filtering)
- `ProcessTree` — own pid (`/proc/self` readable under hidepid=2; tree ≡ app ≡ uid)

**Honesty**: self-capture verifies the UID-filter *plumbing* (target resolution → `addMatchingUid` → frames from a matching-uid app). Capturing a **different** app's audio stays unverified — stated in the driver docs, test headers, and workflow header.

## Device enumeration (rsac-ad8a)
`driveEnumerateDevices()` drives the public enumeration path. Key finding: the JNI side self-obtains the Context via `ActivityThread.currentApplication()` (non-null in an instrumented process) — no init step beyond `System.loadLibrary("rsac")`. The test hard-asserts the default sentinel + unique ids + the playback endpoint, and uses a real numeric-id input device as the observable proxy for the `android_device_enumeration_available` capability gate (forward implication only, per `JNI_OnLoad`). `Device(real-id)` targeted capture is an honest follow-up (needs a token-free export — new plumbing).

## Review evidence
Opus verified: JNI descriptor exactness for both exports (param order, mangled names, compile-time fn-ptr guards), token economics on every arm (no leak/double-consume; the consume latch is single-owner via `try_consume` + `mem::replace`), back-to-back consent cycles are order-independent, worst-case timing ≈3 min inside the 35-min leg, `--defined-only` preserved on the extended symbol assert. Two pre-existing minors noted (start()-failed GlobalRef soft-skip leak mirrors the shipped path; `jstring_to_string` outside `catch_unwind` matches the documented ART vtable assumption).

This PR's emulator run is the live experiment: four potential matrix-evidence flips (three UID tiers + enumeration).

Seeds: works rsac-e6d3 (UID-tier half), rsac-ad8a. Closure on merged evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Android playback verification across system-default, application-targeted, application-name, and process-tree capture tiers.
  - Added device enumeration validation, including device identifiers, types, and playback-capture availability.
  - Added clearer handling for unavailable consent, frames, or emulator devices.

- **Bug Fixes**
  - Builds now fail when required playback and device-enumeration interfaces are missing.
  - Improved validation for invalid capture targets and negotiated audio formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->