### PR TITLE
release: one-time semver-lint exception for shipping the SampleRing removal in 0.4.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -432,6 +432,24 @@ exclude = ["apps/audio-graph/src-tauri"]
 # compiles every gated module so every public item is reachable; the
 # `docsrs` cfg lets `#[cfg_attr(docsrs, doc(...))]` annotations render the
 # platform-availability badges in the docs.rs UI.
+# One-time semver-lint exception (owner decision 2026-07-21): the
+# bridge-zerocopy removal (ADR-0006 resolved REMOVE, PR #71) deleted the
+# FEATURE plus its feature-gated pub items (`create_sample_ring`,
+# `SampleRing*`), tripping `feature_missing` + `function_missing` +
+# `struct_missing` (all formally major; the checker enables all features
+# on both sides). rsac has never been published to any registry, the
+# feature was never wired into a backend, and every consumer is a git
+# dependency pinned by rev/tag — so the owner chose to ship this in patch
+# 0.4.4 rather than 0.5.0. Downgraded to `warn` so the release gate
+# records the breakage loudly without blocking THIS release only.
+# REVERT (delete this whole table) immediately after v0.4.4 tags — these
+# three lints protect the entire public API, not just SampleRing, and
+# from the first registry publish onward removals must gate bumps again.
+[package.metadata.cargo-semver-checks.lints]
+feature_missing = "warn"
+function_missing = "warn"
+struct_missing = "warn"
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Owner decision: 0.4.4, not 0.5.0, for the ADR-0006 SampleRing removal.

The removal trips three cargo-semver-checks lints (`feature_missing`, `function_missing`, `struct_missing` — the checker enables all features on both sides, so the deleted feature-gated pub items count too). All formally major. The override rationale: **rsac has never been published to any registry** (publish workflows disabled; rsac-43e4/rsac-aaea) and the feature was never wired into any backend — there exists no consumer who can break. Version-number semantics matter most where version *resolution* exists; every current consumer pins by git rev/tag.

Scoped as tightly as the tool allows: `[package.metadata.cargo-semver-checks.lints]` downgrades exactly those three lints to `warn` (still reported loudly in the gate output), with a comment mandating deletion of the table immediately after v0.4.4 tags — from the first registry publish onward, removals gate bumps again.

Verified: `cargo semver-checks check-release -p rsac --baseline-rev v0.4.3` now passes with 3 major-level warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)