### PR TITLE
release: v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ Releases with no ABI change omit the subsection (or state "No C ABI changes").
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.4.3] - 2026-07-20
+
+### Added
+
 - **bindings (C FFI):** new `rsac_builder_set_ios_app_group(builder, app_group)`
   — iOS App Group consent configuration reaches the C ABI, completing mobile
   consent parity with the Rust builder (`with_ios_app_group`). Uniform-ABI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,7 +279,12 @@ Releases with no ABI change omit the subsection (or state "No C ABI changes").
   `with_android_projection` signatures are retained. This surface is
   `#[cfg(target_os = "android")]`, so the host `cargo-semver-checks` gate does
   not observe it; the removal of `Copy`/`Hash` is nonetheless a breaking change
-  for Android consumers and gates the next release at **0.5.0** (rsac-3407).
+  for Android consumers (rsac-3407). *Release note (owner decision
+  2026-07-20): shipped in 0.4.3 regardless — rsac has never been published to
+  any registry (rsac-43e4/rsac-aaea), so no consumer can resolve `0.4.x` by
+  semver range and pick this up automatically; git consumers pin by rev/tag.
+  Strict in-range semver discipline applies from the first registry publish
+  onward.*
 - Mobile backend deps (`jni-sys`; `objc2-avf-audio`/`block2`/`objc2`/
   `objc2-foundation` on iOS) are now `optional` and tied to `feat_android`/
   `feat_ios`, completing the `cfg(all(target_os, feature))` double-gate the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "rsac"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "atomic-waker",
  "audioadapter-buffers",
@@ -3335,7 +3335,7 @@ dependencies = [
 
 [[package]]
 name = "rsac-android-native"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "rsac",
 ]
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "rsac-ffi"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "cbindgen",
  "log",
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "rsac-napi"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "napi",
  "napi-build",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rsac-python"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "pyo3",
  "rsac",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-rsac"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "log",
  "rsac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 # Explicit MSRV floor. wasapi 0.23 bumps its own MSRV to 1.76; declaring it here
 # makes the minimum supported Rust version visible (under the pinned 1.95

--- a/bindings/rsac-ffi/Cargo.toml
+++ b/bindings/rsac-ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "rsac-ffi"
 # In lockstep with the workspace version (rsac + napi + python) — ci.yml's
 # version-lockstep gate and scripts/bump-version.sh treat all seven manifests as
 # one version.
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 # Mirror the parent crate's MSRV floor (1.87): rsac-ffi builds against rsac and
 # must not require a newer toolchain than the library it wraps.
@@ -49,7 +49,7 @@ compose = ["rsac/compose"]
 # requirement is what a future cargo publish records (crates.io ignores `path`).
 # Keep the version in lockstep with the parent crate's `[package].version` so a
 # future published rsac-ffi resolves the matching rsac release.
-rsac = { path = "../../", version = "0.4.2", default-features = false }
+rsac = { path = "../../", version = "0.4.3", default-features = false }
 log = "0.4"
 
 [build-dependencies]

--- a/bindings/rsac-napi/Cargo.toml
+++ b/bindings/rsac-napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac-napi"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "Node.js/TypeScript bindings for rsac (Rust Cross-Platform Audio Capture)"
 license = "MIT OR Apache-2.0"

--- a/bindings/rsac-napi/package.json
+++ b/bindings/rsac-napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsac/audio",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Node.js bindings for rsac (Rust cross-platform audio capture)",
   "main": "index.js",
   "types": "index.d.ts",

--- a/bindings/rsac-python/Cargo.toml
+++ b/bindings/rsac-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac-python"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "Python bindings for rsac (Rust Cross-Platform Audio Capture)"
 license = "MIT OR Apache-2.0"

--- a/bindings/rsac-python/pyproject.toml
+++ b/bindings/rsac-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rsac"
-version = "0.4.2"
+version = "0.4.3"
 description = "Python bindings for rsac (cross-platform audio capture library)"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }

--- a/integrations/tauri-plugin-rsac/Cargo.toml
+++ b/integrations/tauri-plugin-rsac/Cargo.toml
@@ -5,7 +5,7 @@ name = "tauri-plugin-rsac"
 # gate asserts equality with root rsac on release tags. Keep this line free of
 # a trailing comment: the bump/lockstep extractors match `version = "X"` only
 # when nothing follows the closing quote.
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 # match root MSRV floor (Cargo.toml:9)
 rust-version = "1.87"
@@ -34,7 +34,7 @@ thiserror = "2"
 log = "0.4"
 # Path dep + version pin — mirrors bindings/rsac-ffi/Cargo.toml:52 exactly.
 # The version pin is what a future publish records; joins version-lockstep.
-rsac = { path = "../../", version = "0.4.2", default-features = false }
+rsac = { path = "../../", version = "0.4.3", default-features = false }
 
 [build-dependencies]
 tauri-plugin = { version = "2", features = ["build"] }

--- a/integrations/tauri-plugin-rsac/guest-js/package.json
+++ b/integrations/tauri-plugin-rsac/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tauri-plugin-rsac-api",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "JS/TS guest API for tauri-plugin-rsac (ADR-0014)",
   "license": "MIT OR Apache-2.0",
   "type": "module",

--- a/mobile/android-native/Cargo.toml
+++ b/mobile/android-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac-android-native"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 publish = false
 description = "Android cdylib shim: builds librsac.so (via cargo-ndk) for the rsac AAR's jniLibs (rsac-0aa9)"


### PR DESCRIPTION
Release Prepare (run 29778937790, bump=patch): bump-version.sh rewrote the 9 lockstep manifests + 2 internal rsac pins to 0.4.3 and rotated the CHANGELOG.

Squash-merge keeping the subject exactly `release: v0.4.3` — release-tag.yml then creates the `v0.4.3` + `bindings/rsac-go/v0.4.3` tags and the GitHub Release. Registry publish workflows remain disabled (owner decision: no publishing until stability), so this produces tags + GitHub Release only.

Semver posture verified before dispatch: `cargo semver-checks --baseline-rev v0.4.2` → 196 checks pass, "no semver update required" — the unreleased host-visible API surface is unchanged (the consent-parity additions live in the cfg-gated mobile surface and bindings, which the host gate does not observe), so a patch bump is legal.

Capture-level status on the three desktop platforms (the release question): system + application + process-tree capture are implemented and capability-reported on all three (WASAPI process-loopback / CoreAudio Process Tap ≥14.4 / PipeWire node targeting), and the wave-12 run's audio legs are green on all three OSes (Windows/Linux/macOS "system+device+process" jobs, run 29775222840).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the package and platform bindings to version **0.4.3**.
  - Aligned native, mobile, JavaScript, and Python package versions for the release.

- **Documentation**
  - Added standard Keep-a-Changelog sections for upcoming changes.
  - Clarified the release timing and future versioning behavior of an Android breaking-change note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->