### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ Releases with no ABI change omit the subsection (or state "No C ABI changes").
 
 ### Removed
 
+### Fixed
+
+### Security
+
+## [0.5.0] - 2026-07-21
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
 - **`bridge-zerocopy` feature + the `SampleRing` data plane** — the opt-in,
   default-off zero-copy `SampleRing` producer plane (`SampleRingProducer` /
   `SampleRingConsumer` / `create_sample_ring`) is removed under

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "rsac"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "atomic-waker",
  "audioadapter-buffers",
@@ -3335,7 +3335,7 @@ dependencies = [
 
 [[package]]
 name = "rsac-android-native"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "rsac",
 ]
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "rsac-ffi"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "cbindgen",
  "log",
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "rsac-napi"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rsac-python"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "pyo3",
  "rsac",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-rsac"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "log",
  "rsac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 # Explicit MSRV floor. wasapi 0.23 bumps its own MSRV to 1.76; declaring it here
 # makes the minimum supported Rust version visible (under the pinned 1.95

--- a/bindings/rsac-ffi/Cargo.toml
+++ b/bindings/rsac-ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "rsac-ffi"
 # In lockstep with the workspace version (rsac + napi + python) — ci.yml's
 # version-lockstep gate and scripts/bump-version.sh treat all seven manifests as
 # one version.
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 # Mirror the parent crate's MSRV floor (1.87): rsac-ffi builds against rsac and
 # must not require a newer toolchain than the library it wraps.
@@ -49,7 +49,7 @@ compose = ["rsac/compose"]
 # requirement is what a future cargo publish records (crates.io ignores `path`).
 # Keep the version in lockstep with the parent crate's `[package].version` so a
 # future published rsac-ffi resolves the matching rsac release.
-rsac = { path = "../../", version = "0.4.3", default-features = false }
+rsac = { path = "../../", version = "0.5.0", default-features = false }
 log = "0.4"
 
 [build-dependencies]

--- a/bindings/rsac-napi/Cargo.toml
+++ b/bindings/rsac-napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac-napi"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 description = "Node.js/TypeScript bindings for rsac (Rust Cross-Platform Audio Capture)"
 license = "MIT OR Apache-2.0"

--- a/bindings/rsac-napi/package.json
+++ b/bindings/rsac-napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsac/audio",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Node.js bindings for rsac (Rust cross-platform audio capture)",
   "main": "index.js",
   "types": "index.d.ts",

--- a/bindings/rsac-python/Cargo.toml
+++ b/bindings/rsac-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac-python"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 description = "Python bindings for rsac (Rust Cross-Platform Audio Capture)"
 license = "MIT OR Apache-2.0"

--- a/bindings/rsac-python/pyproject.toml
+++ b/bindings/rsac-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rsac"
-version = "0.4.3"
+version = "0.5.0"
 description = "Python bindings for rsac (cross-platform audio capture library)"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }

--- a/integrations/tauri-plugin-rsac/Cargo.toml
+++ b/integrations/tauri-plugin-rsac/Cargo.toml
@@ -5,7 +5,7 @@ name = "tauri-plugin-rsac"
 # gate asserts equality with root rsac on release tags. Keep this line free of
 # a trailing comment: the bump/lockstep extractors match `version = "X"` only
 # when nothing follows the closing quote.
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 # match root MSRV floor (Cargo.toml:9)
 rust-version = "1.87"
@@ -34,7 +34,7 @@ thiserror = "2"
 log = "0.4"
 # Path dep + version pin — mirrors bindings/rsac-ffi/Cargo.toml:52 exactly.
 # The version pin is what a future publish records; joins version-lockstep.
-rsac = { path = "../../", version = "0.4.3", default-features = false }
+rsac = { path = "../../", version = "0.5.0", default-features = false }
 
 [build-dependencies]
 tauri-plugin = { version = "2", features = ["build"] }

--- a/integrations/tauri-plugin-rsac/guest-js/package.json
+++ b/integrations/tauri-plugin-rsac/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tauri-plugin-rsac-api",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "JS/TS guest API for tauri-plugin-rsac (ADR-0014)",
   "license": "MIT OR Apache-2.0",
   "type": "module",

--- a/mobile/android-native/Cargo.toml
+++ b/mobile/android-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsac-android-native"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 publish = false
 description = "Android cdylib shim: builds librsac.so (via cargo-ndk) for the rsac AAR's jniLibs (rsac-0aa9)"


### PR DESCRIPTION
Release Prepare (run 29791609514, bump=minor): 9 lockstep manifests + 2 internal rsac pins to 0.5.0, CHANGELOG rotated.

**Why minor, not patch**: the SampleRing removal (PR #71) deleted the `bridge-zerocopy` cargo feature — `cargo semver-checks --baseline-rev v0.4.3` fails `feature_missing` (a removed feature is breaking for any downstream that enabled it; pre-1.0 convention maps breaking → minor). Never published to a registry and never wired into a backend, so the real-world blast radius is zero — but the version number tells the truth anyway, and the release semver gate would (correctly) have refused a 0.4.4.

Contents on top of v0.4.3: the ADR-0006 resolution — `bridge-zerocopy`/`SampleRing` data plane removed with the full five-environment decision record amended into the ADR (net −829 lines; default AudioBuffer plane byte-identical, 594 lib tests re-verified).

Squash-merge keeping the subject exactly `release: v0.5.0` — release-tag.yml creates the tags + GitHub Release. Registry publish workflows remain disabled per the owner hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)